### PR TITLE
[FIX] ProjectBuilder: Fix verbose logging for already built projects

### DIFF
--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -133,7 +133,7 @@ class ProjectBuilder {
 						const projectName = projectBuildContext.getProject().getName();
 						let msg;
 						if (alreadyBuilt.includes(projectName)) {
-							const buildMetadata = projectBuildContext.getTaskRunner().getFormattedBuildMetadata();
+							const buildMetadata = projectBuildContext.getTaskRunner().getBuildMetadata();
 							const ts = new Date(buildMetadata.timestamp).toUTCString();
 							msg = `*> ${projectName} /// already built at ${ts}`;
 						} else {

--- a/lib/graph/Module.js
+++ b/lib/graph/Module.js
@@ -364,6 +364,7 @@ class Module {
 			throw validationErrors[0];
 		}
 
+		log.verbose(`Configuration for module ${this.getId()} is provided in YAML file at ${configPath}`);
 		return configs;
 	}
 
@@ -374,6 +375,7 @@ class Module {
 			log.verbose(`Could not find any build manifest in module ${this.getId()}`);
 			return [];
 		}
+		log.verbose(`Configuration for module ${this.getId()} is provided in build manifest`);
 
 		// This function is expected to return the configuration of a project, so we add the buildManifest metadata
 		// to a temporary attribute of the project configuration and retrieve it later for Specification creation

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -235,7 +235,7 @@ test.serial("build: Multiple projects", async (t) => {
 	const requiresBuildAStub = sinon.stub().returns(true);
 	const requiresBuildBStub = sinon.stub().returns(false);
 	const requiresBuildCStub = sinon.stub().returns(true);
-	const getFormattedBuildMetadataStub = sinon.stub().returns({
+	const getBuildMetadataStub = sinon.stub().returns({
 		timestamp: "2022-07-28T12:00:00.000Z",
 		age: "xx days"
 	});
@@ -251,7 +251,7 @@ test.serial("build: Multiple projects", async (t) => {
 		getTaskRunner: () => {
 			return {
 				requiresBuild: requiresBuildBStub,
-				getFormattedBuildMetadata: getFormattedBuildMetadataStub
+				getBuildMetadata: getBuildMetadataStub
 			};
 		},
 		getProject: sinon.stub().returns(getMockProject("library", "b"))


### PR DESCRIPTION
Function was renamed in TaskRunner but mock was not updated.

Enhanced ui5-builder integration tests to cover this:
https://github.com/SAP/ui5-builder/pull/779