### PR TITLE
[INTERNAL] ui5Framework: Don't log info when no libs are found

### DIFF
--- a/lib/translators/ui5Framework.js
+++ b/lib/translators/ui5Framework.js
@@ -151,13 +151,13 @@ module.exports = {
 			version = tree.framework.version;
 		}
 
-		log.info(`Using ${frameworkName} version: ${version}`);
-
 		const referencedLibraries = utils.getFrameworkLibrariesFromTree(tree);
 		if (!referencedLibraries.length) {
 			log.verbose(`No ${frameworkName} libraries referenced in project ${tree.id} or its dependencies`);
 			return null;
 		}
+
+		log.info(`Using ${frameworkName} version: ${version}`);
 
 		let resolver;
 		if (frameworkName === "OpenUI5") {


### PR DESCRIPTION
This might especially happen when the root project does not use
specVersion 2.0 and defines framework libraries.
The info log might then be confusing.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
