### PR TITLE
[INTERNAL] Bump ava to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,70 +5,31 @@
 	"requires": true,
 	"dependencies": {
 		"@ava/babel-plugin-throws-helper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-3.0.0.tgz",
+			"integrity": "sha512-mN9UolOs4WX09QkheU1ELkVy2WPnwonlO3XMdN8JF8fQqRVgVTR21xDbvEOUsbwz6Zwjq7ji9yzyjuXqDPalxg==",
 			"dev": true
 		},
 		"@ava/babel-preset-stage-4": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
-			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-3.0.0.tgz",
+			"integrity": "sha512-uI5UBx++UsckkfnbF0HH6jvTIvM4r/Kxt1ROO2YXKu5H15sScAtxUIAHiUVbPIw24zPqz/PlF3xxlIDuyFzlQw==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.8.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.20.0",
-				"babel-plugin-transform-async-to-generator": "^6.16.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.19.0",
-				"babel-plugin-transform-es2015-function-name": "^6.9.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
-				"babel-plugin-transform-es2015-parameters": "^6.21.0",
-				"babel-plugin-transform-es2015-spread": "^6.8.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.8.0",
-				"package-hash": "^1.2.0"
-			},
-			"dependencies": {
-				"md5-hex": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
-					"requires": {
-						"md5-o-matic": "^0.1.1"
-					}
-				},
-				"package-hash": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
-					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-					"dev": true,
-					"requires": {
-						"md5-hex": "^1.3.0"
-					}
-				}
+				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+				"@babel/plugin-transform-dotall-regex": "^7.4.3",
+				"@babel/plugin-transform-modules-commonjs": "^7.4.3"
 			}
 		},
 		"@ava/babel-preset-transform-test-files": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
-			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-5.0.0.tgz",
+			"integrity": "sha512-rqgyQwkT0+j2JzYP51dOv80u33rzAvjBtXRzUON+7+6u26mjoudRXci2+1s18rat8r4uOlZfbzm114YS6pwmYw==",
 			"dev": true,
 			"requires": {
-				"@ava/babel-plugin-throws-helper": "^2.0.0",
-				"babel-plugin-espower": "^2.3.2"
-			}
-		},
-		"@ava/write-file-atomic": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
-			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"slide": "^1.1.5"
+				"@ava/babel-plugin-throws-helper": "^3.0.0",
+				"babel-plugin-espower": "^3.0.1"
 			}
 		},
 		"@babel/code-frame": {
@@ -78,6 +39,51 @@
 			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
+			"integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.4",
+				"@babel/helpers": "^7.4.4",
+				"@babel/parser": "^7.4.5",
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.5",
+				"@babel/types": "^7.4.4",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.11",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/generator": {
@@ -101,6 +107,15 @@
 				}
 			}
 		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
 		"@babel/helper-function-name": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
@@ -121,12 +136,96 @@
 				"@babel/types": "^7.0.0"
 			}
 		},
+		"@babel/helper-module-imports": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+			"integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/template": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"lodash": "^4.17.11"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
+		},
+		"@babel/helper-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+			"integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-wrap-function": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
 		"@babel/helper-split-export-declaration": {
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
 			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
 			"dev": true,
 			"requires": {
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.2.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+			"integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
 				"@babel/types": "^7.4.4"
 			}
 		},
@@ -154,6 +253,76 @@
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
 			"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
 			"dev": true
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0",
+				"@babel/plugin-syntax-async-generators": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+			"integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.4.4",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0"
+			}
 		},
 		"@babel/template": {
 			"version": "7.4.4",
@@ -226,58 +395,12 @@
 			}
 		},
 		"@concordance/react": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
-			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-2.0.0.tgz",
+			"integrity": "sha512-huLSkUuM2/P+U0uy2WwlKuixMsTODD8p4JVQBI4VKeopkiN0C7M3N9XYVawb4M+4spN5RrO/eLhk7KoQX6nsfA==",
 			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1"
-			}
-		},
-		"@ladjs/time-require": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
-			"integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
-			"dev": true,
-			"requires": {
-				"chalk": "^0.4.0",
-				"date-time": "^0.1.1",
-				"pretty-ms": "^0.2.1",
-				"text-table": "^0.2.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
-					}
-				},
-				"pretty-ms": {
-					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-					"dev": true,
-					"requires": {
-						"parse-ms": "^0.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-					"dev": true
-				}
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -293,6 +416,12 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+		},
+		"@sindresorhus/is": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"dev": true
 		},
 		"@sinonjs/commons": {
 			"version": "1.4.0",
@@ -329,6 +458,15 @@
 			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
+		},
+		"@szmarczak/http-timer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"dev": true,
+			"requires": {
+				"defer-to-connect": "^1.0.1"
+			}
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -515,18 +653,18 @@
 			"optional": true
 		},
 		"ansi-align": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+			"integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
 			"dev": true,
 			"requires": {
-				"string-width": "^2.0.0"
+				"string-width": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
@@ -536,22 +674,23 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
+						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"strip-ansi": "^5.1.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
@@ -577,88 +716,20 @@
 			}
 		},
 		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.0.2.tgz",
+			"integrity": "sha512-rUe9SxpRQlVg4EM8It7JMNWWYHAirTPpbTuvaSKybb5IejNgWB3PGBBX9rrPKDx2pM/p3Wh+7+ASaWRyyAbxmQ==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
 			},
 			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 					"dev": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
-					}
 				}
 			}
 		},
@@ -704,12 +775,6 @@
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
 			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
-		"arr-exclude": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
-			"dev": true
-		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
@@ -719,12 +784,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-		},
-		"array-differ": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-			"dev": true
 		},
 		"array-find-index": {
 			"version": "1.0.2",
@@ -802,305 +861,332 @@
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
-		"auto-bind": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.1.tgz",
-			"integrity": "sha512-/W9yj1yKmBLwpexwAujeD9YHwYmRuWFGV8HWE7smQab797VeHa4/cnE2NFeDhA+E+5e/OGBI8763EhLjfZ/MXA==",
-			"dev": true
-		},
 		"ava": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-0.25.0.tgz",
