### PR TITLE
[INTERNAL] Move TaskUtil class to ui5-project, allow injection of taskRepository

### DIFF
--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -27,11 +27,15 @@ class ProjectBuilder {
 	 *
 	 * @public
 	 * @param {module:@ui5/project.graph.ProjectGraph} graph Project graph
+	 * @param {module:@ui5/builder.tasks.taskRepository} taskRepository Task Repository module
 	 * @param {module:@ui5/project.build.ProjectBuilder.BuildConfiguration} [buildConfig] Build configuration
 	 */
-	constructor(graph, buildConfig) {
+	constructor(graph, taskRepository, buildConfig) {
 		if (!graph) {
 			throw new Error(`Missing parameter 'graph'`);
+		}
+		if (!taskRepository) {
+			throw new Error(`Missing parameter 'taskRepository'`);
 		}
 		if (!graph.isSealed()) {
 			throw new Error(
@@ -39,7 +43,7 @@ class ProjectBuilder {
 		}
 
 		this._graph = graph;
-		this._buildContext = new BuildContext(graph, buildConfig);
+		this._buildContext = new BuildContext(graph, taskRepository, buildConfig);
 	}
 
 	/**

--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -242,7 +242,7 @@ class TaskRunner {
 						{module:@ui5/fs.AbstractReader} parameters.dependencies
 							Reader or Collection to read dependency files
 						{Object} parameters.taskUtil Specification Version dependent interface to a
-							[TaskUtil]{@link module:@ui5/builder.tasks.TaskUtil} instance
+							[TaskUtil]{@link module:@ui5/project.build.helpers.TaskUtil} instance
 						{Object} parameters.options Options
 						{string} parameters.options.projectName Project name
 						{string} [parameters.options.projectNamespace] Project namespace if available

--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -1,4 +1,3 @@
-const {getTask} = require("@ui5/builder").tasks.taskRepository;
 const composeTaskList = require("./helpers/composeTaskList");
 
 class TaskRunner {
@@ -9,17 +8,19 @@ class TaskRunner {
 	 * @param {object} parameters.graph
 	 * @param {object} parameters.project
 	 * @param {GroupLogger} parameters.parentLogger Logger to use
-	 * @param {module:@ui5/builder.tasks.TaskUtil} parameters.taskUtil TaskUtil instance
+	 * @param {module:@ui5/project.build.helpers.TaskUtil} parameters.taskUtil TaskUtil instance
+	 * @param {module:@ui5/builder.tasks.taskRepository} parameters.taskRepository Task repository
 	 * @param {module:@ui5/project.build.ProjectBuilder.BuildConfiguration} parameters.buildConfig
 	 * 			Build configuration
 	 */
-	constructor({graph, project, parentLogger, taskUtil, buildConfig}) {
+	constructor({graph, project, parentLogger, taskUtil, taskRepository, buildConfig}) {
 		if (!graph || !project || !parentLogger || !taskUtil || !buildConfig) {
 			throw new Error("One or more mandatory parameters not provided");
 		}
 		this._project = project;
 		this._graph = graph;
 		this._taskUtil = taskUtil;
+		this._taskRepository = taskRepository;
 		this._buildConfig = buildConfig;
 
 		this._log = parentLogger.createSubLogger(project.getType() + " " + project.getName(), 0.2);
@@ -49,7 +50,7 @@ class TaskRunner {
 		const standardTasks = buildDefinition({
 			project,
 			taskUtil,
-			getTask
+			getTask: taskRepository.getTask
 		});
 
 		for (const [taskName, params] of standardTasks) {
@@ -165,7 +166,7 @@ class TaskRunner {
 			}
 
 			if (!taskFunction) {
-				taskFunction = getTask(taskName).task;
+				taskFunction = this._taskRepository.getTask(taskName).task;
 			}
 			return taskFunction(params);
 		};
@@ -206,7 +207,7 @@ class TaskRunner {
 			}
 			let standardTask;
 			try {
-				standardTask = getTask(taskDef.name);
+				standardTask = this._taskRepository.getTask(taskDef.name);
 			} catch (e) {/* We expect this to fail with an "Unknown Task" error */}
 			if (standardTask) {
 				throw new Error(

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -7,7 +7,7 @@ const ProjectBuildContext = require("./ProjectBuildContext");
  * @memberof module:@ui5/project.build.helpers
  */
 class BuildContext {
-	constructor(graph, {
+	constructor(graph, taskRepository, { // buildConfig
 		selfContained = false,
 		cssVariables = false,
 		jsdoc = false,
@@ -16,6 +16,9 @@ class BuildContext {
 	} = {}) {
 		if (!graph) {
 			throw new Error(`Missing parameter 'graph'`);
+		}
+		if (!taskRepository) {
+			throw new Error(`Missing parameter 'taskRepository'`);
 		}
 
 		if (createBuildManifest && !["library", "theme-library"].includes(graph.getRoot().getType())) {
@@ -34,6 +37,8 @@ class BuildContext {
 			excludedTasks,
 		};
 
+		this._taskRepository = taskRepository;
+
 		this._options = {
 			cssVariables: cssVariables
 		};
@@ -50,6 +55,10 @@ class BuildContext {
 
 	getBuildConfig() {
 		return this._buildConfig;
+	}
+
+	getTaskRepository() {
+		return this._taskRepository;
 	}
 
 	getGraph() {

--- a/lib/build/helpers/ProjectBuildContext.js
+++ b/lib/build/helpers/ProjectBuildContext.js
@@ -1,12 +1,12 @@
 const ResourceTagCollection = require("@ui5/fs").ResourceTagCollection;
-const TaskUtil = require("@ui5/builder").tasks.TaskUtil;
+const TaskUtil = require("./TaskUtil");
 
 /**
  * Build context of a single project. Always part of an overall
- * [Build Context]{@link module:@ui5/builder.builder.BuildContext}
+ * [Build Context]{@link module:@ui5/project.build.helpers.BuildContext}
  *
  * @private
- * @memberof module:@ui5/builder.builder
+ * @memberof module:@ui5/project.build.helpers
  */
 class ProjectBuildContext {
 	constructor({buildContext, log, project}) {
@@ -102,6 +102,7 @@ class ProjectBuildContext {
 			graph: this._buildContext.getGraph(),
 			project: this._project,
 			taskUtil: this.getTaskUtil(),
+			taskRepository: this._buildContext.getTaskRepository(),
 			parentLogger: this._log,
 			buildConfig: this._buildContext.getBuildConfig()
 		});

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -1,0 +1,237 @@
+/**
+ * Convenience functions for UI5 tasks.
+ * An instance of this class is passed to every standard UI5 task that requires it.
+ *
+ * Custom tasks that define a specification version >= 2.2 will receive an interface
+ * to an instance of this class when called.
+ * The set of available functions on that interface depends on the specification
+ * version defined for the extension.
+ *
+ * @public
+ * @memberof module:@ui5/project.build.helpers
+ */
+class TaskUtil {
+	/**
+	 * Standard Build Tags. See UI5 Tooling
+	 * [RFC 0008]{@link https://github.com/SAP/ui5-tooling/blob/master/rfcs/0008-resource-tagging-during-build.md}
+	 * for details.
+	 *
+	 * @public
+	 * @typedef {object} module:@ui5/project.build.helpers.TaskUtil~StandardBuildTags
+	 * @property {string} OmitFromBuildResult
+	 * 		Setting this tag to true will prevent the resource from being written to the build target directory
+	 * @property {string} IsBundle
+	 * 		This tag identifies resources that contain (i.e. bundle) multiple other resources
+	 * @property {string} IsDebugVariant
+	 * 		This tag identifies resources that are a debug variant (typically named with a "-dbg" suffix)
+	 * 		of another resource. This tag is part of the build manifest.
+	 * @property {string} HasDebugVariant
+	 * 		This tag identifies resources for which a debug variant has been created.
+	 * 		This tag is part of the build manifest.
+	 */
+
+	/**
+	 * Since <code>@ui5/project.build.helpers.ProjectBuildContext</code> is a private class, TaskUtil must not be
+	 * instantiated by modules other than @ui5/project itself.
+	 *
+	 * @param {object} parameters
+	 * @param {module:@ui5/project.build.helpers.ProjectBuildContext} parameters.projectBuildContext ProjectBuildContext
+	 * @public
+	 */
+	constructor({projectBuildContext}) {
+		this._projectBuildContext = projectBuildContext;
+		/**
+		 * @member {module:@ui5/project.build.helpers.TaskUtil~StandardBuildTags}
+		 * @public
+		*/
+		this.STANDARD_TAGS = Object.freeze({
+			// "Project" tags:
+			// Will be stored on project instance and are hence part of the build manifest
+			IsDebugVariant: "ui5:IsDebugVariant",
+			HasDebugVariant: "ui5:HasDebugVariant",
+
+			// "Build" tags:
+			// Will be stored on the project build context
+			// They are only available to the build tasks of a single project
+			OmitFromBuildResult: "ui5:OmitFromBuildResult",
+			IsBundle: "ui5:IsBundle"
+		});
+	}
+
+	/**
+	 * Stores a tag with value for a given resource's path. Note that the tag is independent of the supplied
+	 * resource instance. For two resource instances with the same path, the same tag value is returned.
+	 * If the path of a resource is changed, any tag information previously stored for that resource is lost.
+	 *
+	 * </br></br>
+	 * This method is only available to custom task extensions defining
+	 * <b>Specification Version 2.2 and above</b>.
+	 *
+	 * @param {module:@ui5/fs.Resource} resource Resource-instance the tag should be stored for
+	 * @param {string} tag Name of the tag. Currently only the
+	 * 	[STANDARD_TAGS]{@link module:@ui5/project.build.helpers.TaskUtil#STANDARD_TAGS} are allowed
+	 * @param {string|boolean|integer} [value=true] Tag value. Must be primitive
+	 * @public
+	 */
+	setTag(resource, tag, value) {
+		if (typeof resource === "string") {
+			throw new Error("Deprecated parameter: " +
+				"Since UI5 Tooling 3.0, #setTag requires a resource instance. Strings are no longer accepted");
+		}
+
+		const collection = this._projectBuildContext.getResourceTagCollection(resource, tag);
+		return collection.setTag(resource, tag, value);
+	}
+
+	/**
+	 * Retrieves the value for a stored tag. If no value is stored, <code>undefined</code> is returned.
+	 *
+	 * </br></br>
+	 * This method is only available to custom task extensions defining
+	 * <b>Specification Version 2.2 and above</b>.
+	 *
+	 * @param {module:@ui5/fs.Resource} resource Resource-instance the tag should be retrieved for
+	 * @param {string} tag Name of the tag
+	 * @returns {string|boolean|integer|undefined} Tag value for the given resource.
+	 * 										<code>undefined</code> if no value is available
+	 * @public
+	 */
+	getTag(resource, tag) {
+		if (typeof resource === "string") {
+			throw new Error("Deprecated parameter: " +
+				"Since UI5 Tooling 3.0, #getTag requires a resource instance. Strings are no longer accepted");
+		}
+		const collection = this._projectBuildContext.getResourceTagCollection(resource, tag);
+		return collection.getTag(resource, tag);
+	}
+
+	/**
+	 * Clears the value of a tag stored for the given resource's path.
+	 * It's like the tag was never set for that resource.
+	 *
+	 * </br></br>
+	 * This method is only available to custom task extensions defining
+	 * <b>Specification Version 2.2 and above</b>.
+	 *
+	 * @param {module:@ui5/fs.Resource} resource Resource-instance the tag should be cleared for
+	 * @param {string} tag Tag
+	 * @public
+	 */
+	clearTag(resource, tag) {
+		if (typeof resource === "string") {
+			throw new Error("Deprecated parameter: " +
+				"Since UI5 Tooling 3.0, #clearTag requires a resource instance. Strings are no longer accepted");
+		}
+		const collection = this._projectBuildContext.getResourceTagCollection(resource, tag);
+		return collection.clearTag(resource, tag);
+	}
+
+	/**
+	 * Check whether the project currently being built is the root project.
+	 *
+	 * </br></br>
+	 * This method is only available to custom task extensions defining
+	 * <b>Specification Version 2.2 and above</b>.
+	 *
+	 * @returns {boolean} <code>true</code> if the currently built project is the root project
+	 * @public
+	 */
+	isRootProject() {
+		return this._projectBuildContext.isRootProject();
+	}
+
+	/**
+	 * Retrieves a build option defined by its <code>key</code.
+	 * If no option with the given <code>key</code> is stored, <code>undefined</code> is returned.
+	 *
+	 * @param {string} key The option key
+	 * @returns {any|undefined} The build option (or undefined)
+	 * @private
+	 */
+	getBuildOption(key) {
+		return this._projectBuildContext.getOption(key);
+	}
+
+	/**
+	 * Register a function that must be executed once the build is finished. This can be used to, for example,
+	 * clean up files temporarily created on the file system. If the callback returns a Promise, it will be waited for.
+	 * It will also be executed in cases where the build has failed or has been aborted.
+	 *
+	 * </br></br>
+	 * This method is only available to custom task extensions defining
+	 * <b>Specification Version 2.2 and above</b>.
+	 *
+	 * @param {Function} callback Callback to register. If it returns a Promise, it will be waited for
+	 * @public
+	 */
+	registerCleanupTask(callback) {
+		return this._projectBuildContext.registerCleanupTask(callback);
+	}
+
+	/**
+	 * Retrieve a single project from the dependency graph
+	 *
+	 * </br></br>
+	 * This method is only available to custom task extensions defining
+	 * <b>Specification Version 3.0 and above</b>.
+	 *
+	 * @param {string} projectName Name of the project to retrieve
+	 * @returns {module:@ui5/project.specifications.Project|undefined}
+	 *					project instance or undefined if the project is unknown to the graph
+	 * @public
+	 */
+	getProject(projectName) {
+		return this._projectBuildContext.getProject(projectName);
+	}
+
+	/**
+	 * Get an interface to an instance of this class that only provides those functions
+	 * that are supported by the given custom task extension specification version.
+	 *
+	 * @param {string} specVersion Specification version of custom task extension
+	 * @returns {object} An object with bound instance methods supported by the given specification version
+	 */
+	getInterface(specVersion) {
+		if (["0.1", "1.0", "1.1", "2.0", "2.1"].includes(specVersion)) {
+			return undefined;
+		}
+
+		const baseInterface = {
+			STANDARD_TAGS: this.STANDARD_TAGS,
+		};
+		bindFunctions(this, baseInterface, [
+			"setTag", "clearTag", "getTag", "isRootProject", "registerCleanupTask"
+		]);
+		switch (specVersion) {
+		case "2.2":
+		case "2.3":
+		case "2.4":
+		case "2.5":
+		case "2.6":
+			return baseInterface;
+		case "3.0":
+			baseInterface.getProject = (projectName) => {
+				const project = this.getProject(projectName);
+				const baseProjectInterface = {};
+				bindFunctions(project, baseProjectInterface, [
+					"getName", "getVersion", "getNamespace"
+				]);
+				switch (specVersion) {
+				case "3.0":
+					return baseProjectInterface;
+				}
+			};
+			return baseInterface;
+		default:
+			throw new Error(`TaskUtil: Unknown or unsupported Specification Version ${specVersion}`);
+		}
+	}
+}
+
+function bindFunctions(sourceObject, targetObject, funcNames) {
+	funcNames.forEach((funcName) => {
+		targetObject[funcName] = sourceObject[funcName].bind(sourceObject);
+	});
+}
+
+module.exports = TaskUtil;

--- a/lib/build/helpers/createBuildManifest.js
+++ b/lib/build/helpers/createBuildManifest.js
@@ -47,7 +47,7 @@ module.exports = async function(project, buildConfig) {
 			buildConfig,
 			version: project.getVersion(),
 			namespace: project.getNamespace(),
-			tags: project.getResourceTagCollection().getAllTags()
+			tags: Object.fromEntries(Object.entries(project.getResourceTagCollection().getAllTags()).sort())
 		}
 	};
 

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -452,6 +452,14 @@ class ProjectGraph {
 		}
 	}
 
+	setTaskRepository(taskRepository) {
+		this._taskRepository = taskRepository;
+	}
+
+	getTaskRepository() {
+		return this._taskRepository || require("@ui5/builder").tasks.taskRepository;
+	}
+
 	/**
 	 * Executes a build on the graph
 	 *
@@ -481,7 +489,7 @@ class ProjectGraph {
 		includedDependencies = [], excludedDependencies = [],
 		complexDependencyIncludes,
 		selfContained = false, cssVariables = false, jsdoc = false, createBuildManifest = false,
-		includedTasks = [], excludedTasks = [],
+		includedTasks = [], excludedTasks = []
 	}) {
 		this.seal();
 		if (this._built) {
@@ -491,7 +499,7 @@ class ProjectGraph {
 		}
 		this._built = true;
 		const ProjectBuilder = require("../build/ProjectBuilder");
-		const builder = new ProjectBuilder(this, {
+		const builder = new ProjectBuilder(this, this.getTaskRepository(), {
 			selfContained, cssVariables, jsdoc,
 			createBuildManifest,
 			includedTasks, excludedTasks,

--- a/test/lib/build/TaskRunner.js
+++ b/test/lib/build/TaskRunner.js
@@ -3,6 +3,7 @@ const sinon = require("sinon");
 const mock = require("mock-require");
 
 const parentLogger = require("@ui5/logger").getGroupLogger("mygroup");
+const taskRepository = require("@ui5/builder").tasks.taskRepository;
 
 const TaskRunner = require("../../../lib/build/TaskRunner");
 
@@ -65,6 +66,8 @@ test.beforeEach((t) => {
 		getInterface: sinon.stub()
 	};
 
+	t.context.taskRepository = taskRepository; // TODO: Mock?
+
 	t.context.graph = {
 		getRoot: () => {
 			return {
@@ -76,9 +79,9 @@ test.beforeEach((t) => {
 });
 
 test("Project of type 'application'", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const taskRunner = new TaskRunner({
-		project: getMockProject("application"), graph, taskUtil, parentLogger, buildConfig
+		project: getMockProject("application"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
@@ -99,9 +102,9 @@ test("Project of type 'application'", (t) => {
 });
 
 test("Project of type 'library'", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const taskRunner = new TaskRunner({
-		project: getMockProject("library"), graph, taskUtil, parentLogger, buildConfig
+		project: getMockProject("library"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -124,9 +127,9 @@ test("Project of type 'library'", (t) => {
 });
 
 test("Project of type 'theme-library'", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const taskRunner = new TaskRunner({
-		project: getMockProject("theme-library"), graph, taskUtil, parentLogger, buildConfig
+		project: getMockProject("theme-library"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -139,19 +142,19 @@ test("Project of type 'theme-library'", (t) => {
 });
 
 test("Project of type 'module'", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const taskRunner = new TaskRunner({
-		project: getMockProject("module"), graph, taskUtil, parentLogger, buildConfig
+		project: getMockProject("module"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [], "Correct standard tasks");
 });
 
 test("Unknown project type", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const err = t.throws(() => {
 		new TaskRunner({
-			project: getMockProject("pony"), graph, taskUtil, parentLogger, buildConfig
+			project: getMockProject("pony"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 		});
 	});
 
@@ -159,14 +162,14 @@ test("Unknown project type", (t) => {
 });
 
 test("Custom tasks", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "minify"},
 		{name: "myOtherTask", beforeTask: "replaceVersion"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
@@ -189,14 +192,14 @@ test("Custom tasks", (t) => {
 });
 
 test("Custom tasks with no standard tasks", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask"},
 		{name: "myOtherTask", beforeTask: "myTask"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"myOtherTask",
@@ -205,7 +208,7 @@ test("Custom tasks with no standard tasks", (t) => {
 });
 
 test("Custom tasks with no standard tasks and second task defining no before-/afterTask", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask"},
@@ -213,7 +216,7 @@ test("Custom tasks with no standard tasks and second task defining no before-/af
 	];
 	const err = t.throws(() => {
 		new TaskRunner({
-			project, graph, taskUtil, parentLogger, buildConfig
+			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 		});
 	});
 	t.is(err.message,
@@ -223,14 +226,14 @@ test("Custom tasks with no standard tasks and second task defining no before-/af
 });
 
 test("Custom tasks with both, before- and afterTask reference", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", beforeTask: "minify", afterTask: "replaceVersion"}
 	];
 	const err = t.throws(() => {
 		new TaskRunner({
-			project, graph, taskUtil, parentLogger, buildConfig
+			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 		});
 	});
 	t.is(err.message,
@@ -240,14 +243,14 @@ test("Custom tasks with both, before- and afterTask reference", (t) => {
 });
 
 test("Custom tasks with no before-/afterTask reference", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask"}
 	];
 	const err = t.throws(() => {
 		new TaskRunner({
-			project, graph, taskUtil, parentLogger, buildConfig
+			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 		});
 	});
 	t.is(err.message,
@@ -257,14 +260,14 @@ test("Custom tasks with no before-/afterTask reference", (t) => {
 });
 
 test("Custom tasks without name", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: ""}
 	];
 	const err = t.throws(() => {
 		new TaskRunner({
-			project, graph, taskUtil, parentLogger, buildConfig
+			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 		});
 	});
 	t.is(err.message,
@@ -273,14 +276,14 @@ test("Custom tasks without name", (t) => {
 });
 
 test("Custom task with name of standard tasks", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "replaceVersion", afterTask: "minify"}
 	];
 	const err = t.throws(() => {
 		new TaskRunner({
-			project, graph, taskUtil, parentLogger, buildConfig
+			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 		});
 	});
 	t.is(err.message,
@@ -290,7 +293,7 @@ test("Custom task with name of standard tasks", (t) => {
 });
 
 test("Multiple custom tasks with same name", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "minify"},
@@ -298,7 +301,7 @@ test("Multiple custom tasks with same name", (t) => {
 		{name: "myTask", afterTask: "minify"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
@@ -322,14 +325,14 @@ test("Multiple custom tasks with same name", (t) => {
 });
 
 test("Custom tasks with unknown beforeTask", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", beforeTask: "unknownTask"}
 	];
 	const err = t.throws(() => {
 		new TaskRunner({
-			project, graph, taskUtil, parentLogger, buildConfig
+			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 		});
 	});
 	t.is(err.message,
@@ -339,14 +342,14 @@ test("Custom tasks with unknown beforeTask", (t) => {
 });
 
 test("Custom tasks with unknown afterTask", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "unknownTask"}
 	];
 	const err = t.throws(() => {
 		new TaskRunner({
-			project, graph, taskUtil, parentLogger, buildConfig
+			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 		});
 	});
 	t.is(err.message,
@@ -356,7 +359,7 @@ test("Custom tasks with unknown afterTask", (t) => {
 });
 
 test("Custom tasks is unknown", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	graph.getExtension.returns(undefined);
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
@@ -364,7 +367,7 @@ test("Custom tasks is unknown", (t) => {
 	];
 	const err = t.throws(() => {
 		new TaskRunner({
-			project, graph, taskUtil, parentLogger, buildConfig
+			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 		});
 	});
 	t.is(err.message,
@@ -374,7 +377,7 @@ test("Custom tasks is unknown", (t) => {
 });
 
 test("Custom task is called correctly", async (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const taskStub = sinon.stub();
 	graph.getExtension.returns({
 		getTask: () => taskStub,
@@ -387,7 +390,7 @@ test("Custom task is called correctly", async (t) => {
 	];
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
@@ -416,7 +419,7 @@ test("Custom task is called correctly", async (t) => {
 });
 
 test("Custom task with legacy spec version", async (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const taskStub = sinon.stub();
 	graph.getExtension.returns({
 		getTask: () => taskStub,
@@ -429,7 +432,7 @@ test("Custom task with legacy spec version", async (t) => {
 	];
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
@@ -457,7 +460,7 @@ test("Custom task with legacy spec version", async (t) => {
 });
 
 test("Custom task with specVersion 3.0", async (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const taskStub = sinon.stub();
 	graph.getExtension.returns({
 		getTask: () => taskStub,
@@ -470,7 +473,7 @@ test("Custom task with specVersion 3.0", async (t) => {
 	];
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
@@ -500,7 +503,7 @@ test("Custom task with specVersion 3.0", async (t) => {
 });
 
 test("Multiple custom tasks with same name are called correctly", async (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const taskStub1 = sinon.stub();
 	const taskStub2 = sinon.stub();
 	const taskStub3 = sinon.stub();
@@ -523,7 +526,7 @@ test("Multiple custom tasks with same name are called correctly", async (t) => {
 		{name: "myTask", afterTask: "myTask", configuration: "bird"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
@@ -599,10 +602,10 @@ test.serial("_addTask", async (t) => {
 	});
 	const TaskRunner = mock.reRequire("../../../lib/build/TaskRunner");
 
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	taskRunner._addTask("standardTask");
@@ -640,10 +643,10 @@ test.serial("_addTask with options", async (t) => {
 	const getTaskStub = sinon.stub(require("@ui5/builder").tasks.taskRepository, "getTask").returns({});
 	const TaskRunner = mock.reRequire("../../../lib/build/TaskRunner");
 
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	taskRunner._addTask("standardTask", {
@@ -683,10 +686,10 @@ test.serial("_addTask with options", async (t) => {
 });
 
 test("_addTask: Duplicate task", async (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	taskRunner._addTask("standardTask", {
@@ -703,10 +706,10 @@ test("_addTask: Duplicate task", async (t) => {
 });
 
 test("_addTask: Task already added to execution order", async (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 
 	taskRunner._taskExecutionOrder.push("standardTask");
@@ -721,74 +724,74 @@ test("_addTask: Task already added to execution order", async (t) => {
 });
 
 test("requiresDependencies: Custom Task", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.true(taskRunner.requiresDependencies(), "Project with custom task requires dependencies");
 });
 
 test("requiresDependencies: Default application", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("application");
 	project.getBundles = () => [];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.false(taskRunner.requiresDependencies(), "Default application project does not require dependencies");
 });
 
 test("requiresDependencies: Default library", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("library");
 	project.getBundles = () => [];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.true(taskRunner.requiresDependencies(), "Default library project requires dependencies");
 });
 
 test("requiresDependencies: Default theme-library", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("theme-library");
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.true(taskRunner.requiresDependencies(), "Default theme-library project requires dependencies");
 });
 
 test("requiresDependencies: Default module", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.false(taskRunner.requiresDependencies(), "Default module project does not require dependencies");
 });
 
 test("requiresBuild: has no build-manifest", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("library");
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.true(taskRunner.requiresBuild(), "Project without build-manifest requires to be build");
 });
 
 test("requiresBuild: has build-manifest", (t) => {
-	const {graph, taskUtil} = t.context;
+	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("library");
 	project.hasBuildManifest = () => true;
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	t.false(taskRunner.requiresBuild(), "Project with build-manifest does not require to be build");
 });

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -10,29 +10,41 @@ test.afterEach.always((t) => {
 const BuildContext = require("../../../../lib/build/helpers/BuildContext");
 
 test("Missing parameters", (t) => {
-	const error = t.throws(() => {
+	const error1 = t.throws(() => {
 		new BuildContext();
 	});
 
-	t.is(error.message, `Missing parameter 'graph'`, "Threw with expected error message");
+	t.is(error1.message, `Missing parameter 'graph'`, "Threw with expected error message");
+
+	const error2 = t.throws(() => {
+		new BuildContext("graph");
+	});
+
+	t.is(error2.message, `Missing parameter 'taskRepository'`, "Threw with expected error message");
 });
 
 test("getRootProject", (t) => {
 	const buildContext = new BuildContext({
 		getRoot: () => "pony"
-	});
+	}, "taskRepository");
 
 	t.is(buildContext.getRootProject(), "pony", "Returned correct value");
 });
 
 test("getGraph", (t) => {
-	const buildContext = new BuildContext("graph");
+	const buildContext = new BuildContext("graph", "taskRepository");
 
 	t.is(buildContext.getGraph(), "graph", "Returned correct value");
 });
 
+test("getTaskRepository", (t) => {
+	const buildContext = new BuildContext("graph", "taskRepository");
+
+	t.is(buildContext.getTaskRepository(), "taskRepository", "Returned correct value");
+});
+
 test("getBuildConfig: Default values", (t) => {
-	const buildContext = new BuildContext("graph");
+	const buildContext = new BuildContext("graph", "taskRepository");
 
 	t.deepEqual(buildContext.getBuildConfig(), {
 		selfContained: false,
@@ -51,7 +63,7 @@ test("getBuildConfig: Custom values", (t) => {
 				getType: () => "library"
 			};
 		}
-	}, {
+	}, "taskRepository", {
 		selfContained: true,
 		cssVariables: true,
 		jsdoc: true,
@@ -78,7 +90,7 @@ test("createBuildManifest not supported", (t) => {
 					getType: () => "pony"
 				};
 			}
-		}, {
+		}, "taskRepository", {
 			createBuildManifest: true
 		});
 	});
@@ -88,7 +100,7 @@ test("createBuildManifest not supported", (t) => {
 });
 
 test("getBuildOption", (t) => {
-	const buildContext = new BuildContext("graph", {
+	const buildContext = new BuildContext("graph", "taskRepository", {
 		cssVariables: "value",
 	});
 
@@ -110,8 +122,7 @@ test.serial("createProjectContext", (t) => {
 	mock("../../../../lib/build/helpers/ProjectBuildContext", DummyProjectContext);
 
 	const BuildContext = mock.reRequire("../../../../lib/build/helpers/BuildContext");
-	const testBuildContext = new BuildContext("graph"
-	);
+	const testBuildContext = new BuildContext("graph", "taskRepository");
 
 	const projectContext = testBuildContext.createProjectContext({
 		project: "project",
@@ -125,8 +136,7 @@ test.serial("createProjectContext", (t) => {
 });
 
 test("executeCleanupTasks", async (t) => {
-	const buildContext = new BuildContext("graph"
-	);
+	const buildContext = new BuildContext("graph", "taskRepository");
 
 	const executeCleanupTasks = sinon.stub().resolves();
 

--- a/test/lib/build/helpers/ProjectBuildContext.js
+++ b/test/lib/build/helpers/ProjectBuildContext.js
@@ -241,6 +241,7 @@ test.serial("getTaskRunner", (t) => {
 				graph: "graph",
 				project: "project",
 				taskUtil: "taskUtil",
+				taskRepository: "taskRepository",
 				parentLogger: "log",
 				buildConfig: "buildConfig",
 			}, "Created TaskRunner instance with correct parameters");
@@ -253,7 +254,8 @@ test.serial("getTaskRunner", (t) => {
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {
 			getGraph: () => "graph",
-			getBuildConfig: () => "buildConfig"
+			getBuildConfig: () => "buildConfig",
+			getTaskRepository: () => "taskRepository",
 		},
 		project: "project",
 		log: "log",

--- a/test/lib/build/helpers/TaskUtil.js
+++ b/test/lib/build/helpers/TaskUtil.js
@@ -1,0 +1,385 @@
+const test = require("ava");
+const sinon = require("sinon");
+const TaskUtil = require("../../../../lib/build/helpers/TaskUtil");
+
+test.afterEach.always((t) => {
+	sinon.restore();
+});
+
+const STANDARD_TAGS = Object.freeze({
+	IsDebugVariant: "ui5:IsDebugVariant",
+	HasDebugVariant: "ui5:HasDebugVariant",
+	OmitFromBuildResult: "ui5:OmitFromBuildResult",
+	IsBundle: "ui5:IsBundle"
+});
+
+test("Instantiation", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			// STANDARD_TAGS: ["some tag", "some other tag", "Thursday"]
+		}
+	});
+
+	t.deepEqual(taskUtil.STANDARD_TAGS, STANDARD_TAGS, "Correct standard tags exposed");
+});
+
+test("setTag", async (t) => {
+	const setTagStub = sinon.stub();
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			getResourceTagCollection: () => {
+				return {
+					setTag: setTagStub
+				};
+			}
+		}
+	});
+
+	const dummyResource = {};
+	taskUtil.setTag(dummyResource, "my tag", "my value");
+
+	t.is(setTagStub.callCount, 1, "ResourceTagCollection#setTag got called once");
+	t.deepEqual(setTagStub.getCall(0).args[0], dummyResource, "Correct resource parameter supplied");
+	t.deepEqual(setTagStub.getCall(0).args[1], "my tag", "Correct tag parameter supplied");
+	t.deepEqual(setTagStub.getCall(0).args[2], "my value", "Correct value parameter supplied");
+});
+
+test("getTag", async (t) => {
+	const getTagStub = sinon.stub().returns(42);
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			getResourceTagCollection: () => {
+				return {
+					getTag: getTagStub
+				};
+			}
+		}
+	});
+
+	const dummyResource = {};
+	const res = taskUtil.getTag(dummyResource, "my tag", "my value");
+
+	t.is(getTagStub.callCount, 1, "ResourceTagCollection#getTag got called once");
+	t.deepEqual(getTagStub.getCall(0).args[0], dummyResource, "Correct resource parameter supplied");
+	t.deepEqual(getTagStub.getCall(0).args[1], "my tag", "Correct tag parameter supplied");
+	t.is(res, 42, "Correct result");
+});
+
+test("clearTag", async (t) => {
+	const clearTagStub = sinon.stub();
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			getResourceTagCollection: () => {
+				return {
+					clearTag: clearTagStub
+				};
+			}
+		}
+	});
+
+	const dummyResource = {};
+	taskUtil.clearTag(dummyResource, "my tag", "my value");
+
+	t.is(clearTagStub.callCount, 1, "ResourceTagCollection#clearTag got called once");
+	t.deepEqual(clearTagStub.getCall(0).args[0], dummyResource, "Correct resource parameter supplied");
+	t.deepEqual(clearTagStub.getCall(0).args[1], "my tag", "Correct tag parameter supplied");
+});
+
+test("setTag with resource path is not supported anymore", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const err = t.throws(() => {
+		taskUtil.setTag("my resource", "my tag", "my value");
+	});
+	t.is(err.message,
+		"Deprecated parameter: Since UI5 Tooling 3.0, #setTag " +
+		"requires a resource instance. Strings are no longer accepted",
+		"Threw with expected error message");
+});
+
+test("getTag with resource path is not supported anymore", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const err = t.throws(() => {
+		taskUtil.getTag("my resource", "my tag", "my value");
+	});
+	t.is(err.message,
+		"Deprecated parameter: Since UI5 Tooling 3.0, #getTag " +
+		"requires a resource instance. Strings are no longer accepted",
+		"Threw with expected error message");
+});
+
+test("clearTag with resource path is not supported anymore", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const err = t.throws(() => {
+		taskUtil.clearTag("my resource", "my tag", "my value");
+	});
+	t.is(err.message,
+		"Deprecated parameter: Since UI5 Tooling 3.0, #clearTag " +
+		"requires a resource instance. Strings are no longer accepted",
+		"Threw with expected error message");
+});
+
+test("isRootProject", async (t) => {
+	const isRootProjectStub = sinon.stub().returns(true);
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			isRootProject: isRootProjectStub
+		}
+	});
+
+	const res = taskUtil.isRootProject();
+
+	t.is(isRootProjectStub.callCount, 1, "ProjectBuildContext#isRootProject got called once");
+	t.is(res, true, "Correct result");
+});
+
+test("getBuildOption", (t) => {
+	const getOptionStub = sinon.stub().returns("Pony");
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			getOption: getOptionStub
+		}
+	});
+
+	const res = taskUtil.getBuildOption("friend");
+
+	t.is(getOptionStub.callCount, 1, "ProjectBuildContext#getBuildOption got called once");
+	t.is(res, "Pony", "Correct result");
+});
+
+
+test("getProject", (t) => {
+	const getProjectStub = sinon.stub().returns("Pony farm!");
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			getProject: getProjectStub
+		}
+	});
+
+	const res = taskUtil.getProject("pony farm?");
+
+	t.is(getProjectStub.callCount, 1, "ProjectBuildContext#getProject got called once");
+	t.is(res, "Pony farm!", "Correct result");
+});
+
+test("registerCleanupTask", async (t) => {
+	const registerCleanupTaskStub = sinon.stub();
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			registerCleanupTask: registerCleanupTaskStub
+		}
+	});
+
+	taskUtil.registerCleanupTask("my callback");
+
+	t.is(registerCleanupTaskStub.callCount, 1, "ProjectBuildContext#registerCleanupTask got called once");
+	t.deepEqual(registerCleanupTaskStub.getCall(0).args[0], "my callback", "Correct callback parameter supplied");
+});
+
+test("getInterface: specVersion 1.0", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const interfacedTaskUtil = taskUtil.getInterface("1.0");
+
+	t.is(interfacedTaskUtil, undefined, "no interface provided");
+});
+
+test("getInterface: specVersion 2.2", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const interfacedTaskUtil = taskUtil.getInterface("2.2");
+
+	t.deepEqual(Object.keys(interfacedTaskUtil), [
+		"STANDARD_TAGS",
+		"setTag",
+		"clearTag",
+		"getTag",
+		"isRootProject",
+		"registerCleanupTask"
+	], "Correct methods are provided");
+
+	t.deepEqual(interfacedTaskUtil.STANDARD_TAGS, STANDARD_TAGS, "attribute STANDARD_TAGS is provided");
+	t.is(typeof interfacedTaskUtil.setTag, "function", "function setTag is provided");
+	t.is(typeof interfacedTaskUtil.clearTag, "function", "function clearTag is provided");
+	t.is(typeof interfacedTaskUtil.getTag, "function", "function getTag is provided");
+	t.is(typeof interfacedTaskUtil.isRootProject, "function", "function isRootProject is provided");
+	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
+});
+
+test("getInterface: specVersion 2.3", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const interfacedTaskUtil = taskUtil.getInterface("2.3");
+
+	t.deepEqual(Object.keys(interfacedTaskUtil), [
+		"STANDARD_TAGS",
+		"setTag",
+		"clearTag",
+		"getTag",
+		"isRootProject",
+		"registerCleanupTask"
+	], "Correct methods are provided");
+
+	t.deepEqual(interfacedTaskUtil.STANDARD_TAGS, STANDARD_TAGS, "attribute STANDARD_TAGS is provided");
+	t.is(typeof interfacedTaskUtil.setTag, "function", "function setTag is provided");
+	t.is(typeof interfacedTaskUtil.clearTag, "function", "function clearTag is provided");
+	t.is(typeof interfacedTaskUtil.getTag, "function", "function getTag is provided");
+	t.is(typeof interfacedTaskUtil.isRootProject, "function", "function isRootProject is provided");
+	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
+});
+
+test("getInterface: specVersion 2.4", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const interfacedTaskUtil = taskUtil.getInterface("2.4");
+
+	t.deepEqual(Object.keys(interfacedTaskUtil), [
+		"STANDARD_TAGS",
+		"setTag",
+		"clearTag",
+		"getTag",
+		"isRootProject",
+		"registerCleanupTask"
+	], "Correct methods are provided");
+
+	t.deepEqual(interfacedTaskUtil.STANDARD_TAGS, STANDARD_TAGS, "attribute STANDARD_TAGS is provided");
+	t.is(typeof interfacedTaskUtil.setTag, "function", "function setTag is provided");
+	t.is(typeof interfacedTaskUtil.clearTag, "function", "function clearTag is provided");
+	t.is(typeof interfacedTaskUtil.getTag, "function", "function getTag is provided");
+	t.is(typeof interfacedTaskUtil.isRootProject, "function", "function isRootProject is provided");
+	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
+});
+
+test("getInterface: specVersion 2.5", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const interfacedTaskUtil = taskUtil.getInterface("2.5");
+
+	t.deepEqual(Object.keys(interfacedTaskUtil), [
+		"STANDARD_TAGS",
+		"setTag",
+		"clearTag",
+		"getTag",
+		"isRootProject",
+		"registerCleanupTask"
+	], "Correct methods are provided");
+
+	t.deepEqual(interfacedTaskUtil.STANDARD_TAGS, STANDARD_TAGS, "attribute STANDARD_TAGS is provided");
+	t.is(typeof interfacedTaskUtil.setTag, "function", "function setTag is provided");
+	t.is(typeof interfacedTaskUtil.clearTag, "function", "function clearTag is provided");
+	t.is(typeof interfacedTaskUtil.getTag, "function", "function getTag is provided");
+	t.is(typeof interfacedTaskUtil.isRootProject, "function", "function isRootProject is provided");
+	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
+});
+
+test("getInterface: specVersion 2.6", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const interfacedTaskUtil = taskUtil.getInterface("2.6");
+
+	t.deepEqual(Object.keys(interfacedTaskUtil), [
+		"STANDARD_TAGS",
+		"setTag",
+		"clearTag",
+		"getTag",
+		"isRootProject",
+		"registerCleanupTask"
+	], "Correct methods are provided");
+
+	t.deepEqual(interfacedTaskUtil.STANDARD_TAGS, STANDARD_TAGS, "attribute STANDARD_TAGS is provided");
+	t.is(typeof interfacedTaskUtil.setTag, "function", "function setTag is provided");
+	t.is(typeof interfacedTaskUtil.clearTag, "function", "function clearTag is provided");
+	t.is(typeof interfacedTaskUtil.getTag, "function", "function getTag is provided");
+	t.is(typeof interfacedTaskUtil.isRootProject, "function", "function isRootProject is provided");
+	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
+});
+
+test("getInterface: specVersion 3.0", async (t) => {
+	const getProjectStub = sinon.stub().returns({
+		getName: () => "",
+		getVersion: () => "",
+		getNamespace: () => "",
+		hasBuildManifest: () => "", // Should not be exposed
+		getFrameworkVersion: () => "", // Should not be exposed
+	});
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			getProject: getProjectStub
+		}
+	});
+
+	const interfacedTaskUtil = taskUtil.getInterface("3.0");
+
+	t.deepEqual(Object.keys(interfacedTaskUtil), [
+		"STANDARD_TAGS",
+		"setTag",
+		"clearTag",
+		"getTag",
+		"isRootProject",
+		"registerCleanupTask",
+		"getProject"
+	], "Correct methods are provided");
+
+	t.deepEqual(interfacedTaskUtil.STANDARD_TAGS, STANDARD_TAGS, "attribute STANDARD_TAGS is provided");
+	t.is(typeof interfacedTaskUtil.setTag, "function", "function setTag is provided");
+	t.is(typeof interfacedTaskUtil.clearTag, "function", "function clearTag is provided");
+	t.is(typeof interfacedTaskUtil.getTag, "function", "function getTag is provided");
+	t.is(typeof interfacedTaskUtil.isRootProject, "function", "function isRootProject is provided");
+	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
+	t.is(typeof interfacedTaskUtil.getProject, "function", "function registerCleanupTask is provided");
+
+	const interfacedProject = interfacedTaskUtil.getProject("pony");
+	t.deepEqual(Object.keys(interfacedProject), [
+		"getName",
+		"getVersion",
+		"getNamespace",
+	], "Correct methods are provided");
+	t.is(typeof interfacedProject.getName, "function", "function getName is provided");
+	t.is(typeof interfacedProject.getVersion, "function", "function getVersion is provided");
+	t.is(typeof interfacedProject.getNamespace, "function", "function getNamespace is provided");
+});
+
+test("getInterface: specVersion undefined", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+
+	const err = t.throws(() => {
+		taskUtil.getInterface();
+	});
+
+	t.is(err.message, "TaskUtil: Unknown or unsupported Specification Version undefined",
+		"Throw with correct error message");
+});
+
+test("getInterface: specVersion unknown", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {}
+	});
+	const err = t.throws(() => {
+		taskUtil.getInterface("1.5");
+	});
+
+	t.is(err.message, "TaskUtil: Unknown or unsupported Specification Version 1.5",
+		"Throw with correct error message");
+});


### PR DESCRIPTION
TaskUtil seems to be more influenced by ui5-project. To make it easier
to test and change with ui5-project changes, move it to this repository.
This also further decouples ui5-project from ui5-builder.

Now, ui5-project only requires the task repository from ui5-builder.
Therefore add a new, private API to ProjectGraph, allowing injection of
the module by ui5-builder tests. This ensures that ui5-builder does not
accidentially tests its build with a different version of itself.