### PR TITLE
[INTERNAL] Add specification version 2.0a

### DIFF
--- a/lib/projectPreprocessor.js
+++ b/lib/projectPreprocessor.js
@@ -272,7 +272,8 @@ class ProjectPreprocessor {
 			return false; // ignore this project
 		}
 
-		if (project.specVersion !== "0.1" && project.specVersion !== "1.0" && project.specVersion !== "1.1") {
+		if (project.specVersion !== "0.1" && project.specVersion !== "1.0" && project.specVersion !== "1.1" &&
+				project.specVersion !== "2.0a") {
 			throw new Error(
 				`Unsupported specification version ${project.specVersion} defined for project ` +
 				`${project.id}. Your UI5 CLI installation might be outdated. ` +
@@ -306,6 +307,31 @@ class ProjectPreprocessor {
 					"Only one project of type application can be used. Failed to decide which one to ignore.");
 			} else {
 				return false; // ignore this project
+			}
+		}
+
+		if (project._level === 0) {
+			// Additional checks for the current root project
+			switch (project.specVersion) {
+			case "0.1":
+			case "1.0":
+			case "1.1":
+				if (project.framework) {
+					log.warn(`Project ${project.id} defines a "framework" configuration. ` +
+						`This feature is only supported by Specification Version 2.0 and above. ` +
+						`Please make sure that you are using the latest UI5 CLI and configure your project ` +
+						`to use specVersion: '2.0'.\n` +
+						`For details see ` +
+						`https://sap.github.io/ui5-tooling/pages/Configuration/#specification-versions`);
+				}
+				break;
+			case "2.0a":
+				log.warn(`Project ${project.id} is using an alpha version of Specification Version 2.0. ` +
+					`Some features might not be supported yet. ` +
+					`Please make sure that you are using the latest UI5 CLI.\n` +
+					`For details see ` +
+					`https://sap.github.io/ui5-tooling/pages/Configuration/#specification-versions`);
+				break;
 			}
 		}
 

--- a/test/lib/projectPreprocessor.js
+++ b/test/lib/projectPreprocessor.js
@@ -1650,6 +1650,22 @@ test("specVersion: Project with valid version 1.1", async (t) => {
 	t.deepEqual(res.specVersion, "1.1", "Correct spec version");
 });
 
+test("specVersion: Project with valid version 2.0a", async (t) => {
+	const tree = {
+		id: "application.a",
+		path: applicationAPath,
+		dependencies: [],
+		version: "1.0.0",
+		specVersion: "2.0a",
+		type: "application",
+		metadata: {
+			name: "xy"
+		}
+	};
+	const res = await projectPreprocessor.processTree(tree);
+	t.deepEqual(res.specVersion, "2.0a", "Correct spec version");
+});
+
 test("isBeingProcessed: Is not being processed", (t) => {
 	const preprocessor = new projectPreprocessor.ProjectPreprocessor();
 


### PR DESCRIPTION
Does not add any features but allows projects to already define a
"framework" configuration for use with UI5 CLI 2.0 while staying
compatible with Specification Version 1.1 and already available
UI5 CLI versions.