-			"integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-2.0.0.tgz",
+			"integrity": "sha512-tOfO3yQhKiSECIjST8Xi99l7Bja9EG5hgZFKc92xNZh/6pnct97vWDKENyATBvZIXpdCClSMtGgOX2UaGq+OJA==",
 			"dev": true,
 			"requires": {
-				"@ava/babel-preset-stage-4": "^1.1.0",
-				"@ava/babel-preset-transform-test-files": "^3.0.0",
-				"@ava/write-file-atomic": "^2.2.0",
-				"@concordance/react": "^1.0.0",
-				"@ladjs/time-require": "^0.1.4",
-				"ansi-escapes": "^3.0.0",
-				"ansi-styles": "^3.1.0",
-				"arr-flatten": "^1.0.1",
-				"array-union": "^1.0.1",
-				"array-uniq": "^1.0.2",
-				"arrify": "^1.0.0",
-				"auto-bind": "^1.1.0",
-				"ava-init": "^0.2.0",
-				"babel-core": "^6.17.0",
-				"babel-generator": "^6.26.0",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"bluebird": "^3.0.0",
-				"caching-transform": "^1.0.0",
-				"chalk": "^2.0.1",
-				"chokidar": "^1.4.2",
-				"clean-stack": "^1.1.1",
+				"@ava/babel-preset-stage-4": "^3.0.0",
+				"@ava/babel-preset-transform-test-files": "^5.0.0",
+				"@babel/core": "^7.4.5",
+				"@babel/generator": "^7.4.4",
+				"@babel/plugin-syntax-async-generators": "^7.2.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+				"@concordance/react": "^2.0.0",
+				"ansi-escapes": "^4.1.0",
+				"ansi-styles": "^4.0.0",
+				"arr-flatten": "^1.1.0",
+				"array-union": "^2.1.0",
+				"array-uniq": "^2.1.0",
+				"arrify": "^2.0.1",
+				"bluebird": "^3.5.5",
+				"chalk": "^2.4.2",
+				"chokidar": "^3.0.0",
+				"chunkd": "^1.0.0",
+				"ci-parallel-vars": "^1.0.0",
+				"clean-stack": "^2.1.0",
 				"clean-yaml-object": "^0.1.0",
-				"cli-cursor": "^2.1.0",
-				"cli-spinners": "^1.0.0",
-				"cli-truncate": "^1.0.0",
-				"co-with-promise": "^4.6.0",
+				"cli-cursor": "^3.0.0",
+				"cli-truncate": "^1.1.0",
 				"code-excerpt": "^2.1.1",
 				"common-path-prefix": "^1.0.0",
-				"concordance": "^3.0.0",
-				"convert-source-map": "^1.5.1",
-				"core-assert": "^0.2.0",
+				"concordance": "^4.0.0",
+				"convert-source-map": "^1.6.0",
 				"currently-unhandled": "^0.4.1",
-				"debug": "^3.0.1",
-				"dot-prop": "^4.1.0",
-				"empower-core": "^0.6.1",
+				"debug": "^4.1.1",
+				"del": "^4.1.1",
+				"dot-prop": "^5.0.0",
+				"emittery": "^0.4.1",
+				"empower-core": "^1.2.0",
 				"equal-length": "^1.0.0",
-				"figures": "^2.0.0",
-				"find-cache-dir": "^1.0.0",
-				"fn-name": "^2.0.0",
-				"get-port": "^3.0.0",
-				"globby": "^6.0.0",
-				"has-flag": "^2.0.0",
-				"hullabaloo-config-manager": "^1.1.0",
+				"escape-string-regexp": "^2.0.0",
+				"esm": "^3.2.25",
+				"figures": "^3.0.0",
+				"find-up": "^4.0.0",
+				"get-port": "^5.0.0",
+				"globby": "^9.2.0",
 				"ignore-by-default": "^1.0.0",
-				"import-local": "^0.1.1",
-				"indent-string": "^3.0.0",
-				"is-ci": "^1.0.7",
-				"is-generator-fn": "^1.0.0",
-				"is-obj": "^1.0.0",
-				"is-observable": "^1.0.0",
+				"import-local": "^2.0.0",
+				"indent-string": "^4.0.0",
+				"is-ci": "^2.0.0",
+				"is-error": "^2.2.2",
+				"is-observable": "^2.0.0",
+				"is-plain-object": "^3.0.0",
 				"is-promise": "^2.1.0",
-				"last-line-stream": "^1.0.0",
-				"lodash.clonedeepwith": "^4.5.0",
-				"lodash.debounce": "^4.0.3",
-				"lodash.difference": "^4.3.0",
-				"lodash.flatten": "^4.2.0",
-				"loud-rejection": "^1.2.0",
-				"make-dir": "^1.0.0",
-				"matcher": "^1.0.0",
-				"md5-hex": "^2.0.0",
-				"meow": "^3.7.0",
-				"ms": "^2.0.0",
-				"multimatch": "^2.1.0",
-				"observable-to-promise": "^0.5.0",
-				"option-chain": "^1.0.0",
-				"package-hash": "^2.0.0",
-				"pkg-conf": "^2.0.0",
-				"plur": "^2.0.0",
-				"pretty-ms": "^3.0.0",
+				"lodash": "^4.17.11",
+				"loud-rejection": "^2.1.0",
+				"make-dir": "^3.0.0",
+				"matcher": "^2.0.0",
+				"md5-hex": "^3.0.0",
+				"meow": "^5.0.0",
+				"micromatch": "^4.0.2",
+				"ms": "^2.1.1",
+				"observable-to-promise": "^1.0.0",
+				"ora": "^3.4.0",
+				"package-hash": "^4.0.0",
+				"pkg-conf": "^3.1.0",
+				"plur": "^3.1.1",
+				"pretty-ms": "^5.0.0",
 				"require-precompiled": "^0.1.0",
-				"resolve-cwd": "^2.0.0",
-				"safe-buffer": "^5.1.1",
-				"semver": "^5.4.1",
-				"slash": "^1.0.0",
-				"source-map-support": "^0.5.0",
-				"stack-utils": "^1.0.1",
-				"strip-ansi": "^4.0.0",
-				"strip-bom-buf": "^1.0.0",
+				"resolve-cwd": "^3.0.0",
+				"slash": "^3.0.0",
+				"source-map-support": "^0.5.12",
+				"stack-utils": "^1.0.2",
+				"strip-ansi": "^5.2.0",
+				"strip-bom-buf": "^2.0.0",
 				"supertap": "^1.0.0",
-				"supports-color": "^5.0.0",
+				"supports-color": "^6.1.0",
 				"trim-off-newlines": "^1.0.1",
+				"trim-right": "^1.0.1",
 				"unique-temp-dir": "^1.0.0",
-				"update-notifier": "^2.3.0"
+				"update-notifier": "^3.0.0",
+				"write-file-atomic": "^3.0.0"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.1.0.tgz",
+					"integrity": "sha512-2VY/iCUZTDLD/qxptS3Zn3c6k2MeIbYqjRXqM8T5oC7N2mMjh3xIU3oYru6cHGbldFa9h5i8N0fP65UaUqrMWA==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.3.0"
+					}
+				},
 				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.0.0.tgz",
+					"integrity": "sha512-8zjUtFJ3db/QoPXuuEMloS2AUf79/yeyttJ7Abr3hteopJu9HK8vsgGviGUMq+zyA6cZZO6gAyZoMTF6TgaEjA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.0"
+					}
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"array-uniq": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+					"integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
+					"dev": true
+				},
+				"arrify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+					"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"cli-cursor": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.0.0.tgz",
+					"integrity": "sha512-m7avcYLWHHQVU+cFxu301q3kKZJlcZcKXQSL9kffYnIvRNtqX+a7gJKXqOKusHoKXr4oquSgiMlAo1R0dDkSZA==",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^2.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.0.tgz",
+					"integrity": "sha512-hzTicsCJIHdxih9+2aLR1tNGZX5qSJGRHDPVwSY26tVrEf55XNajLOBWz2UuWSIergszA09/bqnOiHyqx9fxQg==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				},
+				"figures": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+					"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
 					},
 					"dependencies": {
-						"ms": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+						"escape-string-regexp": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+							"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 							"dev": true
 						}
 					}
 				},
-				"globby": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"find-up": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.0.0.tgz",
+					"integrity": "sha512-zoH7ZWPkRdgwYCDVoQTzqjG8JSPANhtvLhh4KVUHyKnaUJJrNeFmWIkTcNuJmR3GLMEmGYEf2S2bjgx26JTF+Q==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-plain-object": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+					"dev": true,
+					"requires": {
+						"isobject": "^4.0.0"
+					}
+				},
+				"isobject": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"loud-rejection": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.1.0.tgz",
+					"integrity": "sha512-g/6MQxUXYHeVqZ4PGpPL1fS1fOvlXoi7bay0pizmjAd/3JhyXwxzwrnr74yzdmhuerlslbRJ3x7IOXzFz0cE5w==",
+					"dev": true,
+					"requires": {
+						"currently-unhandled": "^0.4.1",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+					"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-							"dev": true
-						}
+						"semver": "^6.0.0"
 					}
 				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "^2.0.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
