### PR TITLE
[FIX] ui5Framework.Installer: Detect and resolve incomplete installs

### DIFF
--- a/lib/ui5Framework/npm/Installer.js
+++ b/lib/ui5Framework/npm/Installer.js
@@ -3,6 +3,9 @@ const fs = require("graceful-fs");
 const {promisify} = require("util");
 const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
+const open = promisify(fs.open);
+const close = promisify(fs.close);
+const unlink = promisify(fs.unlink);
 const lockfile = require("lockfile");
 const lock = promisify(lockfile.lock);
 const unlock = promisify(lockfile.unlock);
@@ -25,6 +28,7 @@ class Installer {
 			cacheDir: path.join(ui5HomeDir, "framework", "cacache")
 		});
 		this._lockDir = path.join(ui5HomeDir, "framework", "locks");
+		this._installProgressDir = path.join(ui5HomeDir, "framework", "install-progress");
 	}
 
 	async readJson(jsonPath) {
@@ -61,15 +65,36 @@ class Installer {
 
 	async installPackage({pkgName, version}) {
 		const targetDir = this._getTargetDirForPackage({pkgName, version});
-		const installed = await this._packageJsonExists(targetDir);
-		if (!installed) {
+		const [installed, installInProgress] = await Promise.all([
+			this._packageJsonExists(targetDir),
+			this._isInstallInProgress({pkgName, version})
+		]);
+		if (!installed || installInProgress) {
+			// Package is either not installed or installation is still in progress
 			await this._synchronize({pkgName, version}, async () => {
+				const installInProgress = await this._isInstallInProgress({pkgName, version});
+				if (installInProgress) {
+					// Package install is marked as "in progress" but no lock is set
+					// This might indicate an incomplete or corrupted install
+					// => Remove the directory and reinstall
+
+					log.verbose(
+						`Detected a potentially incomplete installation of package ${pkgName} in version ${version}. ` +
+						`Attempting to remove and reinstall it...`);
+					const rimraf = promisify(require("rimraf"));
+					log.verbose(
+						`Removing package ${pkgName} in version ${version} at ${targetDir}...`);
+					await rimraf(targetDir);
+				}
+
 				// check again whether package is now installed
 				const installed = await this._packageJsonExists(targetDir);
 				if (!installed) {
 					log.info(`Installing missing package ${pkgName}...`);
-					log.verbose(`Installing ${pkgName} in version ${version} to ${targetDir}...`);
-					await this._registry.extractPackage(pkgName, version, targetDir);
+					await this._markInstallInProgress({pkgName, version}, async () => {
+						log.verbose(`Installing ${pkgName} in version ${version} to ${targetDir}...`);
+						await this._registry.extractPackage(pkgName, version, targetDir);
+					});
 				} else {
 					log.verbose(`Alrady installed: ${pkgName} in version ${version}`);
 				}
@@ -115,6 +140,46 @@ class Installer {
 	_getLockPath({pkgName, version}) {
 		const lockName = pkgName.replace(/\//g, "-");
 		return path.join(this._lockDir, `package-${lockName}@${version}.lock`);
+	}
+
+
+	async _markInstallInProgress({pkgName, version}, callback) {
+		const markerPath = this._getInstallProgressMarkerPath({pkgName, version});
+		await mkdirp(this._installProgressDir);
+
+		log.verbose(`Creating install-in-progress marker at ${markerPath}...`);
+		const fd = await open(markerPath, "w");
+		await close(fd);
+
+		try {
+			await callback();
+		} catch (err) {
+			log.verbose(
+				`Installation of package ${pkgName}@${version} failed. ` +
+				`install-in-progress marker will not be removed.`);
+			throw err;
+		}
+		log.verbose(`Removing install-in-progress marker at ${markerPath}...`);
+		await unlink(markerPath);
+	}
+
+	async _isInstallInProgress({pkgName, version}) {
+		try {
+			const markerPath = this._getInstallProgressMarkerPath({pkgName, version});
+			await stat(markerPath);
+			return true;
+		} catch (err) {
+			if (err.code === "ENOENT") { // "File or directory does not exist"
+				return false;
+			} else {
+				throw err;
+			}
+		}
+	}
+
+	_getInstallProgressMarkerPath({pkgName, version}) {
+		const name = pkgName.replace(/\//g, "-");
+		return path.join(this._installProgressDir, `package-${name}@${version}.install-in-progress`);
 	}
 
 	_getTargetDirForPackage({pkgName, version}) {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
 		"read-pkg": "^5.2.0",
 		"read-pkg-up": "^7.0.1",
 		"resolve": "^1.19.0",
+		"rimraf": "^3.0.2",
 		"semver": "^7.3.4"
 	},
 	"devDependencies": {
@@ -138,7 +139,6 @@
 		"mock-require": "^3.0.3",
 		"nyc": "^15.1.0",
 		"open-cli": "^6.0.1",
-		"rimraf": "^3.0.2",
 		"sinon": "^9.2.3",
 		"tap-nyan": "^1.1.0",
 		"tap-xunit": "^2.4.1"


### PR DESCRIPTION
At the beginning of every install, create a marker file unique for that
package and version. If subsequent ui5Framework translator executions
detect such a marker for a package *and* can aquire a lock for it, this
might indicate an aborted or failed install of that package.

In that case, remove the package (if present) and continue with the
normal install process.

Resolves https://github.com/SAP/ui5-tooling/issues/478