### PR TITLE
[INTERNAL] Move Cachebuster config documentation to correct section

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -89,8 +89,6 @@ Some general information:
         + `<virtual path>: <physical path>` (default `/: ./`): Any virtual path mapping can be defined here.  
           *(Only available for projects of type `module`)*  
           It is recommended that modules include their namespace in the virtual path and use the `/resources` prefix (e.g. `/resources/my/first/library/module-xy`).
-- `cachebuster`:
-    - `signatureType`: `time` or `hash`. By default, the generated cachebuster info file signatures are based on timestamps (`time`). In setups like CI environments, a mechanism based on file hashes (`hash`) might be more reliable.
 
 #### builder (optional)
 - `resources`: General resource configuration for this project
@@ -104,6 +102,8 @@ Some general information:
     - `name` (mandatory): The name of the custom task
     - `afterTask` or `beforeTask` (only one, mandatory): The name of the build task after or before which your custom task will be executed.
     - `configuration` (optional): Additional configuration that is passed to the custom build task
+- `cachebuster`:
+    - `signatureType`: `time` or `hash`. By default, the generated cachebuster info file signatures are based on timestamps (`time`). In setups like CI environments, a mechanism based on file hashes (`hash`) might be more reliable.
 
 #### server (optional)
 - `settings` (not yet implemented)


### PR DESCRIPTION
Feature was implemented with https://github.com/SAP/ui5-builder/pull/241.