### PR TITLE
[INTERNAL] Static translator: Ensure that all project paths are absolute

### DIFF
--- a/lib/translators/static.js
+++ b/lib/translators/static.js
@@ -1,6 +1,16 @@
 const path = require("path");
 const fs = require("graceful-fs");
+const {promisify} = require("util");
+const readFile = promisify(fs.readFile);
 const parseYaml = require("js-yaml").safeLoad;
+
+function resolveProjectPaths(project) {
+	project.path = path.resolve(project.path);
+	if (project.dependencies) {
+		project.dependencies.forEach(resolveProjectPaths);
+	}
+	return project;
+}
 
 /**
  * Translator for static resources
@@ -21,22 +31,22 @@ module.exports = {
 	 * @param {Array} [options.parameters] CLI configuration options
 	 * @returns {Promise} Promise resolving with a dependency tree
 	 */
-	generateDependencyTree(dirPath, options = {}) {
+	async generateDependencyTree(dirPath, options = {}) {
 		const depFilePath = options.parameters && options.parameters[0] ||
 								path.join(dirPath, "projectDependencies.yaml");
-
-		return new Promise(function(resolve, reject) {
-			fs.readFile(depFilePath, function(err, buffer) {
-				if (err) {
-					reject(new Error(
-						`[static translator] Failed to locate projectDependencies.json at path: "${dirPath}" `+
-						`- Error: ${err.message}`));
-				} else {
-					resolve(parseYaml(buffer.toString(), {
-						filename: depFilePath
-					}));
-				}
+		try {
+			const buffer = await readFile(depFilePath);
+			const tree = parseYaml(buffer.toString(), {
+				filename: depFilePath
 			});
-		});
+
+			// Ensure that all project paths are absolute
+			resolveProjectPaths(tree);
+			return tree;
+		} catch (err) {
+			throw new Error(
+				`[static translator] Failed to load dependency tree from path ${depFilePath} `+
+				`- Error: ${err.message}`);
+		}
 	}
 };

--- a/test/lib/translators/static.js
+++ b/test/lib/translators/static.js
@@ -18,9 +18,13 @@ test("Error: Throws if projectDependencies.yaml was not found", async (t) => {
 	const fsStub = sinon.stub(fs, "readFile");
 	fsStub.callsArgWith(1, fsError);
 	const error = await t.throwsAsync(staticTranslator.generateDependencyTree(projectPath));
+	const escapedYamlPath = path.join(projectPath, "projectDependencies.yaml")
+		.replace("\\", "\\\\")
+		.replace("/", "\\/")
+		.replace(".", "\\.");
 	t.regex(error.message,
-		new RegExp("\\[static translator\\] Failed to load dependency tree from path " +
-			"notExistingPath\\/projectDependencies\\.yaml - Error: ENOENT:"));
+		new RegExp(`\\[static translator\\] Failed to load dependency tree from path ` +
+			`${escapedYamlPath} - Error: ENOENT:`));
 	fsStub.restore();
 });
 

--- a/test/lib/translators/static.js
+++ b/test/lib/translators/static.js
@@ -12,14 +12,15 @@ test("Generates dependency tree for project with projectDependencies.yaml", (t) 
 		});
 });
 
-
 test("Error: Throws if projectDependencies.yaml was not found", async (t) => {
 	const projectPath = "notExistingPath";
 	const fsError = new Error("File not found");
 	const fsStub = sinon.stub(fs, "readFile");
 	fsStub.callsArgWith(1, fsError);
 	const error = await t.throwsAsync(staticTranslator.generateDependencyTree(projectPath));
-	t.is(error.message, `[static translator] Failed to locate projectDependencies.json at path: "${projectPath}" - Error: ${fsError.message}`);
+	t.regex(error.message,
+		new RegExp("\\[static translator\\] Failed to load dependency tree from path " +
+			"notExistingPath\\/projectDependencies\\.yaml - Error: ENOENT:"));
 	fsStub.restore();
 });
 
@@ -28,17 +29,17 @@ const expectedTree = {
 	version: "0.0.1",
 	description: "Sample App",
 	main: "index.html",
-	path: "./",
+	path: path.resolve("./"),
 	dependencies: [
 		{
 			id: "sap.f",
 			version: "1.56.1",
-			path: "../sap.f"
+			path: path.resolve("../sap.f")
 		},
 		{
 			id: "sap.m",
 			version: "1.61.0",
-			path: "../sap.m"
+			path: path.resolve("../sap.m")
 		}
 	]
 };


### PR DESCRIPTION
Some of our code relies on project paths being absolute (see https://github.com/SAP/ui5-project/pull/236).
Therefore ensure that they are always absolute.