### PR TITLE
[INTERNAL] static translator: Add "tree" option, fix path resolution

### DIFF
--- a/lib/translators/static.js
+++ b/lib/translators/static.js
@@ -4,10 +4,10 @@ const {promisify} = require("util");
 const readFile = promisify(fs.readFile);
 const parseYaml = require("js-yaml").load;
 
-function resolveProjectPaths(project) {
-	project.path = path.resolve(project.path);
+function resolveProjectPaths(cwd, project) {
+	project.path = path.resolve(cwd, project.path);
 	if (project.dependencies) {
-		project.dependencies.forEach(resolveProjectPaths);
+		project.dependencies.forEach((project) => resolveProjectPaths(cwd, project));
 	}
 	return project;
 }
@@ -29,24 +29,28 @@ module.exports = {
 	 * @param {string} dirPath Project path
 	 * @param {object} [options]
 	 * @param {Array} [options.parameters] CLI configuration options
+	 * @param {object} [options.tree] Tree object to be used instead of reading a YAML
 	 * @returns {Promise} Promise resolving with a dependency tree
 	 */
 	async generateDependencyTree(dirPath, options = {}) {
-		const depFilePath = options.parameters && options.parameters[0] ||
-								path.join(dirPath, "projectDependencies.yaml");
-		try {
-			const buffer = await readFile(depFilePath);
-			const tree = parseYaml(buffer.toString(), {
-				filename: depFilePath
-			});
-
-			// Ensure that all project paths are absolute
-			resolveProjectPaths(tree);
-			return tree;
-		} catch (err) {
-			throw new Error(
-				`[static translator] Failed to load dependency tree from path ${depFilePath} `+
-				`- Error: ${err.message}`);
+		let tree = options.tree;
+		if (!tree) {
+			const depFilePath = options.parameters && options.parameters[0] ||
+				path.join(dirPath, "projectDependencies.yaml");
+			try {
+				const contents = await readFile(depFilePath, {encoding: "utf-8"});
+				tree = parseYaml(contents, {
+					filename: depFilePath
+				});
+			} catch (err) {
+				throw new Error(
+					`[static translator] Failed to load dependency tree from path ${depFilePath} `+
+					`- Error: ${err.message}`);
+			}
 		}
+
+		// Ensure that all project paths are absolute
+		resolveProjectPaths(dirPath, tree);
+		return tree;
 	}
 };

--- a/test/lib/translators/static.js
+++ b/test/lib/translators/static.js
@@ -13,6 +13,42 @@ test("Generates dependency tree for project with projectDependencies.yaml", (t) 
 		});
 });
 
+test("Generates dependency tree for project with projectDependencies.yaml (via parameters)", (t) => {
+	return staticTranslator.generateDependencyTree(projectPath, {
+		parameters: [path.join(projectPath, "projectDependencies.yaml")]
+	})
+		.then((parsedTree) => {
+			t.deepEqual(parsedTree, expectedTree, "Parsed correctly");
+		});
+});
+
+test("Generates dependency tree for project by passing tree object", (t) => {
+	return staticTranslator.generateDependencyTree(projectPath, {
+		tree: {
+			id: "testsuite",
+			version: "0.0.1",
+			description: "Sample App",
+			main: "index.html",
+			path: "./",
+			dependencies: [
+				{
+					id: "sap.f",
+					version: "1.56.1",
+					path: "../sap.f"
+				},
+				{
+					id: "sap.m",
+					version: "1.61.0",
+					path: "../sap.m"
+				}
+			]
+		}
+	})
+		.then((parsedTree) => {
+			t.deepEqual(parsedTree, expectedTree, "Parsed correctly");
+		});
+});
+
 test("Error: Throws if projectDependencies.yaml was not found", async (t) => {
 	const projectPath = "notExistingPath";
 	const fsError = new Error("File not found");
@@ -31,17 +67,17 @@ const expectedTree = {
 	version: "0.0.1",
 	description: "Sample App",
 	main: "index.html",
-	path: path.resolve("./"),
+	path: path.resolve(projectPath, "./"),
 	dependencies: [
 		{
 			id: "sap.f",
 			version: "1.56.1",
-			path: path.resolve("../sap.f")
+			path: path.resolve(projectPath, "../sap.f")
 		},
 		{
 			id: "sap.m",
 			version: "1.61.0",
-			path: path.resolve("../sap.m")
+			path: path.resolve(projectPath, "../sap.m")
 		}
 	]
 };


### PR DESCRIPTION
- Allow passing a tree object instead of reading a YAML file
- Path resolution should be based on the passed directory, not based on
the process cwd

JIRA: CPOUI5FOUNDATION-403