-		"ava-init": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
-			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-			"dev": true,
-			"requires": {
-				"arr-exclude": "^1.0.0",
-				"execa": "^0.7.0",
-				"has-yarn": "^1.0.0",
-				"read-pkg-up": "^2.0.0",
-				"write-pkg": "^3.1.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
 				},
 				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-limit": "^2.2.0"
 					}
 				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"ansi-regex": "^4.1.0"
 					}
 				},
-				"path-type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"pify": "^2.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
+						"is-number": "^7.0.0"
 					}
 				},
-				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+				"write-file-atomic": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
+					"integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
+						"imurmurhash": "^0.1.4",
+						"is-typedarray": "^1.0.0",
+						"signal-exit": "^3.0.2",
+						"typedarray-to-buffer": "^3.1.5"
 					}
 				}
 			}
@@ -1115,470 +1201,19 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
-		"babel-core": {
-			"version": "6.26.3",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
-			},
-			"dependencies": {
-				"babylon": {
-					"version": "6.18.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-					"dev": true
-				}
-			}
-		},
-		"babel-generator": {
-			"version": "6.26.1",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
-			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-					"dev": true
-				}
-			}
-		},
-		"babel-helper-builder-binary-assignment-operator-visitor": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
-			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-call-delegate": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
-			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-explode-assignable-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
-			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-get-function-arity": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-hoist-variables": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helper-regex": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-helper-remap-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-helpers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
-			}
-		},
-		"babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-check-es2015-constants": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
 		"babel-plugin-espower": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
-			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-3.0.1.tgz",
+			"integrity": "sha512-Ms49U7VIAtQ/TtcqRbD6UBmJBUCSxiC3+zPc+eGqxKUIFO1lTshyEDRUjhoAbd2rWfwYf3cZ62oXozrd8W6J0A==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "^6.1.0",
-				"babylon": "^6.1.0",
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
 				"call-matcher": "^1.0.0",
 				"core-js": "^2.0.0",
 				"espower-location-detector": "^1.0.0",
 				"espurify": "^1.6.0",
 				"estraverse": "^4.1.1"
-			},
-			"dependencies": {
-				"babylon": {
-					"version": "6.18.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-					"dev": true
-				}
-			}
-		},
-		"babel-plugin-syntax-async-functions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-			"dev": true
-		},
-		"babel-plugin-syntax-exponentiation-operator": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-			"dev": true
-		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-			"dev": true
-		},
-		"babel-plugin-syntax-trailing-function-commas": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-			"dev": true
-		},
-		"babel-plugin-transform-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"dev": true,
-			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-destructuring": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-parameters": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
-			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-spread": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-es2015-sticky-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-plugin-transform-es2015-unicode-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
-			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
-			}
-		},
-		"babel-plugin-transform-exponentiation-operator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
-			}
-		},
-		"babel-plugin-transform-strict-mode": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
-			}
-		},
-		"babel-register": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
-			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
-			},
-			"dependencies": {
-				"source-map-support": {
-					"version": "0.4.18",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-					"dev": true,
-					"requires": {
-						"source-map": "^0.5.6"
-					}
-				}
-			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			}
-		},
-		"babel-template": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
-			},
-			"dependencies": {
-				"babylon": {
-					"version": "6.18.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-					"dev": true
-				}
-			}
-		},
-		"babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
-			},
-			"dependencies": {
-				"babylon": {
-					"version": "6.18.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-					"dev": true
-				}
-			}
-		},
-		"babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"babylon": {
@@ -1650,9 +1285,9 @@
 			}
 		},
 		"binary-extensions": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
 			"dev": true
 		},
 		"bluebird": {
@@ -1666,30 +1301,31 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"boxen": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+			"integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
 			"dev": true,
 			"requires": {
-				"ansi-align": "^2.0.0",
-				"camelcase": "^4.0.0",
-				"chalk": "^2.0.1",
-				"cli-boxes": "^1.0.0",
-				"string-width": "^2.0.0",
+				"ansi-align": "^3.0.0",
+				"camelcase": "^5.3.1",
+				"chalk": "^2.4.2",
+				"cli-boxes": "^2.2.0",
+				"string-width": "^3.0.0",
 				"term-size": "^1.2.0",
+				"type-fest": "^0.3.0",
 				"widest-line": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
@@ -1699,22 +1335,23 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
+						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"strip-ansi": "^5.1.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
@@ -1755,12 +1392,6 @@
 				}
 			}
 		},
-		"buf-compare": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
-			"dev": true
-		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -1788,35 +1419,28 @@
 				"unset-value": "^1.0.0"
 			}
 		},
-		"caching-transform": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+		"cacheable-request": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
+			"integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
 			"dev": true,
 			"requires": {
-				"md5-hex": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"write-file-atomic": "^1.1.4"
+				"clone-response": "^1.0.2",
+				"get-stream": "^4.0.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^3.0.0",
+				"lowercase-keys": "^1.0.1",
+				"normalize-url": "^3.1.0",
+				"responselike": "^1.0.2"
 			},
 			"dependencies": {
-				"md5-hex": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "^0.1.1"
-					}
-				},
-				"write-file-atomic": {
-					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"pump": "^3.0.0"
 					}
 				}
 			}
@@ -1851,26 +1475,29 @@
 			"dev": true
 		},
 		"camelcase": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 			"dev": true
 		},
 		"camelcase-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
+				"camelcase": "^4.1.0",
+				"map-obj": "^2.0.0",
+				"quick-lru": "^1.0.0"
+			},
+			"dependencies": {
+				"map-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
+				}
 			}
-		},
-		"capture-stack-trace": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -1926,26 +1553,79 @@
 			}
 		},
 		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.1.tgz",
+			"integrity": "sha512-2ww34sJWehnbpV0Q4k4V5Hh7juo7po6z7LUWkcIQnSGN1lHOL8GGtLtfwabKvLFQw/hbSUQ0u6V7OgGYgBzlkQ==",
 			"dev": true,
 			"requires": {
-				"anymatch": "^1.3.0",
-				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
+				"anymatch": "^3.0.1",
+				"async-each": "^1.0.3",
+				"braces": "^3.0.2",
+				"fsevents": "^2.0.6",
+				"glob-parent": "^5.0.0",
+				"is-binary-path": "^2.1.0",
+				"is-glob": "^4.0.1",
+				"normalize-path": "^3.0.0",
+				"readdirp": "^3.0.2"
+			},
+			"dependencies": {
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
 			}
 		},
+		"chunkd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/chunkd/-/chunkd-1.0.0.tgz",
+			"integrity": "sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg==",
+			"dev": true
+		},
 		"ci-info": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
+		"ci-parallel-vars": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.0.tgz",
+			"integrity": "sha512-u6dx20FBXm+apMi+5x7UVm6EH7BL1gc4XrcnQewjcB7HWRcor/V5qWc3RG2HwpgDJ26gIi2DSEu3B7sXynAw/g==",
 			"dev": true
 		},
 		"class-utils": {
@@ -1979,9 +1659,9 @@
 			}
 		},
 		"clean-stack": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
