### PR TITLE
[FIX] ui5Framework: Don't access metadata of deduped projects

### DIFF
--- a/lib/translators/ui5Framework.js
+++ b/lib/translators/ui5Framework.js
@@ -220,6 +220,11 @@ module.exports = {
 		const processedProjects = [];
 		while (queue.length) {
 			const project = queue.shift();
+			if (project.deduped) {
+				// Deduped projects have certainly already been processed
+				// Note: Deduped dependencies don't have any metadata or other configuration.
+				continue;
+			}
 			if (processedProjects.includes(project.id)) {
 				// projectTree must be duplicate free. A second occurrence of the same project
 				//	is always the same object. Therefore a single processing needs to be ensured.

--- a/test/lib/translators/ui5Framework.js
+++ b/test/lib/translators/ui5Framework.js
@@ -708,7 +708,11 @@ test.serial("utils.mergeTrees: Do not abort merge if project has already been pr
 								}
 							]
 						},
-						dependencies: []
+						dependencies: [{
+							id: "test2",
+							deduped: true,
+							dependencies: []
+						}]
 					}
 				]
 			},
@@ -805,6 +809,10 @@ test.serial("utils.mergeTrees: Do not abort merge if project has already been pr
 						},
 						dependencies: [
 							{
+								id: "test2",
+								deduped: true,
+								dependencies: []
+							}, {
 								metadata: {
 									name: "lib1"
 								},


### PR DESCRIPTION
Because they don't have any. Otherwise a
"Cannot read property 'name' of undefined" error will be thrown.

This can only occur when using the "ui5 tree --full" command without the
--dedupe option or directly via API.