### PR TITLE
[INTERNAL] Installer: Lazy require registry

### DIFF
--- a/lib/ui5Framework/npm/Installer.js
+++ b/lib/ui5Framework/npm/Installer.js
@@ -8,7 +8,6 @@ const lockfile = require("lockfile");
 const lock = promisify(lockfile.lock);
 const unlock = promisify(lockfile.unlock);
 const mkdirp = require("mkdirp");
-const Registry = require("./Registry");
 const log = require("@ui5/logger").getLogger("normalizer:ui5Framework:npm:Installer");
 
 class Installer {
@@ -21,12 +20,21 @@ class Installer {
 		}
 		this._packagesDir = path.join(ui5HomeDir, "framework", "packages");
 		log.verbose(`Installing to: ${this._packagesDir}`);
-		this._registry = new Registry({
-			cwd,
-			cacheDir: path.join(ui5HomeDir, "framework", "cacache")
-		});
+		this._cwd = cwd;
+		this._caCacheDir = path.join(ui5HomeDir, "framework", "cacache");
 		this._lockDir = path.join(ui5HomeDir, "framework", "locks");
 		this._stagingDir = path.join(ui5HomeDir, "framework", "staging");
+	}
+
+	getRegistry() {
+		if (this._cachedRegistry) {
+			return this._cachedRegistry;
+		}
+		const Registry = require("./Registry");
+		return this._cachedRegistry = new Registry({
+			cwd: this._cwd,
+			cacheDir: this._caCacheDir
+		});
 	}
 
 	async readJson(jsonPath) {
@@ -34,7 +42,7 @@ class Installer {
 	}
 
 	async fetchPackageVersions({pkgName}) {
-		const packument = await this._registry.requestPackagePackument(pkgName);
+		const packument = await this.getRegistry().requestPackagePackument(pkgName);
 		return Object.keys(packument.versions);
 	}
 
@@ -49,7 +57,7 @@ class Installer {
 			};
 		} catch (err) {
 			if (err.code === "ENOENT") { // "File or directory does not exist"
-				const manifest = await this._registry.requestPackageManifest(pkgName, version);
+				const manifest = await this.getRegistry().requestPackageManifest(pkgName, version);
 				return {
 					name: manifest.name,
 					dependencies: manifest.dependencies,
@@ -90,7 +98,7 @@ class Installer {
 					}
 
 					log.verbose(`Installing ${pkgName} in version ${version} to ${stagingDir}...`);
-					await this._registry.extractPackage(pkgName, version, stagingDir);
+					await this.getRegistry().extractPackage(pkgName, version, stagingDir);
 
 					// Do not create target dir itself to prevent EPERM error in following rename operation
 					// (https://github.com/SAP/ui5-tooling/issues/487)

--- a/lib/ui5Framework/npm/Installer.js
+++ b/lib/ui5Framework/npm/Installer.js
@@ -4,10 +4,6 @@ const {promisify} = require("util");
 const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
 const rename = promisify(fs.rename);
-const lockfile = require("lockfile");
-const lock = promisify(lockfile.lock);
-const unlock = promisify(lockfile.unlock);
-const mkdirp = require("mkdirp");
 const log = require("@ui5/logger").getLogger("normalizer:ui5Framework:npm:Installer");
 
 class Installer {
@@ -102,7 +98,7 @@ class Installer {
 
 					// Do not create target dir itself to prevent EPERM error in following rename operation
 					// (https://github.com/SAP/ui5-tooling/issues/487)
-					await mkdirp(path.dirname(targetDir));
+					await require("mkdirp")(path.dirname(targetDir));
 					log.verbose(`Promoting staging directory from ${stagingDir} to ${targetDir}...`);
 					await rename(stagingDir, targetDir);
 				} else {
@@ -135,8 +131,11 @@ class Installer {
 	}
 
 	async _synchronize({pkgName, version}, callback) {
+		const lockfile = require("lockfile");
+		const lock = promisify(lockfile.lock);
+		const unlock = promisify(lockfile.unlock);
 		const lockPath = this._getLockPath({pkgName, version});
-		await mkdirp(this._lockDir);
+		await require("mkdirp")(this._lockDir);
 		log.verbose("Locking " + lockPath);
 		await lock(lockPath, {
 			wait: 10000,

--- a/test/lib/ui5framework/npm/Installer.js
+++ b/test/lib/ui5framework/npm/Installer.js
@@ -60,7 +60,8 @@ test.serial("Installer: fetchPackageVersions", async (t) => {
 		ui5HomeDir: "/ui5Home/"
 	});
 
-	const requestPackagePackumentStub = sinon.stub(installer._registry, "requestPackagePackument")
+	const registry = installer.getRegistry();
+	const requestPackagePackumentStub = sinon.stub(registry, "requestPackagePackument")
 		.resolves({
 			versions: {
 				"1.0.0": {},
@@ -119,10 +120,11 @@ test.serial("Installer: fetchPackageManifest (without existing package.json)", a
 		}
 	};
 
-	const requestPackageManifestStub = sinon.stub(installer._registry, "requestPackageManifest")
+	const registry = installer.getRegistry();
+	const requestPackageManifestStub = sinon.stub(registry, "requestPackageManifest")
 		.callsFake((pkgName, version) => {
 			throw new Error(
-				"_registry.requestPackageManifest stub called with unknown arguments " +
+				"_cachedRegistry.requestPackageManifest stub called with unknown arguments " +
 				`pkgName: ${pkgName}, version: ${version}}`
 			);
 		})
@@ -187,7 +189,8 @@ test.serial("Installer: fetchPackageManifest (with existing package.json)", asyn
 		}
 	};
 
-	const requestPackageManifestStub = sinon.stub(installer._registry, "requestPackageManifest")
+	const registry = installer.getRegistry();
+	const requestPackageManifestStub = sinon.stub(registry, "requestPackageManifest")
 		.rejects(new Error("Unexpected call"));
 
 	const readJsonStub = sinon.stub(installer, "readJson")
@@ -224,7 +227,8 @@ test.serial("Installer: fetchPackageManifest (readJson throws error)", async (t)
 		ui5HomeDir: "/ui5Home/"
 	});
 
-	const requestPackageManifestStub = sinon.stub(installer._registry, "requestPackageManifest")
+	const registry = installer.getRegistry();
+	const requestPackageManifestStub = sinon.stub(registry, "requestPackageManifest")
 		.rejects(new Error("Unexpected call"));
 
 	const readJsonStub = sinon.stub(installer, "readJson")
@@ -415,7 +419,8 @@ test.serial("Installer: installPackage with new package", async (t) => {
 		.returns("staging-dir-path");
 	const pathExistsStub = sinon.stub(installer, "_pathExists").resolves(false);
 
-	const extractPackageStub = sinon.stub(installer._registry, "extractPackage").resolves();
+	const registry = installer.getRegistry();
+	const extractPackageStub = sinon.stub(registry, "extractPackage").resolves();
 
 	const res = await installer.installPackage({
 		pkgName: "myPackage",
@@ -493,7 +498,8 @@ test.serial("Installer: installPackage with already installed package", async (t
 		.returns("staging-dir-path");
 	const pathExistsStub = sinon.stub(installer, "_pathExists").resolves(false);
 
-	const extractPackageStub = sinon.stub(installer._registry, "extractPackage").resolves();
+	const registry = installer.getRegistry();
+	const extractPackageStub = sinon.stub(registry, "extractPackage").resolves();
 
 	const res = await installer.installPackage({
 		pkgName: "myPackage",
@@ -547,7 +553,8 @@ test.serial("Installer: installPackage with install already in progress", async 
 		.returns("staging-dir-path");
 	const pathExistsStub = sinon.stub(installer, "_pathExists").resolves(false);
 
-	const extractPackageStub = sinon.stub(installer._registry, "extractPackage").resolves();
+	const registry = installer.getRegistry();
+	const extractPackageStub = sinon.stub(registry, "extractPackage").resolves();
 
 	await installer.installPackage({
 		pkgName: "myPackage",
@@ -606,7 +613,8 @@ test.serial("Installer: installPackage with new package and existing target and 
 		.returns("staging-dir-path");
 	const pathExistsStub = sinon.stub(installer, "_pathExists").resolves(true); // Staging dir exists
 
-	const extractPackageStub = sinon.stub(installer._registry, "extractPackage").resolves();
+	const registry = installer.getRegistry();
+	const extractPackageStub = sinon.stub(registry, "extractPackage").resolves();
 
 	const res = await installer.installPackage({
 		pkgName: "myPackage",


### PR DESCRIPTION
Prevents initialization of pacote in cases where all packages are
already installed (very common).

Leads to ~100ms faster build of openui5-sample-app.

## `normalizer` Profile

Before:
![Screenshot 2021-11-24 at 18 31 20](https://user-images.githubusercontent.com/1589939/143294871-6cebf7cd-9a01-4f13-b838-28350f2692ab.png)

After 4198ef3:
![Screenshot 2021-11-24 at 18 31 25](https://user-images.githubusercontent.com/1589939/143294913-bbb8a929-4c42-4810-9948-683b9f469f9c.png)

After c676dd4:
![Screenshot 2021-11-24 at 19 29 45](https://user-images.githubusercontent.com/1589939/143294917-e9464430-f889-458d-a89b-cd4b07a5da3a.png)

