### PR TITLE
[INTERNAL] Resolve middleware path

### DIFF
--- a/lib/projectPreprocessor.js
+++ b/lib/projectPreprocessor.js
@@ -496,7 +496,7 @@ class ProjectPreprocessor {
 		}
 		const taskRepository = require("@ui5/builder").tasks.taskRepository;
 
-		const taskPath = path.join(extension.path, extension.task.path);
+		const taskPath = path.resolve(extension.path, extension.task.path);
 		const task = require(taskPath); // throws if not found
 
 		taskRepository.addTask(extension.metadata.name, task);
@@ -511,7 +511,7 @@ class ProjectPreprocessor {
 		}
 		const {middlewareRepository} = require("@ui5/server");
 
-		const middlewarePath = path.join(extension.path, extension.middleware.path);
+		const middlewarePath = path.resolve(extension.path, extension.middleware.path);
 		middlewareRepository.addMiddleware(extension.metadata.name, middlewarePath);
 	}
 }


### PR DESCRIPTION
Using path.join will make local middleware resolution fail (at least for the static translator), as the join drops the "./" so "./lib/myTask.js" becomes "/lib/myTask.js" which will not be resolved.

@matz3 @RandomByte please have a look :)

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
