### PR TITLE
[FIX] ui5Framework.mergeTrees: Do not process the same project multiple times

### DIFF
--- a/lib/translators/npm.js
+++ b/lib/translators/npm.js
@@ -429,7 +429,7 @@ class NpmTranslator {
 			for (let i = 0; i < tree.length; i++) {
 				const rootPackage = tree[i];
 				if (path.resolve(rootPackage.path) === path.resolve(dirPath)) {
-					log.verbose("Built tree:");
+					log.verbose("Treetop:");
 					log.verbose(rootPackage);
 					return rootPackage;
 				}

--- a/lib/translators/ui5Framework.js
+++ b/lib/translators/ui5Framework.js
@@ -212,8 +212,18 @@ module.exports = {
 		log.verbose(`Merging framework tree into project tree "${projectTree.metadata.name}"`);
 
 		const queue = [projectTree];
+		const processedProjects = [];
 		while (queue.length) {
 			const project = queue.shift();
+			if (processedProjects.includes(project.id)) {
+				// projectTree must be duplicate free. A second occurrence of the same project
+				//	is always the same object. Therefore a single processing needs to be ensured.
+				// Otherwise the isFrameworkProject check would detect framework dependencies added
+				//	at an earlier processing of the project and yield incorrect logging.
+				log.verbose(`Project ${project.metadata.name} (${project.id}) has already been processed`);
+				return;
+			}
+			processedProjects.push(project.id);
 
 			project.dependencies = project.dependencies.filter((depProject) => {
 				if (utils.isFrameworkProject(depProject)) {


### PR DESCRIPTION
Since projects are deduped by the projectPreprocessor, repeated
processing of a project that appears multiple times in the project tree
is done on the same object. This leads to issues like the
isFrameworkProject detecting previously added framework libraries as ...
"already added UI5 framework libraries", thus producing incorrect log
messages

The eventual result in projects where a reuse library defining UI5 dependencies has multiple occurrences in the tree is excessive logging like this:
```sh
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.f, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.m, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.core, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.layout, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @sapui5/sap.viz, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.f, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.m, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.core, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.layout, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @sapui5/sap.viz, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.superlib contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.f, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.superlib contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.m, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.superlib contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.core, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.superlib contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.layout, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.superlib contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.unified, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.superlib contains a package.json in which it defines a dependency to the UI5 framework library @sapui5/sap.viz, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.superlib contains a package.json in which it defines a dependency to the UI5 framework library @openui5/themelib_sap_fiori_3, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.f, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.m, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.core, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.layout, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @sapui5/sap.viz, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.f, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.m, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.core, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @openui5/sap.ui.layout, this dependency should be removed.
info normalizer:translators:ui5Framework If project my.pony.collection contains a package.json in which it defines a dependency to the UI5 framework library @sapui5/sap.viz, this dependency should be removed.
```