### PR TITLE
[INTERNAL] projectPreprocessor: Make sure project dependencies exists

### DIFF
--- a/lib/projectPreprocessor.js
+++ b/lib/projectPreprocessor.js
@@ -64,8 +64,7 @@ class ProjectPreprocessor {
 				if (project.dependencies && project.dependencies.length) {
 					// Do a dependency lookahead to apply any extensions that might affect this project
 					await this.dependencyLookahead(project, project.dependencies);
-				}
-				else {
+				} else {
 					// When using the static translator for instance dependencies is not defined and will fail later access calls to it
 					project.dependencies = [];
 				}

--- a/lib/projectPreprocessor.js
+++ b/lib/projectPreprocessor.js
@@ -65,6 +65,10 @@ class ProjectPreprocessor {
 					// Do a dependency lookahead to apply any extensions that might affect this project
 					await this.dependencyLookahead(project, project.dependencies);
 				}
+				else {
+					// When using the static translator for instance dependencies is not defined and will fail later access calls to it
+					project.dependencies = [];
+				}
 
 				const {extensions} = await this.loadProjectConfiguration(project);
 				if (extensions && extensions.length) {


### PR DESCRIPTION
When using the static translator, the dependencies are not filled, however the applyShims method (amongst other), directly try to iterate over it.
So in case dependencies does not exist we create it with an empty array

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