+			"integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
 			"dev": true
 		},
 		"clean-yaml-object": {
@@ -1991,9 +1671,9 @@
 			"dev": true
 		},
 		"cli-boxes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
 			"dev": true
 		},
 		"cli-cursor": {
@@ -2006,9 +1686,9 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.1.0.tgz",
+			"integrity": "sha512-8B00fJOEh1HPrx4fo5eW16XmE1PcL1tGpGrxy63CXGP9nHdPBN63X75hA1zhvQuhVztJWLqV58Roj2qlNM7cAA==",
 			"dev": true
 		},
 		"cli-truncate": {
@@ -2110,13 +1790,13 @@
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
 			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
-		"co-with-promise": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
-			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
+		"clone-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"dev": true,
 			"requires": {
-				"pinkie-promise": "^1.0.0"
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"code-excerpt": {
@@ -2200,31 +1880,31 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concordance": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
-			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/concordance/-/concordance-4.0.0.tgz",
+			"integrity": "sha512-l0RFuB8RLfCS0Pt2Id39/oCPykE01pyxgAFypWTlaGRgvLkZrtczZ8atEHpTeEIW+zYWXTBuA9cCSeEOScxReQ==",
 			"dev": true,
 			"requires": {
 				"date-time": "^2.1.0",
 				"esutils": "^2.0.2",
-				"fast-diff": "^1.1.1",
-				"function-name-support": "^0.2.0",
+				"fast-diff": "^1.1.2",
 				"js-string-escape": "^1.0.1",
 				"lodash.clonedeep": "^4.5.0",
 				"lodash.flattendeep": "^4.4.0",
-				"lodash.merge": "^4.6.0",
+				"lodash.islength": "^4.0.1",
+				"lodash.merge": "^4.6.1",
 				"md5-hex": "^2.0.0",
-				"semver": "^5.3.0",
-				"well-known-symbols": "^1.0.0"
+				"semver": "^5.5.1",
+				"well-known-symbols": "^2.0.0"
 			},
 			"dependencies": {
-				"date-time": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
-					"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+				"md5-hex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+					"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
 					"dev": true,
 					"requires": {
-						"time-zone": "^1.0.0"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"semver": {
@@ -2236,9 +1916,9 @@
 			}
 		},
 		"configstore": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+			"integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
 			"dev": true,
 			"requires": {
 				"dot-prop": "^4.1.0",
@@ -2249,6 +1929,15 @@
 				"xdg-basedir": "^3.0.0"
 			},
 			"dependencies": {
+				"dot-prop": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+					"dev": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				},
 				"make-dir": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -2284,16 +1973,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-		},
-		"core-assert": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
-			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-			"dev": true,
-			"requires": {
-				"buf-compare": "^1.0.0",
-				"is-error": "^2.2.0"
-			}
 		},
 		"core-js": {
 			"version": "2.6.9",
@@ -2347,15 +2026,6 @@
 					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
 				}
-			}
-		},
-		"create-error-class": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-			"dev": true,
-			"requires": {
-				"capture-stack-trace": "^1.0.0"
 			}
 		},
 		"cross-env": {
@@ -2466,10 +2136,13 @@
 			}
 		},
 		"date-time": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-			"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-			"dev": true
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
+			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+			"dev": true,
+			"requires": {
+				"time-zone": "^1.0.0"
+			}
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -2500,6 +2173,15 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^1.0.0"
+			}
+		},
 		"deep-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -2525,6 +2207,29 @@
 			"requires": {
 				"strip-bom": "^3.0.0"
 			}
+		},
+		"defaults": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.2"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+					"dev": true
+				}
+			}
+		},
+		"defer-to-connect": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+			"integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+			"dev": true
 		},
 		"define-property": {
 			"version": "2.0.2",
@@ -2563,6 +2268,50 @@
 				}
 			}
 		},
+		"del": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+			"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+			"dev": true,
+			"requires": {
+				"@types/glob": "^7.1.1",
+				"globby": "^6.1.0",
+				"is-path-cwd": "^2.0.0",
+				"is-path-in-cwd": "^2.0.0",
+				"p-map": "^2.0.0",
+				"pify": "^4.0.1",
+				"rimraf": "^2.6.3"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"dev": true,
+					"requires": {
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+							"dev": true
+						}
+					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				}
+			}
+		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2572,15 +2321,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-		},
-		"detect-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true,
-			"requires": {
-				"repeating": "^2.0.0"
-			}
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -2643,9 +2383,9 @@
 			}
 		},
 		"dot-prop": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.0.0.tgz",
+			"integrity": "sha512-RTmaF2jx3nOBO2GvtFqjnDLycjFUMqt+2pwRx7JVYa81lDauoj9aNkyrJI2ikR58FbBIchiIlRiGG+muLJ4oHQ==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
@@ -2680,6 +2420,12 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"emittery": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
+			"integrity": "sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==",
+			"dev": true
+		},
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -2687,9 +2433,9 @@
 			"dev": true
 		},
 		"empower-core": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-			"integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
+			"integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
 			"dev": true,
 			"requires": {
 				"call-signature": "0.0.2",
@@ -2982,6 +2728,12 @@
 			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
 			"dev": true
 		},
+		"esm": {
+			"version": "3.2.25",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+			"dev": true
+		},
 		"espower-location-detector": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
@@ -3103,57 +2855,6 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
 						"is-extendable": "^0.1.0"
-					}
-				}
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
-			"requires": {
-				"fill-range": "^2.1.0"
-			},
-			"dependencies": {
-				"fill-range": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"dev": true,
-					"requires": {
-						"is-number": "^2.1.0",
-						"isobject": "^2.0.0",
-						"randomatic": "^3.0.0",
-						"repeat-element": "^1.1.2",
-						"repeat-string": "^1.5.2"
-					}
-				},
-				"is-number": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"isobject": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true,
-					"requires": {
-						"isarray": "1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -3349,12 +3050,6 @@
 			"integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==",
 			"dev": true
 		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
-		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3372,28 +3067,6 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
 						"is-extendable": "^0.1.0"
-					}
-				}
-			}
-		},
-		"find-cache-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-			"dev": true,
-			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
-			},
-			"dependencies": {
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
 					}
 				}
 			}
@@ -3423,25 +3096,10 @@
 			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
 			"dev": true
 		},
-		"fn-name": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-			"dev": true
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
-			"requires": {
-				"for-in": "^1.0.1"
-			}
 		},
 		"foreground-child": {
 			"version": "1.5.6",
@@ -3494,558 +3152,11 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+			"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"nan": "^2.12.1",
-				"node-pre-gyp": "^0.12.0"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"fs-minipass": {
-					"version": "1.2.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"minipass": {
-					"version": "2.3.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.2.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"needle": {
-					"version": "2.3.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"debug": "^4.1.0",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.12.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.4.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"semver": {
-					"version": "5.7.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "4.4.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"string-width": "^1.0.2 || 2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"yallist": {
-					"version": "3.0.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
-		"function-name-support": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
-			"dev": true
+			"optional": true
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
@@ -4074,16 +3185,13 @@
 			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 		},
 		"get-port": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-			"dev": true
-		},
-		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.0.0.tgz",
+			"integrity": "sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.3.0"
+			}
 		},
 		"get-stream": {
 			"version": "3.0.0",
@@ -4117,23 +3225,13 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
-			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			}
-		},
 		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+			"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
 			"dev": true,
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "^4.0.1"
 			}
 		},
 		"glob-to-regexp": {
@@ -4149,12 +3247,6 @@
 			"requires": {
 				"ini": "^1.3.4"
 			}
-		},
-		"globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-			"dev": true
 		},
 		"globby": {
 			"version": "9.2.0",
@@ -4184,22 +3276,33 @@
 			}
 		},
 		"got": {
-			"version": "6.7.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"version": "9.6.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
 			"dev": true,
 			"requires": {
-				"create-error-class": "^3.0.0",
+				"@sindresorhus/is": "^0.14.0",
+				"@szmarczak/http-timer": "^1.1.2",
+				"cacheable-request": "^6.0.0",
+				"decompress-response": "^3.3.0",
 				"duplexer3": "^0.1.4",
-				"get-stream": "^3.0.0",
-				"is-redirect": "^1.0.0",
-				"is-retry-allowed": "^1.0.0",
-				"is-stream": "^1.0.0",
-				"lowercase-keys": "^1.0.0",
-				"safe-buffer": "^5.0.1",
-				"timed-out": "^4.0.0",
-				"unzip-response": "^2.0.1",
-				"url-parse-lax": "^1.0.0"
+				"get-stream": "^4.1.0",
+				"lowercase-keys": "^1.0.1",
+				"mimic-response": "^1.0.1",
+				"p-cancelable": "^1.0.0",
+				"to-readable-stream": "^1.0.0",
+				"url-parse-lax": "^3.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
 			}
 		},
 		"graceful-fs": {
@@ -4274,16 +3377,10 @@
 				"ansi-regex": "^2.0.0"
 			}
 		},
