### PR TITLE
[BREAKING] normalizer: Rename optional parameter "translator" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 See [Configuration](docs/Configuration.md).
 
 ## Normalizer
-The purpose of the normalizer is to collect dependency information and to enrich it with project configuration (both done in [generateProjectTree](https://github.com/pages/SAP/ui5-tooling/module-normalizer_normalizer.html#~generateProjectTree)).
+The purpose of the normalizer is to collect dependency information and to enrich it with project configuration (both done in [generateProjectTree](https://sap.github.io/ui5-tooling/module-@ui5_project.normalizer.html#.generateProjectTree)).
 
 [Translators](#translators) are used to collect dependency information. The [Project Preprocessor](#project-preprocessor) enriches this dependency information with project configuration, typically from a `ui5.yaml` file. A development server and build process can use this information to locate project and dependency resources.
 
-If you want to retrieve the project dependency graph without any configuration, you may use use the [generateDependencyTree](https://github.com/pages/SAP/ui5-tooling/module-normalizer_normalizer.html#~generateDependencyTree) API.
+If you want to retrieve the project dependency graph without any configuration, you may use use the [generateDependencyTree](https://sap.github.io/ui5-tooling/module-@ui5_project.normalizer.html#.generateDependencyTree) API.
 
 ## Translators
 Translators collect recursively all dependencies on a package manager specific layer and return information about them in a well-defined tree structure.

--- a/lib/normalizer.js
+++ b/lib/normalizer.js
@@ -18,7 +18,7 @@ const Normalizer = {
 	 * @param {Object} [options]
 	 * @param {string} [options.cwd] Current working directory
 	 * @param {string} [options.configPath] Path to configuration file
-	 * @param {string} [options.translator] Translator to use
+	 * @param {string} [options.translatorName] Translator to use
 	 * @returns {Promise<Object>} Promise resolving to tree object
 	 */
 	generateProjectTree: async function(options = {}) {
@@ -36,24 +36,23 @@ const Normalizer = {
 	 * @public
 	 * @param {Object} [options]
 	 * @param {string} [options.cwd=.] Current working directory
-	 * @param {string} [options.translator=npm] Translator to use
+	 * @param {string} [options.translatorName=npm] Translator to use
 	 * @param {Object} [options.translatorOptions] Options to pass to translator
 	 * @returns {Promise<Object>} Promise resolving to tree object
 	 */
-	generateDependencyTree: async function({cwd = ".", translator="npm", translatorOptions={}} = {}) {
-		// TODO NEXT MAJOR: Rename "translator" option to "translatorName"
+	generateDependencyTree: async function({cwd = ".", translatorName="npm", translatorOptions={}} = {}) {
 		log.verbose("Building dependency tree...");
 
 		let translatorParams = [];
-		let translatorName = translator;
-		if (translator.indexOf(":") !== -1) {
-			translatorParams = translator.split(":");
-			translatorName = translatorParams[0];
+		let translator = translatorName;
+		if (translatorName.indexOf(":") !== -1) {
+			translatorParams = translatorName.split(":");
+			translator = translatorParams[0];
 			translatorParams = translatorParams.slice(1);
 		}
 
 		let translatorModule;
-		switch (translatorName) {
+		switch (translator) {
 		case "static":
 			translatorModule = require("./translators/static");
 			break;
@@ -61,7 +60,7 @@ const Normalizer = {
 			translatorModule = require("./translators/npm");
 			break;
 		default:
-			return Promise.reject(new Error(`Unknown translator ${translatorName}`));
+			return Promise.reject(new Error(`Unknown translator ${translator}`));
 		}
 
 		translatorOptions.parameters = translatorParams;

--- a/lib/translators/static.js
+++ b/lib/translators/static.js
@@ -22,9 +22,8 @@ module.exports = {
 	 * @returns {Promise} Promise resolving with a dependency tree
 	 */
 	generateDependencyTree(dirPath, options = {}) {
-		// TODO NEXT MAJOR: "options" used to be the the parameters array. We check for that here to stay compatible:
-		const parameters = Array.isArray(options) ? options : options.parameters;
-		const depFilePath = parameters && parameters[0] || path.join(dirPath, "projectDependencies.yaml");
+		const depFilePath = options.parameters && options.parameters[0] ||
+								path.join(dirPath, "projectDependencies.yaml");
 
 		return new Promise(function(resolve, reject) {
 			fs.readFile(depFilePath, function(err, buffer) {

--- a/test/lib/normalizer.js
+++ b/test/lib/normalizer.js
@@ -12,7 +12,7 @@ test.serial("Uses npm translator as default strategy", (t) => {
 
 test.serial("Uses static translator as strategy", (t) => {
 	normalizer.generateDependencyTree({
-		translator: "static"
+		translatorName: "static"
 	});
 	t.truthy(staticTranslatorStub.generateDependencyTree.called);
 });
@@ -29,10 +29,10 @@ test.serial("Generate project tree using with overwritten config path", async (t
 });
 
 test("Error: Throws if unknown translator should be used as strategy", async (t) => {
-	const translator = "notExistingTranslator";
+	const translatorName = "notExistingTranslator";
 	return normalizer.generateDependencyTree({
-		translator
+		translatorName
 	}).catch((error) => {
-		t.is(error.message, `Unknown translator ${translator}`);
+		t.is(error.message, `Unknown translator ${translatorName}`);
 	});
 });


### PR DESCRIPTION
This should future-proof the normalizer API to allow for eventually passing
translator objects/instances instead of a simple string.

BREAKING CHANGE: Renamed parameter "translator" of functions generateDependencyTree and generateProjectTree to "translatorName"

Downstream adaptions: https://github.com/SAP/ui5-cli/pull/112