### PR TITLE
[FIX] npm t8r: Handle npm optionalDependencies correctly

### DIFF
--- a/lib/translators/npm.js
+++ b/lib/translators/npm.js
@@ -32,6 +32,26 @@ class NpmTranslator {
 
 		let dependencies = pkg.dependencies || {};
 		let optDependencies = pkg.devDependencies || {};
+
+		// Due to normalization done by by the "read-pkg-up" module the values
+		//  in optionalDependencies get added to dependencies. Also as described here:
+		//  https://github.com/npm/normalize-package-data#what-normalization-currently-entails
+		// Note: optionalDependencies are treated the same as devDependencies in the npm translator
+		if (pkg.optionalDependencies) {
+			for (let depName in pkg.optionalDependencies) {
+				if (pkg.optionalDependencies.hasOwnProperty(depName)) {
+					// Remove entry from "hard" dependencies map
+					if (dependencies[depName]) {
+						delete dependencies[depName];
+					}
+					// Add to optional dependencies map (of not already done)
+					if (optDependencies.hasOwnProperty(depName)) {
+						optDependencies[depName] = pkg.optionalDependencies[depName];
+					}
+				}
+			}
+		}
+
 		const version = pkg.version;
 
 		// Also look for "napa" dependencies (see https://github.com/shama/napa)

--- a/test/fixtures/application.g/package.json
+++ b/test/fixtures/application.g/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "application.g",
+  "version": "1.0.0",
+  "description": "Simple SAPUI5 based application - test for npm optionalDependencies",
+  "main": "index.html",
+  "optionalDependencies": {
+    "library.nonexistent": "file:../library.nonexistent"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/test/fixtures/application.g/ui5.yaml
+++ b/test/fixtures/application.g/ui5.yaml
@@ -1,0 +1,5 @@
+---
+specVersion: "0.1"
+type: application
+metadata:
+  name: application.g

--- a/test/fixtures/application.g/webapp/manifest.json
+++ b/test/fixtures/application.g/webapp/manifest.json
@@ -1,0 +1,13 @@
+{
+    "_version": "1.1.0",
+    "sap.app": {
+        "_version": "1.1.0",
+        "id": "id1",
+        "type": "application",
+        "applicationVersion": {
+            "version": "1.2.2"
+        },
+        "embeds": ["embedded"],
+        "title": "{{title}}"
+    }
+}

--- a/test/lib/translators/npm.js
+++ b/test/lib/translators/npm.js
@@ -7,6 +7,7 @@ const applicationC2Path = path.join(__dirname, "..", "..", "fixtures", "applicat
 const applicationC3Path = path.join(__dirname, "..", "..", "fixtures", "application.c3");
 const applicationDPath = path.join(__dirname, "..", "..", "fixtures", "application.d");
 const applicationFPath = path.join(__dirname, "..", "..", "fixtures", "application.f");
+const applicationGPath = path.join(__dirname, "..", "..", "fixtures", "application.g");
 const errApplicationAPath = path.join(__dirname, "..", "..", "fixtures", "err.application.a");
 
 test("AppA: project with collection dependency", (t) => {
@@ -45,6 +46,12 @@ test("AppD: project with dependency with unresolved optional dependency", (t) =>
 test("AppF: project with UI5-dependencies", (t) => {
 	return npmTranslator.generateDependencyTree(applicationFPath).then((parsedTree) => {
 		t.deepEqual(parsedTree, applicationFTree, "Parsed correctly");
+	});
+});
+
+test("AppG: project with npm 'optionalDependencies' should not fail if optional dependency cannot be resolved", (t) => {
+	return npmTranslator.generateDependencyTree(applicationGPath).then((parsedTree) => {
+		t.deepEqual(parsedTree, applicationGTree, "Parsed correctly");
 	});
 });
 
@@ -225,4 +232,11 @@ const applicationFTree = {
 			dependencies: []
 		}
 	]
+};
+
+const applicationGTree = {
+	id: "application.g",
+	version: "1.0.0",
+	path: applicationGPath,
+	dependencies: []
 };


### PR DESCRIPTION
In the past, optionalDependencies that could not be located caused a
"Failed to locate module".

Fixes #51