-		"has-color": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-			"dev": true
-		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
 		"has-unicode": {
@@ -4321,9 +3418,9 @@
 			}
 		},
 		"has-yarn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
 			"dev": true
 		},
 		"hasha": {
@@ -4333,16 +3430,6 @@
 			"dev": true,
 			"requires": {
 				"is-stream": "^1.0.1"
-			}
-		},
-		"home-or-tmp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
@@ -4375,6 +3462,12 @@
 				}
 			}
 		},
+		"http-cache-semantics": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+			"dev": true
+		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -4383,28 +3476,6 @@
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
-			}
-		},
-		"hullabaloo-config-manager": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
-			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
-			"dev": true,
-			"requires": {
-				"dot-prop": "^4.1.0",
-				"es6-error": "^4.0.2",
-				"graceful-fs": "^4.1.11",
-				"indent-string": "^3.1.0",
-				"json5": "^0.5.1",
-				"lodash.clonedeep": "^4.5.0",
-				"lodash.clonedeepwith": "^4.5.0",
-				"lodash.isequal": "^4.5.0",
-				"lodash.merge": "^4.6.0",
-				"md5-hex": "^2.0.0",
-				"package-hash": "^2.0.0",
-				"pkg-dir": "^2.0.0",
-				"resolve-from": "^3.0.0",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"iconv-lite": {
@@ -4452,13 +3523,24 @@
 			"dev": true
 		},
 		"import-local": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
-			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
+				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
+			},
+			"dependencies": {
+				"resolve-cwd": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+					"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+					"dev": true,
+					"requires": {
+						"resolve-from": "^3.0.0"
+					}
+				}
 			}
 		},
 		"imurmurhash": {
@@ -4566,15 +3648,6 @@
 				}
 			}
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
 		"invert-kv": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -4582,9 +3655,9 @@
 			"dev": true
 		},
 		"irregular-plurals": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
+			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
 			"dev": true
 		},
 		"is-accessor-descriptor": {
@@ -4611,12 +3684,12 @@
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "^1.0.0"
+				"binary-extensions": "^2.0.0"
 			}
 		},
 		"is-buffer": {
@@ -4625,12 +3698,12 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-ci": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.5.0"
+				"ci-info": "^2.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -4668,21 +3741,6 @@
 				}
 			}
 		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
-			"requires": {
-				"is-primitive": "^2.0.0"
-			}
-		},
 		"is-error": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
@@ -4695,19 +3753,10 @@
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
-		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
 		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
@@ -4717,19 +3766,13 @@
 				"number-is-nan": "^1.0.0"
 			}
 		},
-		"is-generator-fn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-			"dev": true
-		},
 		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-installed-globally": {
@@ -4740,12 +3783,23 @@
 			"requires": {
 				"global-dirs": "^0.1.0",
 				"is-path-inside": "^1.0.0"
+			},
+			"dependencies": {
+				"is-path-inside": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+					"dev": true,
+					"requires": {
+						"path-is-inside": "^1.0.1"
+					}
+				}
 			}
 		},
 		"is-npm": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+			"integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
 			"dev": true
 		},
 		"is-number": {
@@ -4773,21 +3827,33 @@
 			"dev": true
 		},
 		"is-observable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.0.0.tgz",
+			"integrity": "sha512-fhBZv3eFKUbyHXZ1oHujdo2tZ+CNbdpdzzlENgCGZUC8keoGxUew2jYFLYcUB4qo7LDD03o4KK11m/QYD7kEjg==",
+			"dev": true
+		},
+		"is-path-cwd": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.1.0.tgz",
+			"integrity": "sha512-Sc5j3/YnM8tDeyCsVeKlm/0p95075DyLmDEIkSgQ7mXkrOX+uTCtmQFm0CYzVyJwcCCmO3k8qfJt17SxQwB5Zw==",
+			"dev": true
+		},
+		"is-path-in-cwd": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
 			"dev": true,
 			"requires": {
-				"symbol-observable": "^1.1.0"
+				"is-path-inside": "^2.1.0"
 			}
 		},
 		"is-path-inside": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "^1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -4804,34 +3870,10 @@
 				"isobject": "^3.0.1"
 			}
 		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
-		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
-		},
-		"is-redirect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-			"dev": true
-		},
-		"is-retry-allowed": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
 			"dev": true
 		},
 		"is-stream": {
@@ -4866,6 +3908,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
 			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
+		},
+		"is-yarn-global": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
 			"dev": true
 		},
 		"isarray": {
@@ -4998,12 +4046,6 @@
 			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
 			"dev": true
 		},
-		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
-		},
 		"js-yaml": {
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -5110,6 +4152,12 @@
 			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
 			"dev": true
 		},
+		"json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"dev": true
+		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -5137,10 +4185,21 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -5159,6 +4218,15 @@
 			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
 			"dev": true
 		},
+		"keyv": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"dev": true,
+			"requires": {
+				"json-buffer": "3.0.0"
+			}
+		},
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -5172,22 +4240,13 @@
 				"graceful-fs": "^4.1.9"
 			}
 		},
-		"last-line-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
-			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-			"dev": true,
-			"requires": {
-				"through2": "^2.0.0"
-			}
-		},
 		"latest-version": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+			"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
 			"dev": true,
 			"requires": {
-				"package-json": "^4.0.0"
+				"package-json": "^6.3.0"
 			}
 		},
 		"lcid": {
@@ -5304,28 +4363,10 @@
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
 		},
-		"lodash.clonedeepwith": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
-			"dev": true
-		},
-		"lodash.debounce": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-			"dev": true
-		},
 		"lodash.defaults": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
 			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
-		},
-		"lodash.difference": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-			"dev": true
 		},
 		"lodash.filter": {
 			"version": "4.6.0",
@@ -5348,10 +4389,10 @@
 			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
 			"integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
 		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+		"lodash.islength": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
+			"integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
 			"dev": true
 		},
 		"lodash.map": {
@@ -5390,20 +4431,20 @@
 			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
 			"dev": true
 		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1"
+			}
+		},
 		"lolex": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.0.1.tgz",
 			"integrity": "sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw==",
 			"dev": true
-		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
 		},
 		"loud-rejection": {
 			"version": "1.6.0",
@@ -5508,24 +4549,26 @@
 			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
 		},
 		"matcher": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
-			"integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-2.0.0.tgz",
+			"integrity": "sha512-nlmfSlgHBFx36j/Pl/KQPbIaqE8Zf0TqmSMjsuddHDg6PMSVgmyW9HpkLs0o0M1n2GIZ/S2BZBLIww/xjhiGng==",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.4"
+				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				}
 			}
 		},
