### PR TITLE
[INTERNAL] Bump @ui5/builder from 1.3.3 to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -496,18 +496,19 @@
 			"integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg=="
 		},
 		"@ui5/builder": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-1.3.3.tgz",
-			"integrity": "sha512-YSgoKasQpndIJSsUIioVXKiaJmrrfYU486rvdS66lbNOJFzLsTygfMKV9vp7FBRIgjSqq8YZCVn2+oiNcb9jxA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-1.4.0.tgz",
+			"integrity": "sha512-gc3AVyOMHKKnXcTf9F/QP3S2E5+4flmXmuFAoD9tqlFXAfBcc+9CNJiuLJzj1keaClsVk/ZkMjkloo7Dpx50WA==",
 			"requires": {
 				"@ui5/fs": "^1.1.2",
 				"@ui5/logger": "^1.0.1",
 				"cheerio": "^0.22.0",
+				"escape-unicode": "^0.2.0",
 				"escodegen": "^1.11.1",
 				"escope": "^3.6.0",
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
-				"globby": "^10.0.0",
+				"globby": "^10.0.1",
 				"graceful-fs": "^4.2.0",
 				"jsdoc": "3.5.5",
 				"less-openui5": "^0.6.0",
@@ -516,7 +517,7 @@
 				"pretty-hrtime": "^1.0.3",
 				"replacestream": "^4.0.3",
 				"rimraf": "^2.6.3",
-				"semver": "^6.1.2",
+				"semver": "^6.3.0",
 				"slash": "^3.0.0",
 				"uglify-es": "^3.2.2",
 				"xml2js": "^0.4.17",
@@ -2522,6 +2523,11 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escape-unicode": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/escape-unicode/-/escape-unicode-0.2.0.tgz",
+			"integrity": "sha512-7jMQuKb8nm0h/9HYLfu4NCLFwoUsd5XO6OZ1z86PbKcMf8zDK1m7nFR0iA2CCShq4TSValaLIveE8T1UBxgALQ=="
 		},
 		"escodegen": {
 			"version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"url": "git@github.com:SAP/ui5-builder.git"
 	},
 	"dependencies": {
-		"@ui5/builder": "^1.3.3",
+		"@ui5/builder": "^1.4.0",
 		"@ui5/logger": "^1.0.1",
 		"@ui5/server": "^1.2.0",
 		"graceful-fs": "^4.2.0",

--- a/test/lib/extensions.js
+++ b/test/lib/extensions.js
@@ -65,6 +65,7 @@ test("Project with project-shim extension with dependency configuration", (t) =>
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						webapp: "webapp"
 					}
@@ -88,6 +89,7 @@ test("Project with project-shim extension with dependency configuration", (t) =>
 				},
 				resources: {
 					configuration: {
+						propertiesFileSourceEncoding: "ISO-8859-1",
 						paths: {
 							src: "src",
 							test: "test"
@@ -176,6 +178,7 @@ test("Project with project-shim extension with dependency declaration and config
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						webapp: "webapp"
 					}
@@ -199,6 +202,7 @@ test("Project with project-shim extension with dependency declaration and config
 				},
 				resources: {
 					configuration: {
+						propertiesFileSourceEncoding: "ISO-8859-1",
 						paths: {
 							src: "src",
 							test: "test"
@@ -224,6 +228,7 @@ test("Project with project-shim extension with dependency declaration and config
 					},
 					resources: {
 						configuration: {
+							propertiesFileSourceEncoding: "ISO-8859-1",
 							paths: {
 								src: "src",
 								test: "test"
@@ -251,6 +256,7 @@ test("Project with project-shim extension with dependency declaration and config
 				},
 				resources: {
 					configuration: {
+						propertiesFileSourceEncoding: "ISO-8859-1",
 						paths: {
 							src: "src",
 							test: "test"
@@ -345,6 +351,7 @@ test("Project with project-shim extension with collection", (t) => {
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						webapp: "webapp"
 					}
@@ -368,6 +375,7 @@ test("Project with project-shim extension with collection", (t) => {
 				},
 				resources: {
 					configuration: {
+						propertiesFileSourceEncoding: "ISO-8859-1",
 						paths: {
 							src: "src",
 							test: "test"
@@ -393,6 +401,7 @@ test("Project with project-shim extension with collection", (t) => {
 					},
 					resources: {
 						configuration: {
+							propertiesFileSourceEncoding: "ISO-8859-1",
 							paths: {
 								src: "src",
 								test: "test"
@@ -420,6 +429,7 @@ test("Project with project-shim extension with collection", (t) => {
 				},
 				resources: {
 					configuration: {
+						propertiesFileSourceEncoding: "ISO-8859-1",
 						paths: {
 							src: "src",
 							test: "test"
@@ -474,6 +484,7 @@ test("Project with project-type extension dependency inline configuration", (t) 
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						root: ""
 					}

--- a/test/lib/projectPreprocessor.js
+++ b/test/lib/projectPreprocessor.js
@@ -32,6 +32,7 @@ test("Project with inline configuration", (t) => {
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						webapp: "webapp"
 					}
@@ -67,6 +68,7 @@ test("Project with configPath", (t) => {
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						webapp: "webapp"
 					}
@@ -102,6 +104,7 @@ test("Project with ui5.yaml at default location", (t) => {
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						webapp: "webapp"
 					}
@@ -137,6 +140,7 @@ test("Project with ui5.yaml at default location and some configuration", (t) => 
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						webapp: "src"
 					}
@@ -321,6 +325,7 @@ test("Ignores additional application-projects", (t) => {
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						webapp: "webapp"
 					}
@@ -362,6 +367,7 @@ test("Inconsistent dependencies with same ID", (t) => {
 				},
 				resources: {
 					configuration: {
+						propertiesFileSourceEncoding: "ISO-8859-1",
 						paths: {
 							src: "main/src",
 							test: "main/test"
@@ -409,6 +415,7 @@ test("Inconsistent dependencies with same ID", (t) => {
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						webapp: "webapp"
 					}
@@ -433,6 +440,7 @@ test("Inconsistent dependencies with same ID", (t) => {
 					},
 					resources: {
 						configuration: {
+							propertiesFileSourceEncoding: "ISO-8859-1",
 							paths: {
 								src: "main/src",
 								test: "main/test"
@@ -459,6 +467,7 @@ test("Inconsistent dependencies with same ID", (t) => {
 							},
 							resources: {
 								configuration: {
+									propertiesFileSourceEncoding: "ISO-8859-1",
 									paths: {
 										src: "src",
 										test: "test"
@@ -488,6 +497,7 @@ test("Inconsistent dependencies with same ID", (t) => {
 					},
 					resources: {
 						configuration: {
+							propertiesFileSourceEncoding: "ISO-8859-1",
 							paths: {
 								src: "src",
 								test: "test"
@@ -629,6 +639,7 @@ const expectedTreeWithInvalidModules = {
 		"_level": 1,
 		"resources": {
 			"configuration": {
+				"propertiesFileSourceEncoding": "ISO-8859-1",
 				"paths": {
 					"src": "src",
 					"test": "test"
@@ -655,6 +666,7 @@ const expectedTreeWithInvalidModules = {
 		"_level": 1,
 		"resources": {
 			"configuration": {
+				"propertiesFileSourceEncoding": "ISO-8859-1",
 				"paths": {
 					"src": "src",
 					"test": "test"
@@ -676,6 +688,7 @@ const expectedTreeWithInvalidModules = {
 	"kind": "project",
 	"resources": {
 		"configuration": {
+			"propertiesFileSourceEncoding": "ISO-8859-1",
 			"paths": {
 				"webapp": "webapp"
 			}
@@ -708,6 +721,7 @@ const treeAWithInlineConfigs = {
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						src: "main/src",
 						test: "main/test"
@@ -813,6 +827,7 @@ const expectedTreeAWithInlineConfigs = {
 	},
 	"resources": {
 		"configuration": {
+			"propertiesFileSourceEncoding": "ISO-8859-1",
 			"paths": {
 				"webapp": "webapp"
 			}
@@ -837,6 +852,7 @@ const expectedTreeAWithInlineConfigs = {
 			},
 			"resources": {
 				"configuration": {
+					"propertiesFileSourceEncoding": "ISO-8859-1",
 					"paths": {
 						"src": "main/src",
 						"test": "main/test"
@@ -863,6 +879,7 @@ const expectedTreeAWithInlineConfigs = {
 					},
 					"resources": {
 						"configuration": {
+							"propertiesFileSourceEncoding": "ISO-8859-1",
 							"paths": {
 								"src": "src",
 								"test": "test"
@@ -892,6 +909,7 @@ const expectedTreeAWithInlineConfigs = {
 			},
 			"resources": {
 				"configuration": {
+					"propertiesFileSourceEncoding": "ISO-8859-1",
 					"paths": {
 						"src": "src",
 						"test": "test"
@@ -923,6 +941,7 @@ const expectedTreeAWithConfigPaths = {
 	},
 	"resources": {
 		"configuration": {
+			"propertiesFileSourceEncoding": "ISO-8859-1",
 			"paths": {
 				"webapp": "webapp"
 			}
@@ -948,6 +967,7 @@ const expectedTreeAWithConfigPaths = {
 			},
 			"resources": {
 				"configuration": {
+					"propertiesFileSourceEncoding": "ISO-8859-1",
 					"paths": {
 						"src": "main/src",
 						"test": "main/test"
@@ -975,6 +995,7 @@ const expectedTreeAWithConfigPaths = {
 					},
 					"resources": {
 						"configuration": {
+							"propertiesFileSourceEncoding": "ISO-8859-1",
 							"paths": {
 								"src": "src",
 								"test": "test"
@@ -1005,6 +1026,7 @@ const expectedTreeAWithConfigPaths = {
 			},
 			"resources": {
 				"configuration": {
+					"propertiesFileSourceEncoding": "ISO-8859-1",
 					"paths": {
 						"src": "src",
 						"test": "test"
@@ -1052,6 +1074,7 @@ const treeBWithInlineConfigs = {
 					},
 					resources: {
 						configuration: {
+							propertiesFileSourceEncoding: "ISO-8859-1",
 							paths: {
 								src: "main/src",
 								test: "main/test"
@@ -1085,6 +1108,7 @@ const treeBWithInlineConfigs = {
 			},
 			resources: {
 				configuration: {
+					propertiesFileSourceEncoding: "ISO-8859-1",
 					paths: {
 						src: "main/src",
 						test: "main/test"
@@ -1122,6 +1146,7 @@ const expectedTreeBWithInlineConfigs = {
 	},
 	"resources": {
 		"configuration": {
+			"propertiesFileSourceEncoding": "ISO-8859-1",
 			"paths": {
 				"webapp": "webapp"
 			}
@@ -1146,6 +1171,7 @@ const expectedTreeBWithInlineConfigs = {
 			},
 			"resources": {
 				"configuration": {
+					"propertiesFileSourceEncoding": "ISO-8859-1",
 					"paths": {
 						"src": "src",
 						"test": "test"
@@ -1172,6 +1198,7 @@ const expectedTreeBWithInlineConfigs = {
 					},
 					"resources": {
 						"configuration": {
+							"propertiesFileSourceEncoding": "ISO-8859-1",
 							"paths": {
 								"src": "main/src",
 								"test": "main/test"
@@ -1198,6 +1225,7 @@ const expectedTreeBWithInlineConfigs = {
 							},
 							"resources": {
 								"configuration": {
+									"propertiesFileSourceEncoding": "ISO-8859-1",
 									"paths": {
 										"src": "src",
 										"test": "test"
@@ -1229,6 +1257,7 @@ const expectedTreeBWithInlineConfigs = {
 			},
 			"resources": {
 				"configuration": {
+					"propertiesFileSourceEncoding": "ISO-8859-1",
 					"paths": {
 						"src": "main/src",
 						"test": "main/test"
@@ -1255,6 +1284,7 @@ const expectedTreeBWithInlineConfigs = {
 					},
 					"resources": {
 						"configuration": {
+							"propertiesFileSourceEncoding": "ISO-8859-1",
 							"paths": {
 								"src": "src",
 								"test": "test"
@@ -1407,6 +1437,7 @@ const expectedTreeApplicationCycleA = {
 					"_level": 2,
 					"resources": {
 						"configuration": {
+							"propertiesFileSourceEncoding": "ISO-8859-1",
 							"paths": {
 								"src": "src",
 								"test": "test"
@@ -1446,6 +1477,7 @@ const expectedTreeApplicationCycleA = {
 					"_level": 2,
 					"resources": {
 						"configuration": {
+							"propertiesFileSourceEncoding": "ISO-8859-1",
 							"paths": {
 								"src": "src",
 								"test": "test"
@@ -1474,6 +1506,7 @@ const expectedTreeApplicationCycleA = {
 			"_level": 1,
 			"resources": {
 				"configuration": {
+					"propertiesFileSourceEncoding": "ISO-8859-1",
 					"paths": {
 						"src": "src",
 						"test": "test"
@@ -1490,6 +1523,7 @@ const expectedTreeApplicationCycleA = {
 	"kind": "project",
 	"resources": {
 		"configuration": {
+			"propertiesFileSourceEncoding": "ISO-8859-1",
 			"paths": {
 				"webapp": "webapp"
 			}


### PR DESCRIPTION
Changelog of this version: SAP/ui5-builder:CHANGELOG.md@v1.4.0