### PR TITLE
[FEATURE] Add specification version 1.1

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,2 +1,4 @@
 # Configuration
-This documentation moved to a new place: [sap.github.io/ui5-tooling/pages/Configuration/](https://sap.github.io/ui5-tooling/pages/Configuration/)
+This documentation moved to a new place: [sap.github.io/ui5-tooling/pages/Configuration/](https://sap.github.io/ui5-tooling/pages/Configuration/).
+
+The **Specification Version Documentation** can be found here: [sap.github.io/ui5-tooling/pages/Configuration/#specification-versions](https://sap.github.io/ui5-tooling/pages/Configuration/#specification-versions)

--- a/lib/projectPreprocessor.js
+++ b/lib/projectPreprocessor.js
@@ -272,11 +272,11 @@ class ProjectPreprocessor {
 			return false; // ignore this project
 		}
 
-		if (project.specVersion !== "0.1" && project.specVersion !== "1.0") {
+		if (project.specVersion !== "0.1" && project.specVersion !== "1.0" && project.specVersion !== "1.1") {
 			throw new Error(
 				`Unsupported specification version ${project.specVersion} defined for project ` +
-				`${project.id}. ` +
-				`See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions`);
+				`${project.id}. Your UI5 CLI installation might be outdated. ` +
+				`For details see https://sap.github.io/ui5-tooling/pages/Configuration/#specification-versions`);
 		}
 
 		if (!project.type) {
@@ -330,11 +330,13 @@ class ProjectPreprocessor {
 
 		if (!extension.specVersion) {
 			throw new Error(`No specification version defined for extension ${extension.metadata.name}`);
-		} else if (extension.specVersion !== "0.1" && extension.specVersion !== "1.0") {
+		} else if (extension.specVersion !== "0.1" &&
+				extension.specVersion !== "1.0" &&
+				extension.specVersion !== "1.1") {
 			throw new Error(
 				`Unsupported specification version ${extension.specVersion} defined for extension ` +
-				`${extension.metadata.name}. ` +
-				`See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions`);
+				`${extension.metadata.name}. Your UI5 CLI installation might be outdated. ` +
+				`For details see https://sap.github.io/ui5-tooling/pages/Configuration/#specification-versions`);
 		} else if (this.appliedExtensions[extension.metadata.name]) {
 			log.verbose(`Extension with the name ${extension.metadata.name} has already been applied. ` +
 				"This might have been done during dependency lookahead.");

--- a/test/lib/extensions.js
+++ b/test/lib/extensions.js
@@ -696,7 +696,8 @@ test("specVersion: Extension with invalid version", async (t) => {
 	const preprocessor = new Preprocessor();
 	await t.throwsAsync(preprocessor.applyExtension(extension),
 		"Unsupported specification version 0.9 defined for extension shims.a. " +
-		"See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions",
+		"Your UI5 CLI installation might be outdated. For details see " +
+		"https://sap.github.io/ui5-tooling/pages/Configuration/#specification-versions",
 		"Rejected with error");
 });
 
@@ -738,4 +739,24 @@ test("specVersion: Extension with valid version 1.0", async (t) => {
 	const handleShimStub = sinon.stub(preprocessor, "handleShim");
 	await preprocessor.applyExtension(extension);
 	t.deepEqual(handleShimStub.getCall(0).args[0].specVersion, "1.0", "Correct spec version");
+});
+
+test("specVersion: Extension with valid version 1.1", async (t) => {
+	const extension = {
+		id: "extension.a",
+		path: applicationAPath,
+		dependencies: [],
+		version: "1.0.0",
+		specVersion: "1.1",
+		kind: "extension",
+		type: "project-shim",
+		metadata: {
+			name: "shims.a"
+		},
+		shims: {}
+	};
+	const preprocessor = new Preprocessor();
+	const handleShimStub = sinon.stub(preprocessor, "handleShim");
+	await preprocessor.applyExtension(extension);
+	t.deepEqual(handleShimStub.getCall(0).args[0].specVersion, "1.1", "Correct spec version");
 });

--- a/test/lib/projectPreprocessor.js
+++ b/test/lib/projectPreprocessor.js
@@ -1597,7 +1597,8 @@ test("specVersion: Project with invalid version", async (t) => {
 	};
 	await t.throwsAsync(projectPreprocessor.processTree(tree),
 		"Unsupported specification version 0.9 defined for project application.a. " +
-		"See https://github.com/SAP/ui5-project/blob/master/docs/Configuration.md#specification-versions",
+		"Your UI5 CLI installation might be outdated. For details see " +
+		"https://sap.github.io/ui5-tooling/pages/Configuration/#specification-versions",
 		"Rejected with error");
 });
 
@@ -1631,6 +1632,22 @@ test("specVersion: Project with valid version 1.0", async (t) => {
 	};
 	const res = await projectPreprocessor.processTree(tree);
 	t.deepEqual(res.specVersion, "1.0", "Correct spec version");
+});
+
+test("specVersion: Project with valid version 1.1", async (t) => {
+	const tree = {
+		id: "application.a",
+		path: applicationAPath,
+		dependencies: [],
+		version: "1.0.0",
+		specVersion: "1.1",
+		type: "application",
+		metadata: {
+			name: "xy"
+		}
+	};
+	const res = await projectPreprocessor.processTree(tree);
+	t.deepEqual(res.specVersion, "1.1", "Correct spec version");
 });
 
 test("isBeingProcessed: Is not being processed", (t) => {


### PR DESCRIPTION
The new 'theme-library' type requires spec version 1.1:
https://github.com/SAP/ui5-builder/pull/285

Also change wording of the error message for unsupported spec versions
and fix the referenced URL. This should make it clear that the used
version of the UI5 CLI might be outdated.