### PR TITLE
[INTERNAL] git-chglog: Fix mutli-release-branch setup

### DIFF
--- a/.chglog/release-config.yml
+++ b/.chglog/release-config.yml
@@ -3,6 +3,7 @@ template: RELEASE.tpl.md
 info:
   repository_url: https://github.com/SAP/ui5-project
 options:
+  tag_filter_pattern: '^v[^012]' # For release notes ignore versions below v3 to that we always compare the _last v3+_ tag with the current release
   commits:
     filters:
       Type:

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
 		"jsdoc-generate": "jsdoc -c ./jsdoc.json -t $(node -p 'path.dirname(require.resolve(\"docdash\"))') ./lib/ || (echo 'Error during JSDoc generation! Check log.' && exit 1)",
 		"jsdoc-watch": "npm run jsdoc && chokidar \"./lib/**/*.js\" -c \"npm run jsdoc-generate\"",
 		"preversion": "npm test",
-		"version": "git-chglog --next-tag v$npm_package_version -o CHANGELOG.md && git add CHANGELOG.md",
+		"version": "git-chglog --sort semver --next-tag v$npm_package_version -o CHANGELOG.md && git add CHANGELOG.md",
 		"postversion": "git push --follow-tags",
-		"release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version",
+		"release-note": "git-chglog --sort semver -c .chglog/release-config.yml v$npm_package_version",
 		"depcheck": "depcheck --ignores docdash"
 	},
 	"files": [


### PR DESCRIPTION
* Always sort by semver instead of date to fix changelog generation when different branches are tagged at intersecting times
* For release notes on the current next branch, ignore any tags <=v2 to ensure that we always compare to a v3 tag
  (sorting by semver doesn't seem to work here)