### PR TITLE
[INTERNAL] Clarify error message for invalid or unsupported specVersions

### DIFF
--- a/lib/projectPreprocessor.js
+++ b/lib/projectPreprocessor.js
@@ -268,8 +268,9 @@ class ProjectPreprocessor {
 
 		if (project.specVersion !== "0.1" && project.specVersion !== "1.0") {
 			throw new Error(
-				`Invalid specification version defined for project ${project.id}: ${project.specVersion}. ` +
-				"See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions");
+				`Unsupported specification version ${project.specVersion} defined for project ` +
+				`${project.id}. ` +
+				`See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions`);
 		}
 
 		if (!project.type) {
@@ -325,8 +326,8 @@ class ProjectPreprocessor {
 			throw new Error(`No specification version defined for extension ${extension.metadata.name}`);
 		} else if (extension.specVersion !== "0.1" && extension.specVersion !== "1.0") {
 			throw new Error(
-				`Invalid specification version defined for extension ` +
-				`${extension.metadata.name}: ${extension.specVersion}. ` +
+				`Unsupported specification version ${extension.specVersion} defined for extension ` +
+				`${extension.metadata.name}. ` +
 				`See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions`);
 		} else if (this.appliedExtensions[extension.metadata.name]) {
 			log.verbose(`Extension with the name ${extension.metadata.name} has already been applied. ` +

--- a/test/lib/extensions.js
+++ b/test/lib/extensions.js
@@ -612,7 +612,7 @@ test("specVersion: Extension with invalid version", async (t) => {
 	};
 	const preprocessor = new Preprocessor();
 	await t.throws(preprocessor.applyExtension(extension),
-		"Invalid specification version defined for extension shims.a: 0.9. " +
+		"Unsupported specification version 0.9 defined for extension shims.a. " +
 		"See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions",
 		"Rejected with error");
 });

--- a/test/lib/projectPreprocessor.js
+++ b/test/lib/projectPreprocessor.js
@@ -1400,7 +1400,7 @@ test("specVersion: Project with invalid version", async (t) => {
 		}
 	};
 	await t.throws(projectPreprocessor.processTree(tree),
-		"Invalid specification version defined for project application.a: 0.9. " +
+		"Unsupported specification version 0.9 defined for project application.a. " +
 		"See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions",
 		"Rejected with error");
 });


### PR DESCRIPTION
Old CLI releases might simply not support a certain specVersion