### PR TITLE
[INTERNAL] projectPreprocessor tests: Adopt to required namespaces

### DIFF
--- a/test/fixtures/application.a/webapp/manifest.json
+++ b/test/fixtures/application.a/webapp/manifest.json
@@ -1,0 +1,13 @@
+{
+    "_version": "1.1.0",
+    "sap.app": {
+        "_version": "1.1.0",
+        "id": "id1",
+        "type": "application",
+        "applicationVersion": {
+            "version": "1.2.2"
+        },
+        "embeds": ["embedded"],
+        "title": "{{title}}"
+    }
+}

--- a/test/fixtures/cyclic-deps/node_modules/application.cycle.a/webapp/manifest.json
+++ b/test/fixtures/cyclic-deps/node_modules/application.cycle.a/webapp/manifest.json
@@ -1,0 +1,13 @@
+{
+    "_version": "1.1.0",
+    "sap.app": {
+        "_version": "1.1.0",
+        "id": "id1",
+        "type": "application",
+        "applicationVersion": {
+            "version": "1.2.2"
+        },
+        "embeds": ["embedded"],
+        "title": "{{title}}"
+    }
+}

--- a/test/fixtures/cyclic-deps/node_modules/library.cycle.a/src/cycle/a/.library
+++ b/test/fixtures/cyclic-deps/node_modules/library.cycle.a/src/cycle/a/.library
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <library xmlns="http://www.sap.com/sap.ui.library.xsd" >
 
-	<name>library.cycle.a</name>
+	<name>cycle.a</name>
 	<vendor>SAP SE</vendor>
 	<copyright>${copyright}</copyright>
 	<version>${version}</version>

--- a/test/fixtures/cyclic-deps/node_modules/library.cycle.b/src/cycle/b/.library
+++ b/test/fixtures/cyclic-deps/node_modules/library.cycle.b/src/cycle/b/.library
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <library xmlns="http://www.sap.com/sap.ui.library.xsd" >
 
-	<name>library.cycle.b</name>
+	<name>cycle.b</name>
 	<vendor>SAP SE</vendor>
 	<copyright>${copyright}</copyright>
 	<version>${version}</version>

--- a/test/lib/extensions.js
+++ b/test/lib/extensions.js
@@ -62,6 +62,7 @@ test("Project with project-shim extension with dependency configuration", (t) =>
 			type: "application",
 			metadata: {
 				name: "xy",
+				namespace: "id1"
 			},
 			resources: {
 				configuration: {
@@ -175,6 +176,7 @@ test("Project with project-shim extension with dependency declaration and config
 			type: "application",
 			metadata: {
 				name: "xy",
+				namespace: "id1"
 			},
 			resources: {
 				configuration: {
@@ -348,6 +350,7 @@ test("Project with project-shim extension with collection", (t) => {
 			type: "application",
 			metadata: {
 				name: "xy",
+				namespace: "id1"
 			},
 			resources: {
 				configuration: {

--- a/test/lib/projectPreprocessor.js
+++ b/test/lib/projectPreprocessor.js
@@ -36,6 +36,7 @@ test("Project with inline configuration", (t) => {
 			type: "application",
 			metadata: {
 				name: "xy",
+				namespace: "id1"
 			},
 			resources: {
 				configuration: {
@@ -71,7 +72,8 @@ test("Project with configPath", (t) => {
 			_level: 0,
 			type: "application",
 			metadata: {
-				name: "application.b"
+				name: "application.b",
+				namespace: "id1"
 			},
 			resources: {
 				configuration: {
@@ -107,7 +109,8 @@ test("Project with ui5.yaml at default location", (t) => {
 			_level: 0,
 			type: "application",
 			metadata: {
-				name: "application.a"
+				name: "application.a",
+				namespace: "id1"
 			},
 			resources: {
 				configuration: {
@@ -194,7 +197,8 @@ test("No type configured for root project", (t) => {
 		path: path.join(__dirname, "../fixtures/application.a"),
 		dependencies: [],
 		metadata: {
-			name: "application.a"
+			name: "application.a",
+			namespace: "id1"
 		}
 	};
 	return t.throwsAsync(projectPreprocessor.processTree(tree),
@@ -328,7 +332,8 @@ test("Ignores additional application-projects", (t) => {
 			_level: 0,
 			type: "application",
 			metadata: {
-				name: "application.a"
+				name: "application.a",
+				namespace: "id1"
 			},
 			resources: {
 				configuration: {
@@ -418,7 +423,8 @@ test("Inconsistent dependencies with same ID", (t) => {
 			_level: 0,
 			type: "application",
 			metadata: {
-				name: "application.a"
+				name: "application.a",
+				namespace: "id1"
 			},
 			resources: {
 				configuration: {
@@ -689,7 +695,8 @@ const expectedTreeWithInvalidModules = {
 	"specVersion": "1.0",
 	"type": "application",
 	"metadata": {
-		"name": "application.a"
+		"name": "application.a",
+		"namespace": "id1"
 	},
 	"_level": 0,
 	"kind": "project",
@@ -831,6 +838,7 @@ const expectedTreeAWithInlineConfigs = {
 	"type": "application",
 	"metadata": {
 		"name": "application.a",
+		"namespace": "id1"
 	},
 	"resources": {
 		"configuration": {
@@ -945,6 +953,7 @@ const expectedTreeAWithConfigPaths = {
 	"type": "application",
 	"metadata": {
 		"name": "application.a",
+		"namespace": "id1"
 	},
 	"resources": {
 		"configuration": {
@@ -1402,6 +1411,7 @@ const expectedTreeApplicationCycleA = {
 	"type": "application",
 	"metadata": {
 		"name": "application.cycle.a",
+		"namespace": "id1"
 	},
 	"dependencies": [
 		{
@@ -1424,6 +1434,7 @@ const expectedTreeApplicationCycleA = {
 					"type": "library",
 					"metadata": {
 						"name": "library.cycle.a",
+						"namespace": "cycle/a",
 						"copyright": "${copyright}"
 					},
 					"dependencies": [
@@ -1464,6 +1475,7 @@ const expectedTreeApplicationCycleA = {
 					"type": "library",
 					"metadata": {
 						"name": "library.cycle.b",
+						"namespace": "cycle/b",
 						"copyright": "${copyright}"
 					},
 					"dependencies": [


### PR DESCRIPTION
Tests are failing due to https://github.com/SAP/ui5-builder/pull/430

Adopt tests to provide necessary manifest.json files and expect the
corresponding namespace information.