### PR TITLE
[FIX] ui5Framework.Installer: Ensure atomic install process

### DIFF
--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -83,6 +83,9 @@ class AbstractResolver {
 			try {
 				await this._processLibrary(libraryName, libraryMetadata, errors);
 			} catch (err) {
+				log.verbose(`Failed to process library ${libraryName}`);
+				log.verbose(`Error: ${err.message}`);
+				log.verbose(`Call stack: ${err.stack}`);
 				return `Failed to resolve library ${libraryName}: ${err.message}`;
 			}
 		}));

--- a/lib/ui5Framework/npm/Installer.js
+++ b/lib/ui5Framework/npm/Installer.js
@@ -3,6 +3,7 @@ const fs = require("graceful-fs");
 const {promisify} = require("util");
 const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
+const rename = promisify(fs.rename);
 const lockfile = require("lockfile");
 const lock = promisify(lockfile.lock);
 const unlock = promisify(lockfile.unlock);
@@ -18,13 +19,14 @@ class Installer {
 		if (!ui5HomeDir) {
 			throw new Error(`Installer: Missing parameter "ui5HomeDir"`);
 		}
-		this._baseDir = path.join(ui5HomeDir, "framework", "packages");
-		log.verbose(`Installing to: ${this._baseDir}`);
+		this._packagesDir = path.join(ui5HomeDir, "framework", "packages");
+		log.verbose(`Installing to: ${this._packagesDir}`);
 		this._registry = new Registry({
 			cwd,
 			cacheDir: path.join(ui5HomeDir, "framework", "cacache")
 		});
 		this._lockDir = path.join(ui5HomeDir, "framework", "locks");
+		this._stagingDir = path.join(ui5HomeDir, "framework", "staging");
 	}
 
 	async readJson(jsonPath) {
@@ -67,9 +69,21 @@ class Installer {
 				// check again whether package is now installed
 				const installed = await this._packageJsonExists(targetDir);
 				if (!installed) {
+					const stagingDir = this._getStagingDirForPackage({pkgName, version});
 					log.info(`Installing missing package ${pkgName}...`);
-					log.verbose(`Installing ${pkgName} in version ${version} to ${targetDir}...`);
-					await this._registry.extractPackage(pkgName, version, targetDir);
+
+					// Check whether staging dir already exists and remove it
+					if (await this._pathExists(stagingDir)) {
+						const rimraf = promisify(require("rimraf"));
+						log.verbose(`Removing existing staging directory at ${stagingDir}...`);
+						await rimraf(stagingDir);
+					}
+
+					log.verbose(`Installing ${pkgName} in version ${version} to ${stagingDir}...`);
+					await this._registry.extractPackage(pkgName, version, stagingDir);
+					await mkdirp(targetDir);
+					log.verbose(`Promoting staging directory from ${stagingDir} to ${targetDir}...`);
+					await rename(stagingDir, targetDir);
 				} else {
 					log.verbose(`Alrady installed: ${pkgName} in version ${version}`);
 				}
@@ -83,8 +97,12 @@ class Installer {
 	}
 
 	async _packageJsonExists(targetDir) {
+		return this._pathExists(path.join(targetDir, "package.json"));
+	}
+
+	async _pathExists(targetPath) {
 		try {
-			await stat(path.join(targetDir, "package.json"));
+			await stat(targetPath);
 			return true;
 		} catch (err) {
 			if (err.code === "ENOENT") { // "File or directory does not exist"
@@ -118,7 +136,11 @@ class Installer {
 	}
 
 	_getTargetDirForPackage({pkgName, version}) {
-		return path.join(this._baseDir, ...pkgName.split("/"), version);
+		return path.join(this._packagesDir, ...pkgName.split("/"), version);
+	}
+
+	_getStagingDirForPackage({pkgName, version}) {
+		return path.join(this._stagingDir, `${pkgName.replace("/", "-")}-${version}`);
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
 		"read-pkg": "^5.2.0",
 		"read-pkg-up": "^7.0.1",
 		"resolve": "^1.19.0",
+		"rimraf": "^3.0.2",
 		"semver": "^7.3.4"
 	},
 	"devDependencies": {
@@ -138,7 +139,6 @@
 		"mock-require": "^3.0.3",
 		"nyc": "^15.1.0",
 		"open-cli": "^6.0.1",
-		"rimraf": "^3.0.2",
 		"sinon": "^9.2.3",
 		"tap-nyan": "^1.1.0",
 		"tap-xunit": "^2.4.1"

--- a/test/lib/translators/ui5Framework.integration.js
+++ b/test/lib/translators/ui5Framework.integration.js
@@ -3,6 +3,7 @@ const sinon = require("sinon");
 const mock = require("mock-require");
 const path = require("path");
 const os = require("os");
+const fs = require("graceful-fs");
 
 const pacote = require("pacote");
 const libnpmconfig = require("libnpmconfig");
@@ -18,6 +19,10 @@ let Installer;
 const fakeBaseDir = path.join(__dirname, "fake-tmp");
 const ui5FrameworkBaseDir = path.join(fakeBaseDir, "homedir", ".ui5", "framework");
 const ui5PackagesBaseDir = path.join(ui5FrameworkBaseDir, "packages");
+
+test.before((t) => {
+	sinon.stub(fs, "rename").yieldsAsync();
+});
 
 test.beforeEach((t) => {
 	sinon.stub(libnpmconfig, "read").returns({

--- a/test/lib/ui5framework/npm/Installer.js
+++ b/test/lib/ui5framework/npm/Installer.js
@@ -2,6 +2,7 @@ const test = require("ava");
 const sinon = require("sinon");
 const mock = require("mock-require");
 const path = require("path");
+const fs = require("graceful-fs");
 
 const lockfile = require("lockfile");
 
@@ -11,8 +12,13 @@ test.beforeEach((t) => {
 	t.context.mkdirpStub = sinon.stub().resolves();
 	mock("mkdirp", t.context.mkdirpStub);
 
+	t.context.rimrafStub = sinon.stub().yieldsAsync();
+	mock("rimraf", t.context.rimrafStub);
+
 	t.context.lockStub = sinon.stub(lockfile, "lock");
 	t.context.unlockStub = sinon.stub(lockfile, "unlock");
+	t.context.renameStub = sinon.stub(fs, "rename").yieldsAsync();
+	t.context.statStub = sinon.stub(fs, "stat").callThrough();
 
 	// Re-require to ensure that mocked modules are used
 	Installer = mock.reRequire("../../../../lib/ui5Framework/npm/Installer");
@@ -29,8 +35,9 @@ test.serial("Installer: constructor", (t) => {
 		ui5HomeDir: "/ui5Home/"
 	});
 	t.true(installer instanceof Installer, "Constructor returns instance of class");
-	t.is(installer._baseDir, path.join("/ui5Home/", "framework", "packages"));
+	t.is(installer._packagesDir, path.join("/ui5Home/", "framework", "packages"));
 	t.is(installer._lockDir, path.join("/ui5Home/", "framework", "locks"));
+	t.is(installer._stagingDir, path.join("/ui5Home/", "framework", "staging"));
 });
 
 test.serial("Installer: constructor requires 'cwd'", (t) => {
@@ -249,7 +256,6 @@ test.serial("Installer: _synchronize", async (t) => {
 		ui5HomeDir: "/ui5Home/"
 	});
 
-	t.context.mkdirpStub.resolves();
 	t.context.lockStub.yieldsAsync();
 	t.context.unlockStub.yieldsAsync();
 
@@ -294,7 +300,6 @@ test.serial("Installer: _synchronize should unlock when callback promise has res
 		ui5HomeDir: "/ui5Home/"
 	});
 
-	t.context.mkdirpStub.resolves();
 	t.context.lockStub.yieldsAsync();
 	t.context.unlockStub.yieldsAsync();
 
@@ -323,7 +328,6 @@ test.serial("Installer: _synchronize should throw when locking fails", async (t)
 		ui5HomeDir: "/ui5Home/"
 	});
 
-	t.context.mkdirpStub.resolves();
 	t.context.lockStub.yieldsAsync(new Error("Locking error"));
 
 	sinon.stub(installer, "_getLockPath").returns("/locks/lockfile.lock");
@@ -347,7 +351,6 @@ test.serial("Installer: _synchronize should still unlock when callback throws an
 		ui5HomeDir: "/ui5Home/"
 	});
 
-	t.context.mkdirpStub.resolves();
 	t.context.lockStub.yieldsAsync();
 	t.context.unlockStub.yieldsAsync();
 
@@ -373,7 +376,6 @@ test.serial("Installer: _synchronize should still unlock when callback rejects w
 		ui5HomeDir: "/ui5Home/"
 	});
 
-	t.context.mkdirpStub.resolves();
 	t.context.lockStub.yieldsAsync();
 	t.context.unlockStub.yieldsAsync();
 
@@ -391,4 +393,318 @@ test.serial("Installer: _synchronize should still unlock when callback rejects w
 	t.is(callback.callCount, 1, "callback should be called once");
 	t.is(t.context.lockStub.callCount, 1, "lock should be called once");
 	t.is(t.context.unlockStub.callCount, 1, "unlock should be called once");
+});
+
+test.serial("Installer: installPackage with new package", async (t) => {
+	const installer = new Installer({
+		cwd: "/cwd/",
+		ui5HomeDir: "/ui5Home/"
+	});
+
+	t.context.lockStub.yieldsAsync();
+	t.context.unlockStub.yieldsAsync();
+
+	const getTargetDirForPackageStub = sinon.stub(installer, "_getTargetDirForPackage")
+		.returns("package-dir-path");
+
+	const packageJsonExistsStub = sinon.stub(installer, "_packageJsonExists").resolves(false);
+	const synchronizeSpy = sinon.spy(installer, "_synchronize");
+
+	const getStagingDirForPackageStub = sinon.stub(installer, "_getStagingDirForPackage")
+		.returns("staging-dir-path");
+	const pathExistsStub = sinon.stub(installer, "_pathExists").resolves(false);
+
+	const extractPackageStub = sinon.stub(installer._registry, "extractPackage").resolves();
+
+	const res = await installer.installPackage({
+		pkgName: "myPackage",
+		version: "1.2.3"
+	});
+
+	t.deepEqual(res, {
+		pkgPath: "package-dir-path"
+	}, "Should return correct values");
+
+	t.is(getTargetDirForPackageStub.callCount, 1, "_getTargetDirForPackage should be called once");
+	t.deepEqual(getTargetDirForPackageStub.getCall(0).args[0], {
+		pkgName: "myPackage",
+		version: "1.2.3"
+	}, "_getTargetDirForPackage should be called with the correct arguments");
+
+	t.is(packageJsonExistsStub.callCount, 2, "_packageJsonExists should be called twice");
+	t.is(packageJsonExistsStub.getCall(0).args[0], "package-dir-path",
+		"_packageJsonExists should be called with the correct arguments on first call");
+	t.is(packageJsonExistsStub.getCall(1).args[0], "package-dir-path",
+		"_packageJsonExists should be called with the correct arguments on second call");
+
+	t.is(synchronizeSpy.callCount, 1, "_synchronize should be called once");
+	t.deepEqual(synchronizeSpy.getCall(0).args[0], {
+		pkgName: "myPackage",
+		version: "1.2.3"
+	}, "_synchronize should be called with the correct first argument");
+	t.is(t.context.lockStub.callCount, 1, "lock should be called once");
+	t.is(t.context.unlockStub.callCount, 1, "unlock should be called once");
+
+	t.is(getStagingDirForPackageStub.callCount, 1, "_getStagingDirForPackage should be called once");
+	t.deepEqual(getStagingDirForPackageStub.getCall(0).args[0], {
+		pkgName: "myPackage",
+		version: "1.2.3"
+	}, "_getStagingDirForPackage should be called with the correct arguments");
+
+	t.is(pathExistsStub.callCount, 1, "_pathExists should be called once");
+	t.is(pathExistsStub.getCall(0).args[0], "staging-dir-path",
+		"_packageJsonExists should be called with the correct arguments");
+	t.is(t.context.rimrafStub.callCount, 0, "rimraf should never be called");
+
+	t.is(extractPackageStub.callCount, 1, "_extractPackage should be called once");
+
+	t.is(t.context.mkdirpStub.callCount, 2, "mkdirp should be called twice");
+	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
+		"mkdirp should be called with the correct arguments on first call");
+	t.is(t.context.mkdirpStub.getCall(1).args[0], "package-dir-path",
+		"mkdirp should be called with the correct arguments on second call");
+
+	t.is(t.context.renameStub.callCount, 1, "fs.rename should be called once");
+	t.is(t.context.renameStub.getCall(0).args[0], "staging-dir-path",
+		"fs.rename should be called with the correct first argument");
+	t.is(t.context.renameStub.getCall(0).args[1], "package-dir-path",
+		"fs.rename should be called with the correct second argument");
+});
+
+test.serial("Installer: installPackage with already installed package", async (t) => {
+	const installer = new Installer({
+		cwd: "/cwd/",
+		ui5HomeDir: "/ui5Home/"
+	});
+
+	t.context.lockStub.yieldsAsync();
+	t.context.unlockStub.yieldsAsync();
+
+	const getTargetDirForPackageStub = sinon.stub(installer, "_getTargetDirForPackage")
+		.returns("package-dir-path");
+
+	const packageJsonExistsStub = sinon.stub(installer, "_packageJsonExists").resolves(true);
+	const synchronizeSpy = sinon.spy(installer, "_synchronize");
+
+	const getStagingDirForPackageStub = sinon.stub(installer, "_getStagingDirForPackage")
+		.returns("staging-dir-path");
+	const pathExistsStub = sinon.stub(installer, "_pathExists").resolves(false);
+
+	const extractPackageStub = sinon.stub(installer._registry, "extractPackage").resolves();
+
+	const res = await installer.installPackage({
+		pkgName: "myPackage",
+		version: "1.2.3"
+	});
+
+	t.deepEqual(res, {
+		pkgPath: "package-dir-path"
+	}, "Should return correct values");
+
+	t.is(getTargetDirForPackageStub.callCount, 1, "_getTargetDirForPackage should be called once");
+	t.deepEqual(getTargetDirForPackageStub.getCall(0).args[0], {
+		pkgName: "myPackage",
+		version: "1.2.3"
+	}, "_getTargetDirForPackage should be called with the correct arguments");
+
+	t.is(packageJsonExistsStub.callCount, 1, "_packageJsonExists should be called once");
+	t.is(packageJsonExistsStub.getCall(0).args[0], "package-dir-path",
+		"_packageJsonExists should be called with the correct arguments on first call");
+
+	t.is(synchronizeSpy.callCount, 0, "_synchronize should never be called");
+	t.is(t.context.lockStub.callCount, 0, "lock should never be called");
+	t.is(t.context.unlockStub.callCount, 0, "unlock should never be called");
+	t.is(getStagingDirForPackageStub.callCount, 0, "_getStagingDirForPackage should never be called");
+	t.is(pathExistsStub.callCount, 0, "_pathExists should never be called");
+	t.is(t.context.rimrafStub.callCount, 0, "rimraf should never be called");
+	t.is(extractPackageStub.callCount, 0, "_extractPackage should never be called");
+	t.is(t.context.mkdirpStub.callCount, 0, "mkdirp should never be called");
+	t.is(t.context.renameStub.callCount, 0, "fs.rename should never be called");
+});
+
+test.serial("Installer: installPackage with install already in progress", async (t) => {
+	const installer = new Installer({
+		cwd: "/cwd/",
+		ui5HomeDir: "/ui5Home/"
+	});
+
+	t.context.lockStub.yieldsAsync();
+	t.context.unlockStub.yieldsAsync();
+
+	const getTargetDirForPackageStub = sinon.stub(installer, "_getTargetDirForPackage")
+		.returns("package-dir-path");
+
+	const packageJsonExistsStub = sinon.stub(installer, "_packageJsonExists")
+		.onFirstCall().resolves(false)
+		.onSecondCall().resolves(true); // After lock got acquired, package has been installed
+
+	const synchronizeSpy = sinon.spy(installer, "_synchronize");
+
+	const getStagingDirForPackageStub = sinon.stub(installer, "_getStagingDirForPackage")
+		.returns("staging-dir-path");
+	const pathExistsStub = sinon.stub(installer, "_pathExists").resolves(false);
+
+	const extractPackageStub = sinon.stub(installer._registry, "extractPackage").resolves();
+
+	await installer.installPackage({
+		pkgName: "myPackage",
+		version: "1.2.3"
+	});
+
+	t.is(getTargetDirForPackageStub.callCount, 1, "_getTargetDirForPackage should be called once");
+	t.deepEqual(getTargetDirForPackageStub.getCall(0).args[0], {
+		pkgName: "myPackage",
+		version: "1.2.3"
+	}, "_getTargetDirForPackage should be called with the correct arguments");
+
+	t.is(packageJsonExistsStub.callCount, 2, "_packageJsonExists should be called twice");
+	t.is(packageJsonExistsStub.getCall(0).args[0], "package-dir-path",
+		"_packageJsonExists should be called with the correct arguments on first call");
+	t.is(packageJsonExistsStub.getCall(1).args[0], "package-dir-path",
+		"_packageJsonExists should be called with the correct arguments on second call");
+
+	t.is(synchronizeSpy.callCount, 1, "_synchronize should be called once");
+	t.deepEqual(synchronizeSpy.getCall(0).args[0], {
+		pkgName: "myPackage",
+		version: "1.2.3"
+	}, "_synchronize should be called with the correct first argument");
+	t.is(t.context.lockStub.callCount, 1, "lock should be called once");
+	t.is(t.context.unlockStub.callCount, 1, "unlock should be called once");
+
+	t.is(t.context.rimrafStub.callCount, 0, "rimraf should never be called");
+
+	t.is(t.context.mkdirpStub.callCount, 1, "mkdirp should be called once");
+	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
+		"mkdirp should be called with the correct arguments");
+
+	t.is(getStagingDirForPackageStub.callCount, 0, "_getStagingDirForPackage should never be called");
+	t.is(pathExistsStub.callCount, 0, "_pathExists should never be called");
+	t.is(extractPackageStub.callCount, 0, "_extractPackage should never be called");
+	t.is(t.context.renameStub.callCount, 0, "fs.rename should never be called");
+});
+
+test.serial("Installer: installPackage with new package and existing staging", async (t) => {
+	const installer = new Installer({
+		cwd: "/cwd/",
+		ui5HomeDir: "/ui5Home/"
+	});
+
+	t.context.lockStub.yieldsAsync();
+	t.context.unlockStub.yieldsAsync();
+
+	const getTargetDirForPackageStub = sinon.stub(installer, "_getTargetDirForPackage")
+		.returns("package-dir-path");
+
+	const packageJsonExistsStub = sinon.stub(installer, "_packageJsonExists").resolves(false);
+	const synchronizeSpy = sinon.spy(installer, "_synchronize");
+
+	const getStagingDirForPackageStub = sinon.stub(installer, "_getStagingDirForPackage")
+		.returns("staging-dir-path");
+	const pathExistsStub = sinon.stub(installer, "_pathExists").resolves(true); // Staging dir exists
+
+	const extractPackageStub = sinon.stub(installer._registry, "extractPackage").resolves();
+
+	const res = await installer.installPackage({
+		pkgName: "myPackage",
+		version: "1.2.3"
+	});
+
+	t.deepEqual(res, {
+		pkgPath: "package-dir-path"
+	}, "Should return correct values");
+
+	t.is(getTargetDirForPackageStub.callCount, 1, "_getTargetDirForPackage should be called once");
+	t.deepEqual(getTargetDirForPackageStub.getCall(0).args[0], {
+		pkgName: "myPackage",
+		version: "1.2.3"
+	}, "_getTargetDirForPackage should be called with the correct arguments");
+
+	t.is(packageJsonExistsStub.callCount, 2, "_packageJsonExists should be called twice");
+	t.is(packageJsonExistsStub.getCall(0).args[0], "package-dir-path",
+		"_packageJsonExists should be called with the correct arguments on first call");
+	t.is(packageJsonExistsStub.getCall(1).args[0], "package-dir-path",
+		"_packageJsonExists should be called with the correct arguments on second call");
+
+	t.is(synchronizeSpy.callCount, 1, "_synchronize should be called once");
+	t.deepEqual(synchronizeSpy.getCall(0).args[0], {
+		pkgName: "myPackage",
+		version: "1.2.3"
+	}, "_synchronize should be called with the correct first argument");
+	t.is(t.context.lockStub.callCount, 1, "lock should be called once");
+	t.is(t.context.unlockStub.callCount, 1, "unlock should be called once");
+
+	t.is(getStagingDirForPackageStub.callCount, 1, "_getStagingDirForPackage should be called once");
+	t.deepEqual(getStagingDirForPackageStub.getCall(0).args[0], {
+		pkgName: "myPackage",
+		version: "1.2.3"
+	}, "_getStagingDirForPackage should be called with the correct arguments");
+
+	t.is(pathExistsStub.callCount, 1, "_pathExists should be called once");
+	t.is(pathExistsStub.getCall(0).args[0], "staging-dir-path",
+		"_packageJsonExists should be called with the correct arguments");
+
+	t.is(t.context.rimrafStub.callCount, 1, "rimraf should be called once");
+	t.is(t.context.rimrafStub.getCall(0).args[0], "staging-dir-path",
+		"rimraf should be called with the correct arguments");
+
+	t.is(extractPackageStub.callCount, 1, "_extractPackage should be called once");
+
+	t.is(t.context.mkdirpStub.callCount, 2, "mkdirp should be called twice");
+	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
+		"mkdirp should be called with the correct arguments on first call");
+	t.is(t.context.mkdirpStub.getCall(1).args[0], "package-dir-path",
+		"mkdirp should be called with the correct arguments on second call");
+
+	t.is(t.context.renameStub.callCount, 1, "fs.rename should be called once");
+	t.is(t.context.renameStub.getCall(0).args[0], "staging-dir-path",
+		"fs.rename should be called with the correct first argument");
+	t.is(t.context.renameStub.getCall(0).args[1], "package-dir-path",
+		"fs.rename should be called with the correct second argument");
+});
+
+test.serial("Installer: _pathExists - exists", async (t) => {
+	const installer = new Installer({
+		cwd: "/cwd/",
+		ui5HomeDir: "/ui5Home/"
+	});
+
+	const res = await installer._pathExists(__dirname);
+
+	t.is(res, true, "Path should exist");
+	t.is(t.context.statStub.getCall(0).args[0], __dirname,
+		"fs.stat should be called with correct arguments");
+});
+
+test.serial("Installer: _pathExists - does not exist", async (t) => {
+	const installer = new Installer({
+		cwd: "/cwd/",
+		ui5HomeDir: "/ui5Home/"
+	});
+
+	const notFoundError = new Error("Not found");
+	notFoundError.code = "ENOENT";
+	t.context.statStub.yieldsAsync(notFoundError);
+
+	const res = await installer._pathExists("my-path");
+
+	t.is(res, false, "Path should not exist");
+	t.is(t.context.statStub.getCall(0).args[0], "my-path",
+		"fs.stat should be called with correct arguments");
+});
+
+test.serial("Installer: _pathExists - re-throws unexpected errors", async (t) => {
+	const installer = new Installer({
+		cwd: "/cwd/",
+		ui5HomeDir: "/ui5Home/"
+	});
+
+	const notFoundError = new Error("Pony Error");
+	notFoundError.code = "PONY";
+	t.context.statStub.yieldsAsync(notFoundError);
+
+	const err = await t.throwsAsync(installer._pathExists("my-path"));
+
+	t.is(err, notFoundError, "Should throw with expected exception");
+	t.is(t.context.statStub.getCall(0).args[0], "my-path",
+		"fs.stat should be called with correct arguments");
 });


### PR DESCRIPTION
Start a package install into a dedicated staging directory. Only if
download and extraction have completed, rename the staging- to the
target directory.

If subsequent ui5Framework translator executions detect an existing
staging directory during installation of a package, this directory shall
be removed first to ensure a complete install.

Alternative approach to https://github.com/SAP/ui5-project/pull/382
Resolves https://github.com/SAP/ui5-tooling/issues/478