### PR TITLE
[FIX] npm t8r: Fix collection fallback with missing package.json

### DIFF
--- a/lib/translators/npm.js
+++ b/lib/translators/npm.js
@@ -190,24 +190,27 @@ class NpmTranslator {
 		}).then((pkgPath) => {
 			return path.dirname(pkgPath);
 		}).catch((err) => {
+			// Fallback: Check for a collection above this module
 			return readPkgUp({
 				cwd: path.dirname(basePath)
 			}).then((result) => {
-				const pkg = result.pkg;
+				if (result.pkg) {
+					const pkg = result.pkg;
 
-				// As of today, collections only exist in shims
-				this.shimCollection(pkg.name, pkg);
-				if (pkg.collection) {
-					log.verbose(
-						"Unable to locate module %s via resolve logic but found a collection in parent hierarchy: %s",
-						moduleName, pkg.name);
-					const modules = pkg.collection.modules || {};
-					if (modules[moduleName]) {
-						const modulePath = path.join(path.dirname(result.path), modules[moduleName]);
-						log.verbose("Found module %s in that collection", moduleName);
-						return modulePath;
+					// As of today, collections only exist in shims
+					this.shimCollection(pkg.name, pkg);
+					if (pkg.collection) {
+						log.verbose(
+							"Unable to locate module %s via resolve logic but found a collection in parent hierarchy: %s",
+							moduleName, pkg.name);
+						const modules = pkg.collection.modules || {};
+						if (modules[moduleName]) {
+							const modulePath = path.join(path.dirname(result.path), modules[moduleName]);
+							log.verbose("Found module %s in that collection", moduleName);
+							return modulePath;
+						}
+						throw new Error(`Could not find module ${moduleName} in collection ${pkg.name}`);
 					}
-					throw new Error(`Could not find module ${moduleName} in collection ${pkg.name}`);
 				}
 				throw new Error(`Could not locate module ${moduleName} via resolve logic ` +
 					`(error: ${err.message}) or in a collection`);

--- a/test/fixtures/err.application.a/package.json
+++ b/test/fixtures/err.application.a/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "err.application.a",
+  "version": "1.0.0",
+  "description": "Simple SAPUI5 based application - test for missing dependencies",
+  "main": "index.html",
+  "dependencies": {
+    "library.xx": "file:../not.existing"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/test/lib/translators/npm.js
+++ b/test/lib/translators/npm.js
@@ -7,6 +7,7 @@ const applicationC2Path = path.join(__dirname, "..", "..", "fixtures", "applicat
 const applicationC3Path = path.join(__dirname, "..", "..", "fixtures", "application.c3");
 const applicationDPath = path.join(__dirname, "..", "..", "fixtures", "application.d");
 const applicationFPath = path.join(__dirname, "..", "..", "fixtures", "application.f");
+const errApplicationAPath = path.join(__dirname, "..", "..", "fixtures", "err.application.a");
 
 test("AppA: project with collection dependency", (t) => {
 	return npmTranslator.generateDependencyTree(applicationAPath).then((parsedTree) => {
@@ -26,7 +27,8 @@ test("AppC2: project with dependency with optional dependency resolved through o
 	});
 });
 
-test("AppC3: project with dependency with optional dependency resolved through other project (but got hoisted)", (t) => {
+test("AppC3: project with dependency with optional dependency resolved " +
+	"through other project (but got hoisted)", (t) => {
 	return npmTranslator.generateDependencyTree(applicationC3Path).then((parsedTree) => {
 		t.deepEqual(parsedTree, applicationC3Tree, "Parsed correctly");
 	});
@@ -50,6 +52,18 @@ test("Error: missing package.json", async (t) => {
 	const error = await t.throws(npmTranslator.generateDependencyTree(path.parse(__dirname).root));
 	t.is(error.message, "[npm translator] Failed to locate package.json for directory \"/\"");
 });
+
+test("Error: missing dependency", async (t) => {
+	const error = await t.throws(npmTranslator.generateDependencyTree(errApplicationAPath));
+	t.is(error.message, "[npm translator] Failed to locate module library.xx from " +
+		errApplicationAPath + " - Error: Could not locate " +
+		"module library.xx via resolve logic (error: Cannot find module 'library.xx/package.json' from '" +
+		errApplicationAPath + "') or in a collection");
+});
+
+// TODO: Test for scenarios where a dependency is missing *and there is no package.json* in the path above the root module
+//	This should test whether the collection-fallback can handle not receiving a .pkg object from readPkgUp
+//	Currently tricky to test as there is always a package.json located above the test fixtures.
 
 /* ========================= */
 /* ======= Test data ======= */


### PR DESCRIPTION
If the dependency resolution falls back to try resolving via a
collection it looks for a package.json in the path above the current
module. The current implementation throws when no package.json could be
found at all.