-		"math-random": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
-			"dev": true
-		},
 		"md5-hex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
-			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.0.tgz",
+			"integrity": "sha512-uA+EX5IV1r5lKBJecwTSec3k6xl4ziBUZihRiOpOHCeHjKA0ai6+eImamXQy/cI3Qep5mQgFTeJld9tcwdBNFw==",
 			"dev": true,
 			"requires": {
 				"md5-o-matic": "^0.1.1"
@@ -5563,130 +4606,82 @@
 			}
 		},
 		"meow": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+			"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
+				"camelcase-keys": "^4.0.0",
+				"decamelize-keys": "^1.0.0",
 				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
+				"minimist-options": "^3.0.1",
 				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
+				"read-pkg-up": "^3.0.0",
+				"redent": "^2.0.0",
+				"trim-newlines": "^2.0.0",
+				"yargs-parser": "^10.0.0"
 			},
 			"dependencies": {
 				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"path-exists": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 					"dev": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "^2.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
 				},
 				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+				"yargs-parser": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -5758,6 +4753,12 @@
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 			"dev": true
 		},
+		"mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5822,30 +4823,11 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
-		"multimatch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"dev": true,
-			"requires": {
-				"array-differ": "^1.0.0",
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"minimatch": "^3.0.0"
-			}
-		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
-		},
-		"nan": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-			"dev": true,
-			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -5940,6 +4922,12 @@
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
+		},
+		"normalize-url": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+			"dev": true
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -6105,16 +5093,6 @@
 				"isobject": "^3.0.0"
 			}
 		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
-			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
-			}
-		},
 		"object.pick": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -6124,32 +5102,13 @@
 			}
 		},
 		"observable-to-promise": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
-			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-1.0.0.tgz",
+			"integrity": "sha512-cqnGUrNsE6vdVDTPAX9/WeVzwy/z37vdxupdQXU8vgTXRFH72KCZiZga8aca2ulRPIeem8W3vW9rQHBwfIl2WA==",
 			"dev": true,
 			"requires": {
-				"is-observable": "^0.2.0",
+				"is-observable": "^2.0.0",
 				"symbol-observable": "^1.0.4"
-			},
-			"dependencies": {
-				"is-observable": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
-					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-					"dev": true,
-					"requires": {
-						"symbol-observable": "^0.2.2"
-					},
-					"dependencies": {
-						"symbol-observable": {
-							"version": "0.2.4",
-							"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
-							"dev": true
-						}
-					}
-				}
 			}
 		},
 		"once": {
@@ -6341,12 +5300,6 @@
 				}
 			}
 		},
-		"option-chain": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
-			"dev": true
-		},
 		"optionator": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -6358,6 +5311,37 @@
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2",
 				"wordwrap": "~1.0.0"
+			}
+		},
+		"ora": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+			"integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2",
+				"cli-cursor": "^2.1.0",
+				"cli-spinners": "^2.0.0",
+				"log-symbols": "^2.2.0",
+				"strip-ansi": "^5.2.0",
+				"wcwidth": "^1.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
 			}
 		},
 		"os-homedir": {
@@ -6428,6 +5412,12 @@
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
+		"p-cancelable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"dev": true
+		},
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -6462,33 +5452,51 @@
 				"p-limit": "^2.0.0"
 			}
 		},
+		"p-map": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true
+		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"package-hash": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
-			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
+				"graceful-fs": "^4.1.15",
+				"hasha": "^5.0.0",
 				"lodash.flattendeep": "^4.4.0",
-				"md5-hex": "^2.0.0",
 				"release-zalgo": "^1.0.0"
+			},
+			"dependencies": {
+				"hasha": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.0.0.tgz",
+					"integrity": "sha512-PqWdhnQhq6tqD32hZv+l1e5mJHNSudjnaAzgAHfkGiU0ABN6lmbZF8abJIulQHbZ7oiHhP8yL6O910ICMc+5pw==",
+					"dev": true,
+					"requires": {
+						"is-stream": "^1.1.0",
+						"type-fest": "^0.3.0"
+					}
+				}
 			}
 		},
 		"package-json": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.3.0.tgz",
+			"integrity": "sha512-XO7WS3EEXd48vmW633Y97Mh9xuENFiOevI9G+ExfTG/k6xuY9cBd3fxkAoDMSEsNZXasaVJIJ1rD/n7GMf18bA==",
 			"dev": true,
 			"requires": {
-				"got": "^6.7.1",
-				"registry-auth-token": "^3.0.1",
-				"registry-url": "^3.0.3",
-				"semver": "^5.1.0"
+				"got": "^9.6.0",
+				"registry-auth-token": "^3.4.0",
+				"registry-url": "^5.0.0",
+				"semver": "^5.6.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -6508,18 +5516,6 @@
 				"callsites": "^3.0.0"
 			}
 		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
-			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
-			}
-		},
 		"parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -6530,9 +5526,9 @@
 			}
 		},
 		"parse-ms": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-			"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+			"integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
 			"dev": true
 		},
 		"pascalcase": {
@@ -6613,136 +5609,67 @@
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
 		"pinkie": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
 			"dev": true
 		},
 		"pinkie-promise": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-			"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "^1.0.0"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-conf": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+			"integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.0.0",
-				"load-json-file": "^4.0.0"
+				"find-up": "^3.0.0",
+				"load-json-file": "^5.2.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+				"load-json-file": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+					"integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"graceful-fs": "^4.1.15",
+						"parse-json": "^4.0.0",
+						"pify": "^4.0.1",
+						"strip-bom": "^3.0.0",
+						"type-fest": "^0.3.0"
 					}
 				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
 				}
 			}
 		},
 		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
-				}
+				"find-up": "^3.0.0"
 			}
 		},
 		"plur": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
+			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
 			"dev": true,
 			"requires": {
-				"irregular-plurals": "^1.0.0"
+				"irregular-plurals": "^2.0.0"
 			}
 		},
 		"posix-character-classes": {
@@ -6756,15 +5683,9 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
-		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
 			"dev": true
 		},
 		"pretty-data": {
@@ -6778,27 +5699,13 @@
 			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
 		},
 		"pretty-ms": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
-			"integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.0.0.tgz",
+			"integrity": "sha512-94VRYjL9k33RzfKiGokPBPpsmloBYSf5Ri+Pq19zlsEcUKFob+admeXr5eFDRuPjFmEOcjJvPGdillYOJyvZ7Q==",
 			"dev": true,
 			"requires": {
-				"parse-ms": "^1.0.0"
-			},
-			"dependencies": {
-				"parse-ms": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-					"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-					"dev": true
-				}
+				"parse-ms": "^2.1.0"
 			}
-		},
-		"private": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
@@ -6852,25 +5759,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/random-int/-/random-int-2.0.0.tgz",
 			"integrity": "sha512-jCJ4a8BJ+z3f4SYSFtYIiRfcdxe2Bvh+Gg2J+LjriL3dVOtrF77u0tklYbO8acHoZQ7JlYJn3lNKfW5TFjcwdQ=="
-		},
-		"randomatic": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-			"dev": true,
-			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
-				}
-			}
 		},
 		"rc": {
 			"version": "1.2.8",
@@ -6926,35 +5814,22 @@
 			}
 		},
 		"readdirp": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.0.2.tgz",
+			"integrity": "sha512-LbyJYv48eywrhOlScq16H/VkCiGKGPC2TpOdZCJ7QXnYEjn3NN/Oblh8QEU3vqfSRBB7OGvh5x45NKiVeNujIQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"micromatch": "^3.1.10",
-				"readable-stream": "^2.0.2"
+				"picomatch": "^2.0.4"
 			}
 		},
 		"redent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
