### PR TITLE
[FIX] lib/normalizer: Allow absolute windows paths and multiple parameters

### DIFF
--- a/lib/normalizer.js
+++ b/lib/normalizer.js
@@ -60,15 +60,14 @@ const Normalizer = {
 		log.verbose("Building dependency tree...");
 
 		let translatorParams = [];
-		let translator = translatorName;
-		if (translatorName.indexOf(":") !== -1) {
-			translatorParams = translatorName.split(":");
-			translator = translatorParams[0];
-			translatorParams = translatorParams.slice(1);
+		const indexTranslatorName = translatorName.indexOf(":");
+		if (indexTranslatorName !== -1) {
+			translatorParams = translatorName.substring(indexTranslatorName + 1).split(",");
+			translatorName = translatorName.substring(0, indexTranslatorName);
 		}
 
 		let translatorModule;
-		switch (translator) {
+		switch (translatorName) {
 		case "static":
 			translatorModule = require("./translators/static");
 			break;
@@ -76,7 +75,7 @@ const Normalizer = {
 			translatorModule = require("./translators/npm");
 			break;
 		default:
-			return Promise.reject(new Error(`Unknown translator ${translator}`));
+			return Promise.reject(new Error(`Unknown translator ${translatorName}`));
 		}
 
 		translatorOptions.parameters = translatorParams;

--- a/test/lib/normalizer.js
+++ b/test/lib/normalizer.js
@@ -68,3 +68,34 @@ test.serial("Error: Throws if unknown translator should be used as strategy", as
 		t.is(error.message, `Unknown translator ${translatorName}`);
 	});
 });
+
+test.serial("Parse translator options correctly (unix path)", async (t) => {
+	normalizer.generateDependencyTree({
+		translatorName: "static:/mypath/myfile"
+	});
+	const args = t.context.staticTranslatorStub.generateDependencyTree.args[0];
+	t.truthy(args[1], "The translator is called correctly with arguments");
+	t.is(args[1].parameters.length, 1, "The number of parameters are correct.");
+	t.is(args[1].parameters[0], "/mypath/myfile", "The parameters entry is correct '/mypath/myfile'");
+});
+
+test.serial("Parse translator options correctly (windows path)", async (t) => {
+	normalizer.generateDependencyTree({
+		translatorName: "static:C:/mypath/myfile"
+	});
+	const args = t.context.staticTranslatorStub.generateDependencyTree.args[0];
+	t.truthy(args[1], "The translator is called correctly with arguments");
+	t.is(args[1].parameters.length, 1, "The number of parameters are correct.");
+	t.is(args[1].parameters[0], "C:/mypath/myfile", "The parameters entry is correct '/mypath/myfile'");
+});
+
+test.serial("Parse translator options correctly (multiple parameters)", async (t) => {
+	normalizer.generateDependencyTree({
+		translatorName: "static:mypath/myfile,mypath2/myfile2"
+	});
+	const args = t.context.staticTranslatorStub.generateDependencyTree.args[0];
+	t.truthy(args[1], "The translator is called correctly with arguments");
+	t.is(args[1].parameters.length, 2, "The number of parameters are correct.");
+	t.is(args[1].parameters[0], "mypath/myfile", "The parameters entry is correct '/mypath/myfile'");
+	t.is(args[1].parameters[1], "mypath2/myfile2", "The parameters entry is correct '/mypath2/myfile2'");
+});


### PR DESCRIPTION
This PR fixes the usages of absolute windows file paths e.g. `static:C:/myfolderA/myfileA` and offers a new way of passing multiple parameters to the translators e.g. `static:myfolderA/myfileA,myfolderB/myfileB`