### PR TITLE
[INTERNAL] ui5Framework/projectPreprocessor: Do not process root project again

### DIFF
--- a/lib/projectPreprocessor.js
+++ b/lib/projectPreprocessor.js
@@ -82,8 +82,12 @@ class ProjectPreprocessor {
 				}
 				this.applyShims(project);
 				if (this.isConfigValid(project)) {
-					await this.applyType(project);
-					this.checkProjectMetadata(parent, project);
+					// Do not apply transparent projects.
+					// Their only purpose might be to have their dependencies processed
+					if (!project._transparentProject) {
+						await this.applyType(project);
+						this.checkProjectMetadata(parent, project);
+					}
 					queue.push({
 						// copy array, so that the queue is stable while ignored project dependencies are removed
 						projects: [...project.dependencies],

--- a/lib/translators/ui5Framework.js
+++ b/lib/translators/ui5Framework.js
@@ -170,12 +170,19 @@ module.exports = {
 		});
 
 		// Use root project (=requesting project) as root of framework tree
-		const frameworkTree = {
-			id: tree.id,
-			version: tree.version,
-			path: tree.path,
-			dependencies: libraries
-		};
+		// For this we clone all properties of the root project,
+		// except the dependencies since they will be overwritten anyways
+		const frameworkTree = {};
+		for (const attribute in tree) {
+			if (tree.hasOwnProperty(attribute) && attribute !== "dependencies") {
+				frameworkTree[attribute] = JSON.parse(JSON.stringify(tree[attribute]));
+			}
+		}
+
+		// Overwrite dependencies to exclusively contain framework libraries
+		frameworkTree.dependencies = libraries;
+		// Flag as transparent so that the project type is not applied again
+		frameworkTree._transparentProject = true;
 		return frameworkTree;
 	},
 

--- a/test/lib/translators/ui5Framework.integration.js
+++ b/test/lib/translators/ui5Framework.integration.js
@@ -671,9 +671,14 @@ test.serial("ui5Framework translator should not try to install anything when no 
 			version: "1.75.0"
 		}
 	});
+	const frameworkTree = Object.assign({}, projectPreprocessorTree, {
+		_transparentProject: true
+	});
 
 	sinon.stub(normalizer, "generateDependencyTree").resolves(translatorTree);
-	sinon.stub(projectPreprocessor, "processTree").withArgs(translatorTree).resolves(projectPreprocessorTree);
+	sinon.stub(projectPreprocessor, "processTree")
+		.withArgs(translatorTree).resolves(projectPreprocessorTree)
+		.withArgs(frameworkTree).resolves(frameworkTree);
 
 	const extractStub = sinon.stub(pacote, "extract");
 	const manifestStub = sinon.stub(pacote, "manifest");

--- a/test/lib/translators/ui5Framework.js
+++ b/test/lib/translators/ui5Framework.js
@@ -29,6 +29,7 @@ test.afterEach.always((t) => {
 
 test.serial("generateDependencyTree", async (t) => {
 	const tree = {
+		specVersion: "2.0",
 		id: "test1",
 		version: "1.0.0",
 		path: "/test-project/",
@@ -84,14 +85,20 @@ test.serial("generateDependencyTree", async (t) => {
 		"Sapui5Resolver#getProject should be called with expected args (call 3)");
 
 	t.deepEqual(ui5FrameworkTree, {
+		specVersion: "2.0", // specVersion must not be lost to prevent config re-loading in projectPreprocessor
 		id: "test1",
 		version: "1.0.0",
 		path: "/test-project/",
+		framework: {
+			name: "SAPUI5",
+			version: "1.75.0"
+		},
 		dependencies: [
 			{fake: "metadata-project-1"},
 			{fake: "metadata-project-2"},
 			{fake: "metadata-project-3"}
-		]
+		],
+		_transparentProject: true
 	});
 });
 


### PR DESCRIPTION
Since the root project of a framework tree has already been processed,
do not apply its type and additional checks again. This is to prevent
duplicate logging of infos and warnings and to reduce the overhead of
formatting the project again.