-			},
-			"dependencies": {
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
-					}
-				}
+				"indent-string": "^3.0.0",
+				"strip-indent": "^2.0.0"
 			}
 		},
 		"regenerate": {
@@ -6963,19 +5838,13 @@
 			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
 			"dev": true
 		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+		"regenerate-unicode-properties": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"regenerate": "^1.4.0"
 			}
 		},
 		"regex-not": {
@@ -6994,14 +5863,17 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+			"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
 			"dev": true,
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^8.0.2",
+				"regjsgen": "^0.5.0",
+				"regjsparser": "^0.6.0",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
 		},
 		"registry-auth-token": {
@@ -7015,24 +5887,24 @@
 			}
 		},
 		"registry-url": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
 			"dev": true,
 			"requires": {
-				"rc": "^1.0.1"
+				"rc": "^1.2.8"
 			}
 		},
 		"regjsgen": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
 			"dev": true
 		},
 		"regjsparser": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -7061,15 +5933,6 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
 		},
 		"replacestream": {
 			"version": "4.0.3",
@@ -7143,12 +6006,20 @@
 			}
 		},
 		"resolve-cwd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
 			}
 		},
 		"resolve-from": {
@@ -7161,6 +6032,15 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+		},
+		"responselike": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"dev": true,
+			"requires": {
+				"lowercase-keys": "^1.0.0"
+			}
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
@@ -7316,9 +6196,9 @@
 			}
 		},
 		"slash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
 		"slice-ansi": {
@@ -7337,12 +6217,6 @@
 					"dev": true
 				}
 			}
-		},
-		"slide": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-			"dev": true
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -7439,15 +6313,6 @@
 						"is-buffer": "^1.1.5"
 					}
 				}
-			}
-		},
-		"sort-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"dev": true,
-			"requires": {
-				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-map": {
@@ -7618,9 +6483,9 @@
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-bom-buf": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
-			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz",
+			"integrity": "sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==",
 			"dev": true,
 			"requires": {
 				"is-utf8": "^0.2.1"
@@ -7633,13 +6498,10 @@
 			"dev": true
 		},
 		"strip-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "^4.0.1"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -7938,12 +6800,6 @@
 			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
 			"dev": true
 		},
-		"timed-out": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true
-		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -7952,12 +6808,6 @@
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
-		},
-		"to-fast-properties": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-			"dev": true
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -7976,6 +6826,12 @@
 					}
 				}
 			}
+		},
+		"to-readable-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+			"dev": true
 		},
 		"to-regex": {
 			"version": "3.0.2",
@@ -8014,9 +6870,9 @@
 			}
 		},
 		"trim-newlines": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
 			"dev": true
 		},
 		"trim-off-newlines": {
@@ -8064,6 +6920,21 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
+		"type-fest": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+			"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+			"dev": true
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
+		},
 		"uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -8101,6 +6972,34 @@
 			"version": "1.8.3",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
 			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+			"dev": true
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"dev": true,
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+			"dev": true
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+			"dev": true
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -8190,26 +7089,22 @@
 				}
 			}
 		},
-		"unzip-response": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-			"dev": true
-		},
 		"update-notifier": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.0.tgz",
+			"integrity": "sha512-6Xe3oF2bvuoj4YECUc52yxVs94yWrxwqHbzyveDktTS1WhnlTRpNcQMxUshcB7nRVGi1jEXiqL5cW1S5WSyzKg==",
 			"dev": true,
 			"requires": {
-				"boxen": "^1.2.1",
+				"boxen": "^3.0.0",
 				"chalk": "^2.0.1",
-				"configstore": "^3.0.0",
+				"configstore": "^4.0.0",
+				"has-yarn": "^2.1.0",
 				"import-lazy": "^2.1.0",
-				"is-ci": "^1.0.10",
+				"is-ci": "^2.0.0",
 				"is-installed-globally": "^0.1.0",
-				"is-npm": "^1.0.0",
-				"latest-version": "^3.0.0",
+				"is-npm": "^3.0.0",
+				"is-yarn-global": "^0.3.0",
+				"latest-version": "^5.0.0",
 				"semver-diff": "^2.0.0",
 				"xdg-basedir": "^3.0.0"
 			}
@@ -8228,12 +7123,12 @@
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url-parse-lax": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "^1.0.1"
+				"prepend-http": "^2.0.0"
 			}
 		},
 		"use": {
@@ -8270,10 +7165,19 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
+		"wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"dev": true,
+			"requires": {
+				"defaults": "^1.0.3"
+			}
+		},
 		"well-known-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+			"integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
 			"dev": true
 		},
 		"which": {
@@ -8414,47 +7318,6 @@
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^3.0.2"
-			}
-		},
-		"write-json-file": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
-			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-			"dev": true,
-			"requires": {
-				"detect-indent": "^5.0.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^1.0.0",
-				"pify": "^3.0.0",
-				"sort-keys": "^2.0.0",
-				"write-file-atomic": "^2.0.0"
-			},
-			"dependencies": {
-				"detect-indent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-					"dev": true
-				},
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				}
-			}
-		},
-		"write-pkg": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
-			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
-			"dev": true,
-			"requires": {
-				"sort-keys": "^2.0.0",
-				"write-json-file": "^2.2.0"
 			}
 		},
 		"xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"files": [
 			"test/lib/**/*.js"
 		],
-		"source": [
+		"sources": [
 			"lib/**/*.js",
 			"test/lib/**/*.js"
 		]
@@ -104,7 +104,7 @@
 		"resolve": "^1.11.0"
 	},
 	"devDependencies": {
-		"ava": "^0.25.0",
+		"ava": "^2.0.0",
 		"coveralls": "^3.0.3",
 		"cross-env": "^5.2.0",
 		"docdash": "^1.1.1",

--- a/test/lib/extensions.js
+++ b/test/lib/extensions.js
@@ -1,4 +1,4 @@
-const {test} = require("ava");
+const test = require("ava");
 const path = require("path");
 const sinon = require("sinon");
 const projectPreprocessor = require("../..").projectPreprocessor;
@@ -458,7 +458,7 @@ test("Project with project-type extension dependency inline configuration", (t) 
 			name: "xy"
 		}
 	};
