### PR TITLE
[FIX] Allow the use of specVersion 2.1 for projects

### DIFF
--- a/lib/projectPreprocessor.js
+++ b/lib/projectPreprocessor.js
@@ -277,7 +277,8 @@ class ProjectPreprocessor {
 		}
 
 		if (project.specVersion !== "0.1" && project.specVersion !== "1.0" &&
-			project.specVersion !== "1.1" && project.specVersion !== "2.0") {
+			project.specVersion !== "1.1" && project.specVersion !== "2.0" &&
+			project.specVersion !== "2.1") {
 			throw new Error(
 				`Unsupported specification version ${project.specVersion} defined for project ` +
 				`${project.id}. Your UI5 CLI installation might be outdated. ` +

--- a/test/lib/projectPreprocessor.js
+++ b/test/lib/projectPreprocessor.js
@@ -1702,6 +1702,22 @@ test("specVersion: Project with valid version 2.0", async (t) => {
 	t.deepEqual(res.specVersion, "2.0", "Correct spec version");
 });
 
+test("specVersion: Project with valid version 2.1", async (t) => {
+	const tree = {
+		id: "application.a",
+		path: applicationAPath,
+		dependencies: [],
+		version: "1.0.0",
+		specVersion: "2.1",
+		type: "application",
+		metadata: {
+			name: "xy"
+		}
+	};
+	const res = await projectPreprocessor.processTree(tree);
+	t.deepEqual(res.specVersion, "2.1", "Correct spec version");
+});
+
 test("isBeingProcessed: Is not being processed", (t) => {
 	const preprocessor = new projectPreprocessor._ProjectPreprocessor({});
 


### PR DESCRIPTION
https://github.com/SAP/ui5-project/pull/308 only allowed the use of the
new spec version for extensions.