-	return t.throws(projectPreprocessor.processTree(tree).then((parsedTree) => {
+	return t.throwsAsync(projectPreprocessor.processTree(tree).then((parsedTree) => {
 		t.deepEqual(parsedTree, {
 			_level: 0,
 			type: "z",
@@ -508,7 +508,7 @@ test("Project with unknown extension dependency inline configuration", (t) => {
 			name: "xy"
 		}
 	};
-	return t.throws(projectPreprocessor.processTree(tree),
+	return t.throwsAsync(projectPreprocessor.processTree(tree),
 		"Unknown extension type 'phony-pony' for extension.a", "Rejected with error");
 });
 
@@ -573,7 +573,7 @@ test("Project with task extension dependency - task module not found", async (t)
 			name: "xy"
 		}
 	};
-	const error = await t.throws(projectPreprocessor.processTree(tree));
+	const error = await t.throwsAsync(projectPreprocessor.processTree(tree));
 	t.regex(error.message, /^Cannot find module.*/, "Rejected with error");
 });
 
@@ -591,7 +591,7 @@ test("specVersion: Missing version", async (t) => {
 		shims: {}
 	};
 	const preprocessor = new Preprocessor();
-	await t.throws(preprocessor.applyExtension(extension),
+	await t.throwsAsync(preprocessor.applyExtension(extension),
 		"No specification version defined for extension shims.a",
 		"Rejected with error");
 });
@@ -611,7 +611,7 @@ test("specVersion: Extension with invalid version", async (t) => {
 		shims: {}
 	};
 	const preprocessor = new Preprocessor();
-	await t.throws(preprocessor.applyExtension(extension),
+	await t.throwsAsync(preprocessor.applyExtension(extension),
 		"Unsupported specification version 0.9 defined for extension shims.a. " +
 		"See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions",
 		"Rejected with error");

--- a/test/lib/normalizer.js
+++ b/test/lib/normalizer.js
@@ -1,4 +1,4 @@
-const {test} = require("ava");
+const test = require("ava");
 const sinon = require("sinon");
 const normalizer = require("../..").normalizer;
 const npmTranslatorStub = sinon.stub(require("../..").translators.npm);

--- a/test/lib/projectPreprocessor.js
+++ b/test/lib/projectPreprocessor.js
@@ -1,4 +1,4 @@
-const {test} = require("ava");
+const test = require("ava");
 const path = require("path");
 const projectPreprocessor = require("../..").projectPreprocessor;
 const applicationAPath = path.join(__dirname, "..", "fixtures", "application.a");
@@ -161,7 +161,7 @@ test("Missing configuration for root project", (t) => {
 		path: "non-existent",
 		dependencies: []
 	};
-	return t.throws(projectPreprocessor.processTree(tree),
+	return t.throwsAsync(projectPreprocessor.processTree(tree),
 		"No specification version defined for root project application.a",
 		"Rejected with error");
 });
@@ -171,7 +171,7 @@ test("Missing id for root project", (t) => {
 		path: path.join(__dirname, "../fixtures/application.a"),
 		dependencies: []
 	};
-	return t.throws(projectPreprocessor.processTree(tree),
+	return t.throwsAsync(projectPreprocessor.processTree(tree),
 		"Encountered project with missing id (root project)", "Rejected with error");
 });
 
@@ -186,7 +186,7 @@ test("No type configured for root project", (t) => {
 			name: "application.a"
 		}
 	};
-	return t.throws(projectPreprocessor.processTree(tree),
+	return t.throwsAsync(projectPreprocessor.processTree(tree),
 		"No type configured for root project application.a",
 		"Rejected with error");
 });
@@ -198,7 +198,7 @@ test("Missing dependencies", (t) => {
 		path: applicationAPath,
 		dependencies: []
 	});
-	return t.notThrows(projectPreprocessor.processTree(tree),
+	return t.notThrowsAsync(projectPreprocessor.processTree(tree),
 		"Gracefully accepted project with no dependency attribute");
 });
 
@@ -238,7 +238,7 @@ test("Multiple non-root application-projects on same level", (t) => {
 			dependencies: []
 		}]
 	});
-	return t.throws(projectPreprocessor.processTree(tree),
+	return t.throwsAsync(projectPreprocessor.processTree(tree),
 		"Found at least two projects application.a and application.b of type application with the same distance to " +
 			"the root project. Only one project of type application can be used. Failed to decide which one to ignore.",
 		"Rejected with error");
@@ -527,7 +527,7 @@ test("Project tree B with inline configs", (t) => {
 	});
 });
 
-test("Project tree B with inline configs", (t) => {
+test("Project tree Cycle A with inline configs", (t) => {
 	// Tree B depends on Library B which has a dependency to Library D
 	return projectPreprocessor.processTree(treeApplicationCycleA).then((parsedTree) => {
 		t.deepEqual(parsedTree, expectedTreeApplicationCycleA, "Parsed correctly");
@@ -1496,7 +1496,7 @@ test("Application version in package.json data is missing", (t) => {
 			name: "xy"
 		}
 	};
-	return t.throws(projectPreprocessor.processTree(tree)).then((error) => {
+	return t.throwsAsync(projectPreprocessor.processTree(tree)).then((error) => {
 		t.is(error.message, "\"version\" is missing for project " + tree.id);
 	});
 });
@@ -1511,7 +1511,7 @@ test("Library version in package.json data is missing", (t) => {
 			name: "library.d"
 		}
 	};
-	return t.throws(projectPreprocessor.processTree(tree)).then((error) => {
+	return t.throwsAsync(projectPreprocessor.processTree(tree)).then((error) => {
 		t.is(error.message, "\"version\" is missing for project " + tree.id);
 	});
 });
@@ -1527,7 +1527,7 @@ test("specVersion: Missing version", (t) => {
 			name: "xy"
 		}
 	};
-	return t.throws(projectPreprocessor.processTree(tree),
+	return t.throwsAsync(projectPreprocessor.processTree(tree),
 		"No specification version defined for root project application.a",
 		"Rejected with error");
 });
@@ -1544,7 +1544,7 @@ test("specVersion: Project with invalid version", async (t) => {
 			name: "xy"
 		}
 	};
-	await t.throws(projectPreprocessor.processTree(tree),
+	await t.throwsAsync(projectPreprocessor.processTree(tree),
 		"Unsupported specification version 0.9 defined for project application.a. " +
 		"See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions",
 		"Rejected with error");

--- a/test/lib/translators/npm.js
+++ b/test/lib/translators/npm.js
@@ -1,4 +1,4 @@
-const {test} = require("ava");
+const test = require("ava");
 const path = require("path");
 const mock = require("mock-require");
 const applicationAPath = path.join(__dirname, "..", "..", "fixtures", "application.a");
@@ -136,12 +136,12 @@ test("AppCycleE: cyclic npm deps - Cycle via devDependency", (t) => {
 
 test("Error: missing package.json", async (t) => {
 	const dir = path.parse(__dirname).root;
-	const error = await t.throws(npmTranslator.generateDependencyTree(dir));
+	const error = await t.throwsAsync(npmTranslator.generateDependencyTree(dir));
 	t.is(error.message, `[npm translator] Failed to locate package.json for directory "${dir}"`);
 });
 
 test("Error: missing dependency", async (t) => {
-	const error = await t.throws(npmTranslator.generateDependencyTree(errApplicationAPath));
+	const error = await t.throwsAsync(npmTranslator.generateDependencyTree(errApplicationAPath));
 	t.is(error.message, "[npm translator] Could not locate " +
 		"module library.xx via resolve logic (error: Cannot find module 'library.xx/package.json' from '" +
 		errApplicationAPath + "') or in a collection");

--- a/test/lib/translators/static.js
+++ b/test/lib/translators/static.js
@@ -1,4 +1,4 @@
-const {test} = require("ava");
+const test = require("ava");
 const path = require("path");
 const fs = require("graceful-fs");
 const sinon = require("sinon");
@@ -18,7 +18,7 @@ test("Error: Throws if projectDependencies.yaml was not found", async (t) => {
 	const fsError = new Error("File not found");
 	const fsStub = sinon.stub(fs, "readFile");
 	fsStub.callsArgWith(1, fsError);
-	const error = await t.throws(staticTranslator.generateDependencyTree(projectPath));
+	const error = await t.throwsAsync(staticTranslator.generateDependencyTree(projectPath));
 	t.is(error.message, `[static translator] Failed to locate projectDependencies.json at path: "${projectPath}" - Error: ${fsError.message}`);
 	fsStub.restore();
 });


### PR DESCRIPTION
Relevant changelogs:
https://github.com/avajs/ava/releases/tag/v1.0.1
https://github.com/avajs/ava/releases/tag/v2.0.0

Relevant changes:
- AVA now requires at least Node.js 8.9.4. We require only 8.5.
  However, since this is a devDependency I guess we can live with that.
- t.throws() does not accept promises anymore. Use t.throwsAsync()
- Test titles now must be unique