### PR TITLE
[INTERNAL] use eslint-plugin-ava and cleanup test-suite

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,10 @@ module.exports = {
 		"node": true,
 		"es2021": true
 	},
-	"extends": ["eslint:recommended", "google"],
+	"extends": ["eslint:recommended", "plugin:ava/recommended", "google"],
 	"plugins": [
-		"jsdoc"
+		"jsdoc",
+		"ava"
 	],
 	"rules": {
 		"indent": [
@@ -64,7 +65,10 @@ module.exports = {
 		"jsdoc/require-returns": 0,
 		"jsdoc/require-returns-description": 0,
 		"jsdoc/require-returns-type": 2,
-		"jsdoc/valid-types": 0
+		"jsdoc/valid-types": 0,
+		// ava/assertion-arguments reports concatenated strings in a assertion message as an issue
+		// See: https://github.com/avajs/eslint-plugin-ava/issues/332
+		"ava/assertion-arguments": 0
 	},
 	"settings": {
 		"jsdoc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
 				"docdash": "^1.2.0",
 				"eslint": "^8.7.0",
 				"eslint-config-google": "^0.14.0",
+				"eslint-plugin-ava": "^13.0.2",
 				"eslint-plugin-jsdoc": "^37.6.3",
 				"istanbul-lib-coverage": "^3.2.0",
 				"istanbul-lib-instrument": "^4.0.3",
@@ -2881,6 +2882,18 @@
 				"once": "^1.4.0"
 			}
 		},
+		"node_modules/enhance-visitors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+			"integrity": "sha512-+29eJLiUixTEDRaZ35Vu8jP3gPLNcQQkQkOQjLp2X+6cZGGPDD/uasbFzvLsJKnGZnvmyZ0srxudwOtskHeIDA==",
+			"dev": true,
+			"dependencies": {
+				"lodash": "^4.13.1"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -3123,6 +3136,119 @@
 				"eslint": ">=5.16.0"
 			}
 		},
+		"node_modules/eslint-plugin-ava": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"dev": true,
+			"dependencies": {
+				"enhance-visitors": "^1.0.0",
+				"eslint-utils": "^3.0.0",
+				"espree": "^9.0.0",
+				"espurify": "^2.1.1",
+				"import-modules": "^2.1.0",
+				"micro-spelling-correcter": "^1.1.1",
+				"pkg-dir": "^5.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.22 <13 || >=14.17 <15 || >=16.4"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.22.0"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/pkg-dir": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/eslint-plugin-jsdoc": {
 			"version": "37.9.7",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
@@ -3266,6 +3392,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/espurify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
+			"integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
+			"dev": true
 		},
 		"node_modules/esquery": {
 			"version": "1.4.0",
@@ -4147,6 +4279,18 @@
 			"bin": {
 				"import-local-fixture": "fixtures/cli.js"
 			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-modules": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+			"integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -5219,6 +5363,12 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/micro-spelling-correcter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+			"integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
+			"dev": true
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.5",
@@ -8736,6 +8886,18 @@
 			"dependencies": {
 				"buffer-crc32": "~0.2.3"
 			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		}
 	},
 	"dependencies": {
@@ -10971,6 +11133,15 @@
 				"once": "^1.4.0"
 			}
 		},
+		"enhance-visitors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+			"integrity": "sha512-+29eJLiUixTEDRaZ35Vu8jP3gPLNcQQkQkOQjLp2X+6cZGGPDD/uasbFzvLsJKnGZnvmyZ0srxudwOtskHeIDA==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.13.1"
+			}
+		},
 		"entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -11199,6 +11370,82 @@
 			"dev": true,
 			"requires": {}
 		},
+		"eslint-plugin-ava": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"dev": true,
+			"requires": {
+				"enhance-visitors": "^1.0.0",
+				"eslint-utils": "^3.0.0",
+				"espree": "^9.0.0",
+				"espurify": "^2.1.1",
+				"import-modules": "^2.1.0",
+				"micro-spelling-correcter": "^1.1.1",
+				"pkg-dir": "^5.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+					"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
+			}
+		},
 		"eslint-plugin-jsdoc": {
 			"version": "37.9.7",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
@@ -11269,6 +11516,12 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"espurify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
+			"integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
 			"dev": true
 		},
 		"esquery": {
@@ -11978,6 +12231,12 @@
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
 			}
+		},
+		"import-modules": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+			"integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
@@ -12795,6 +13054,12 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+		},
+		"micro-spelling-correcter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+			"integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "4.0.5",
@@ -15564,6 +15829,12 @@
 			"requires": {
 				"buffer-crc32": "~0.2.3"
 			}
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
 		"eslint": "^8.7.0",
 		"eslint-config-google": "^0.14.0",
 		"eslint-plugin-jsdoc": "^37.6.3",
+		"eslint-plugin-ava": "^13.0.2",
 		"istanbul-lib-coverage": "^3.2.0",
 		"istanbul-lib-instrument": "^4.0.3",
 		"istanbul-lib-report": "^3.0.0",

--- a/test/lib/build/TaskRunner.js
+++ b/test/lib/build/TaskRunner.js
@@ -685,7 +685,7 @@ test.serial("_addTask with options", async (t) => {
 	mock.stopAll();
 });
 
-test("_addTask: Duplicate task", async (t) => {
+test("_addTask: Duplicate task", (t) => {
 	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 	const taskRunner = new TaskRunner({
@@ -705,7 +705,7 @@ test("_addTask: Duplicate task", async (t) => {
 		"Threw with expected error message");
 });
 
-test("_addTask: Task already added to execution order", async (t) => {
+test("_addTask: Task already added to execution order", (t) => {
 	const {graph, taskUtil, taskRepository} = t.context;
 	const project = getMockProject("module");
 	const taskRunner = new TaskRunner({

--- a/test/lib/build/definitions/application.js
+++ b/test/lib/build/definitions/application.js
@@ -37,7 +37,7 @@ test.beforeEach((t) => {
 	t.context.getTask = sinon.stub();
 });
 
-test("Standard build", async (t) => {
+test("Standard build", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	const tasks = application({
 		project, taskUtil, getTask
@@ -103,7 +103,7 @@ test("Standard build", async (t) => {
 	t.is(taskUtil.getBuildOption.callCount, 0, "taskUtil#getBuildOption has not been called");
 });
 
-test("Standard build with legacy spec version", async (t) => {
+test("Standard build with legacy spec version", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getSpecVersion = () => "0.1";
 	const generateBundleTaskStub = sinon.stub();
@@ -346,7 +346,7 @@ test("Custom bundles", async (t) => {
 	}, "generateBundle task got called with correct arguments");
 });
 
-test("Minification excludes", async (t) => {
+test("Minification excludes", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getMinificationExcludes = () => ["**.html"];
 
@@ -366,7 +366,7 @@ test("Minification excludes", async (t) => {
 	}, "Correct minify task definition");
 });
 
-test("Minification excludes not applied for legacy specVersion", async (t) => {
+test("Minification excludes not applied for legacy specVersion", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getSpecVersion = () => "2.5";
 	project.getMinificationExcludes = () => ["**.html"];
@@ -386,7 +386,7 @@ test("Minification excludes not applied for legacy specVersion", async (t) => {
 	}, "Correct minify task definition");
 });
 
-test("generateComponentPreload with custom paths, excludes and custom bundle", async (t) => {
+test("generateComponentPreload with custom paths, excludes and custom bundle", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getBundles = () => [{
 		bundleDefinition: {
@@ -433,7 +433,7 @@ test("generateComponentPreload with custom paths, excludes and custom bundle", a
 	}, "Correct generateComponentPreload task definition");
 });
 
-test("generateComponentPreload with custom namespaces and excludes", async (t) => {
+test("generateComponentPreload with custom namespaces and excludes", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getComponentPreloadNamespaces = () => [
 		"project/b/componentA",
@@ -459,7 +459,7 @@ test("generateComponentPreload with custom namespaces and excludes", async (t) =
 	}, "Correct generateComponentPreload task definition");
 });
 
-test("generateComponentPreload with excludes", async (t) => {
+test("generateComponentPreload with excludes", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getComponentPreloadExcludes = () => ["project/b/componentA/dir/**"];
 

--- a/test/lib/build/definitions/library.js
+++ b/test/lib/build/definitions/library.js
@@ -151,7 +151,7 @@ test("Standard build", async (t) => {
 		"taskUtil#getBuildOption got called with correct argument");
 });
 
-test("Standard build with legacy spec version", async (t) => {
+test("Standard build with legacy spec version", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getSpecVersion = () => "0.1";
 
@@ -414,7 +414,7 @@ test("Custom bundles", async (t) => {
 	}, "generateBundle task got called with correct arguments");
 });
 
-test("Minification excludes", async (t) => {
+test("Minification excludes", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getMinificationExcludes = () => ["**.html"];
 
@@ -434,7 +434,7 @@ test("Minification excludes", async (t) => {
 	}, "Correct minify task definition");
 });
 
-test("Minification excludes not applied for legacy specVersion", async (t) => {
+test("Minification excludes not applied for legacy specVersion", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getSpecVersion = () => "2.5";
 	project.getMinificationExcludes = () => ["**.html"];
@@ -454,7 +454,7 @@ test("Minification excludes not applied for legacy specVersion", async (t) => {
 	}, "Correct minify task definition");
 });
 
-test("generateComponentPreload with custom paths, excludes and custom bundle", async (t) => {
+test("generateComponentPreload with custom paths, excludes and custom bundle", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getBundles = () => [{
 		bundleDefinition: {
@@ -501,7 +501,7 @@ test("generateComponentPreload with custom paths, excludes and custom bundle", a
 	}, "Correct generateComponentPreload task definition");
 });
 
-test("generateComponentPreload with custom namespaces and excludes", async (t) => {
+test("generateComponentPreload with custom namespaces and excludes", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getComponentPreloadNamespaces = () => [
 		"project/b/componentA",
@@ -527,7 +527,7 @@ test("generateComponentPreload with custom namespaces and excludes", async (t) =
 	}, "Correct generateComponentPreload task definition");
 });
 
-test("generateLibraryPreload with excludes", async (t) => {
+test("generateLibraryPreload with excludes", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getLibraryPreloadExcludes = () => ["project/b/dir/**"];
 
@@ -544,7 +544,7 @@ test("generateLibraryPreload with excludes", async (t) => {
 	}, "Correct generateLibraryPreload task definition");
 });
 
-test("buildThemes: Project is not root", async (t) => {
+test("buildThemes: Project is not root", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	taskUtil.isRootProject.returns(false);
 
@@ -564,7 +564,7 @@ test("buildThemes: Project is not root", async (t) => {
 		}
 	}, "Correct buildThemes task definition");
 });
-test("buildThemes: CSS Variables enabled", async (t) => {
+test("buildThemes: CSS Variables enabled", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	taskUtil.getBuildOption.returns(true);
 

--- a/test/lib/build/definitions/module.js
+++ b/test/lib/build/definitions/module.js
@@ -2,7 +2,7 @@ const test = require("ava");
 
 const moduleDefinition = require("../../../../lib/build/definitions/module");
 
-test("Standard build", async (t) => {
+test("Standard build", (t) => {
 	const tasks = moduleDefinition({});
 	t.is(tasks.size, 0, "No tasks returned");
 });

--- a/test/lib/build/definitions/themeLibrary.js
+++ b/test/lib/build/definitions/themeLibrary.js
@@ -37,7 +37,7 @@ test.beforeEach((t) => {
 	t.context.getTask = sinon.stub();
 });
 
-test("Standard build", async (t) => {
+test("Standard build", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 
 	const tasks = themeLibrary({
@@ -82,7 +82,7 @@ test("Standard build", async (t) => {
 		"taskUtil#getBuildOption got called with correct argument");
 });
 
-test("Standard build for non root project", async (t) => {
+test("Standard build for non root project", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	taskUtil.isRootProject.returns(false);
 
@@ -128,7 +128,7 @@ test("Standard build for non root project", async (t) => {
 		"taskUtil#getBuildOption got called with correct argument");
 });
 
-test("CSS variables enabled", async (t) => {
+test("CSS variables enabled", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	taskUtil.getBuildOption.returns(true);
 

--- a/test/lib/build/helpers/TaskUtil.js
+++ b/test/lib/build/helpers/TaskUtil.js
@@ -13,7 +13,7 @@ const STANDARD_TAGS = Object.freeze({
 	IsBundle: "ui5:IsBundle"
 });
 
-test("Instantiation", async (t) => {
+test("Instantiation", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {
 			// STANDARD_TAGS: ["some tag", "some other tag", "Thursday"]
@@ -23,7 +23,7 @@ test("Instantiation", async (t) => {
 	t.deepEqual(taskUtil.STANDARD_TAGS, STANDARD_TAGS, "Correct standard tags exposed");
 });
 
-test("setTag", async (t) => {
+test("setTag", (t) => {
 	const setTagStub = sinon.stub();
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {
@@ -40,11 +40,11 @@ test("setTag", async (t) => {
 
 	t.is(setTagStub.callCount, 1, "ResourceTagCollection#setTag got called once");
 	t.deepEqual(setTagStub.getCall(0).args[0], dummyResource, "Correct resource parameter supplied");
-	t.deepEqual(setTagStub.getCall(0).args[1], "my tag", "Correct tag parameter supplied");
-	t.deepEqual(setTagStub.getCall(0).args[2], "my value", "Correct value parameter supplied");
+	t.is(setTagStub.getCall(0).args[1], "my tag", "Correct tag parameter supplied");
+	t.is(setTagStub.getCall(0).args[2], "my value", "Correct value parameter supplied");
 });
 
-test("getTag", async (t) => {
+test("getTag", (t) => {
 	const getTagStub = sinon.stub().returns(42);
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {
@@ -61,11 +61,11 @@ test("getTag", async (t) => {
 
 	t.is(getTagStub.callCount, 1, "ResourceTagCollection#getTag got called once");
 	t.deepEqual(getTagStub.getCall(0).args[0], dummyResource, "Correct resource parameter supplied");
-	t.deepEqual(getTagStub.getCall(0).args[1], "my tag", "Correct tag parameter supplied");
+	t.is(getTagStub.getCall(0).args[1], "my tag", "Correct tag parameter supplied");
 	t.is(res, 42, "Correct result");
 });
 
-test("clearTag", async (t) => {
+test("clearTag", (t) => {
 	const clearTagStub = sinon.stub();
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {
@@ -82,10 +82,10 @@ test("clearTag", async (t) => {
 
 	t.is(clearTagStub.callCount, 1, "ResourceTagCollection#clearTag got called once");
 	t.deepEqual(clearTagStub.getCall(0).args[0], dummyResource, "Correct resource parameter supplied");
-	t.deepEqual(clearTagStub.getCall(0).args[1], "my tag", "Correct tag parameter supplied");
+	t.is(clearTagStub.getCall(0).args[1], "my tag", "Correct tag parameter supplied");
 });
 
-test("setTag with resource path is not supported anymore", async (t) => {
+test("setTag with resource path is not supported anymore", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -99,7 +99,7 @@ test("setTag with resource path is not supported anymore", async (t) => {
 		"Threw with expected error message");
 });
 
-test("getTag with resource path is not supported anymore", async (t) => {
+test("getTag with resource path is not supported anymore", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -113,7 +113,7 @@ test("getTag with resource path is not supported anymore", async (t) => {
 		"Threw with expected error message");
 });
 
-test("clearTag with resource path is not supported anymore", async (t) => {
+test("clearTag with resource path is not supported anymore", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -127,7 +127,7 @@ test("clearTag with resource path is not supported anymore", async (t) => {
 		"Threw with expected error message");
 });
 
-test("isRootProject", async (t) => {
+test("isRootProject", (t) => {
 	const isRootProjectStub = sinon.stub().returns(true);
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {
@@ -170,7 +170,7 @@ test("getProject", (t) => {
 	t.is(res, "Pony farm!", "Correct result");
 });
 
-test("registerCleanupTask", async (t) => {
+test("registerCleanupTask", (t) => {
 	const registerCleanupTaskStub = sinon.stub();
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {
@@ -181,10 +181,10 @@ test("registerCleanupTask", async (t) => {
 	taskUtil.registerCleanupTask("my callback");
 
 	t.is(registerCleanupTaskStub.callCount, 1, "ProjectBuildContext#registerCleanupTask got called once");
-	t.deepEqual(registerCleanupTaskStub.getCall(0).args[0], "my callback", "Correct callback parameter supplied");
+	t.is(registerCleanupTaskStub.getCall(0).args[0], "my callback", "Correct callback parameter supplied");
 });
 
-test("getInterface: specVersion 1.0", async (t) => {
+test("getInterface: specVersion 1.0", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -194,7 +194,7 @@ test("getInterface: specVersion 1.0", async (t) => {
 	t.is(interfacedTaskUtil, undefined, "no interface provided");
 });
 
-test("getInterface: specVersion 2.2", async (t) => {
+test("getInterface: specVersion 2.2", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -218,7 +218,7 @@ test("getInterface: specVersion 2.2", async (t) => {
 	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
 });
 
-test("getInterface: specVersion 2.3", async (t) => {
+test("getInterface: specVersion 2.3", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -242,7 +242,7 @@ test("getInterface: specVersion 2.3", async (t) => {
 	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
 });
 
-test("getInterface: specVersion 2.4", async (t) => {
+test("getInterface: specVersion 2.4", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -266,7 +266,7 @@ test("getInterface: specVersion 2.4", async (t) => {
 	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
 });
 
-test("getInterface: specVersion 2.5", async (t) => {
+test("getInterface: specVersion 2.5", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -290,7 +290,7 @@ test("getInterface: specVersion 2.5", async (t) => {
 	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
 });
 
-test("getInterface: specVersion 2.6", async (t) => {
+test("getInterface: specVersion 2.6", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -314,7 +314,7 @@ test("getInterface: specVersion 2.6", async (t) => {
 	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
 });
 
-test("getInterface: specVersion 3.0", async (t) => {
+test("getInterface: specVersion 3.0", (t) => {
 	const getProjectStub = sinon.stub().returns({
 		getName: () => "",
 		getVersion: () => "",
@@ -359,7 +359,7 @@ test("getInterface: specVersion 3.0", async (t) => {
 	t.is(typeof interfacedProject.getNamespace, "function", "function getNamespace is provided");
 });
 
-test("getInterface: specVersion undefined", async (t) => {
+test("getInterface: specVersion undefined", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});
@@ -372,7 +372,7 @@ test("getInterface: specVersion undefined", async (t) => {
 		"Throw with correct error message");
 });
 
-test("getInterface: specVersion unknown", async (t) => {
+test("getInterface: specVersion unknown", (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {}
 	});

--- a/test/lib/generateProjectGraph.usingObject.js
+++ b/test/lib/generateProjectGraph.usingObject.js
@@ -369,7 +369,7 @@ test("Missing second-level dependencies", async (t) => {
 			path: path.join(applicationAPath, "node_modules", "library.d")
 		}]
 	});
-	return t.notThrowsAsync(projectGraphFromTree({dependencyTree: tree}),
+	await t.notThrowsAsync(projectGraphFromTree({dependencyTree: tree}),
 		"Gracefully accepted project with no dependencies attribute");
 });
 
@@ -1427,6 +1427,7 @@ test("Project with project-shim extension with collection", async (t) => {
 });
 
 // TODO: Fixme
+// eslint-disable-next-line ava/no-skip-test
 test.skip("Project with project-shim extension with self-containing collection shim", async (t) => {
 	const tree = {
 		id: "application.a.id",

--- a/test/lib/graph/Module.js
+++ b/test/lib/graph/Module.js
@@ -29,7 +29,7 @@ const archiveLibProjectInput = {
 	modulePath: buildDescriptionLibraryAPath
 };
 
-test("Instantiate a basic module", async (t) => {
+test("Instantiate a basic module", (t) => {
 	const ui5Module = new Module(basicModuleInput);
 	t.is(ui5Module.getId(), "application.a.id", "Should return correct ID");
 	t.is(ui5Module.getVersion(), "1.0.0", "Should return correct version");
@@ -147,7 +147,7 @@ test("Use configuration from absolute configPath", async (t) => {
 	t.is(extensions.length, 0, "Should return no extensions");
 });
 
-test("configuration and configPath must not be provided together", async (t) => {
+test("configuration and configPath must not be provided together", (t) => {
 	// 'configuration' as object
 	t.throws(() => {
 		new Module({

--- a/test/lib/graph/ProjectGraph.js
+++ b/test/lib/graph/ProjectGraph.js
@@ -81,7 +81,7 @@ test.afterEach.always((t) => {
 	t.context.sinon.restore();
 });
 
-test("Instantiate a basic project graph", async (t) => {
+test("Instantiate a basic project graph", (t) => {
 	const {ProjectGraph} = t.context;
 	t.notThrows(() => {
 		new ProjectGraph({
@@ -90,7 +90,7 @@ test("Instantiate a basic project graph", async (t) => {
 	}, "Should not throw");
 });
 
-test("Instantiate a basic project with missing parameter rootProjectName", async (t) => {
+test("Instantiate a basic project with missing parameter rootProjectName", (t) => {
 	const {ProjectGraph} = t.context;
 	const error = t.throws(() => {
 		new ProjectGraph({});
@@ -110,7 +110,7 @@ test("getRoot", async (t) => {
 	t.is(res, project, "Should return correct root project");
 });
 
-test("getRoot: Root not added to graph", async (t) => {
+test("getRoot: Root not added to graph", (t) => {
 	const {ProjectGraph} = t.context;
 	const graph = new ProjectGraph({
 		rootProjectName: "application.a"
@@ -187,7 +187,7 @@ test("addProject: Add project with integer-like name", async (t) => {
 		"Should throw with expected error message");
 });
 
-test("getProject: Project is not in graph", async (t) => {
+test("getProject: Project is not in graph", (t) => {
 	const {ProjectGraph} = t.context;
 	const graph = new ProjectGraph({
 		rootProjectName: "my root project"
@@ -259,7 +259,7 @@ test("addExtension: Add extension with integer-like name", async (t) => {
 		"Should throw with expected error message");
 });
 
-test("getExtension: Project is not in graph", async (t) => {
+test("getExtension: Project is not in graph", (t) => {
 	const {ProjectGraph} = t.context;
 	const graph = new ProjectGraph({
 		rootProjectName: "my root project"
@@ -449,7 +449,7 @@ test("getDependencies: Project without dependencies", async (t) => {
 		"Should return an empty array for project without dependencies");
 });
 
-test("getDependencies: Unknown project", async (t) => {
+test("getDependencies: Unknown project", (t) => {
 	const {ProjectGraph} = t.context;
 	const graph = new ProjectGraph({
 		rootProjectName: "my root project"
@@ -1035,7 +1035,7 @@ test("join", async (t) => {
 	t.is(graph1.getExtension("extension.b"), extensionB, "Should return correct joined extension");
 });
 
-test("join: Seals incoming graph", async (t) => {
+test("join: Seals incoming graph", (t) => {
 	const {ProjectGraph} = t.context;
 	const graph1 = new ProjectGraph({
 		rootProjectName: "library.a"
@@ -1051,7 +1051,7 @@ test("join: Seals incoming graph", async (t) => {
 	t.is(sealSpy.callCount, 1, "Should call seal() on incoming graph once");
 });
 
-test("join: Incoming graph already sealed", async (t) => {
+test("join: Incoming graph already sealed", (t) => {
 	const {ProjectGraph} = t.context;
 	const graph1 = new ProjectGraph({
 		rootProjectName: "library.a"

--- a/test/lib/graph/ShimCollection.js
+++ b/test/lib/graph/ShimCollection.js
@@ -2,7 +2,7 @@ const test = require("ava");
 
 const ShimCollection = require("../../../lib/graph/ShimCollection");
 
-test("Add shims", async (t) => {
+test("Add shims", (t) => {
 	const collection = new ShimCollection();
 	collection.addProjectShim({
 		getName: () => "shim-1",

--- a/test/lib/graph/helpers/ui5Framework.integration.js
+++ b/test/lib/graph/helpers/ui5Framework.integration.js
@@ -206,6 +206,7 @@ function defineTest(testName, {
 
 		sinon.stub(Module.prototype, "_readConfigFile")
 			.callsFake(async function() {
+				// eslint-disable-next-line no-invalid-this
 				switch (this.getPath()) {
 				case path.join(ui5PackagesBaseDir, npmScope, "sap.ui.lib1",
 					frameworkName === "SAPUI5" ? "1.75.1" : "1.75.0"):
@@ -275,6 +276,7 @@ function defineTest(testName, {
 				default:
 					throw new Error(
 						"Module#_readConfigFile stub called with unknown project: " +
+						// eslint-disable-next-line no-invalid-this
 						(this.getId())
 					);
 				}

--- a/test/lib/graph/projectGraphBuilder.js
+++ b/test/lib/graph/projectGraphBuilder.js
@@ -449,7 +449,7 @@ test("Project defining a collection shim for itself should be ignored", async (t
 		"library.c"
 	]);
 	const p = graph.getProject("library.a");
-	t.deepEqual(p.getCustomConfiguration(), undefined,
+	t.is(p.getCustomConfiguration(), undefined,
 		"No configuration from collection project has been applied");
 });
 

--- a/test/lib/specifications/ComponentProject.js
+++ b/test/lib/specifications/ComponentProject.js
@@ -144,7 +144,7 @@ test("_resolveMavenPlaceholder: resolves maven placeholder from first POM level"
 	});
 
 	const res = await project._resolveMavenPlaceholder("${mvn-pony}");
-	t.deepEqual(res, "unicorn", "Resolved placeholder correctly");
+	t.is(res, "unicorn", "Resolved placeholder correctly");
 });
 
 test("_resolveMavenPlaceholder: resolves maven placeholder from deeper POM level", async (t) => {
@@ -158,7 +158,7 @@ test("_resolveMavenPlaceholder: resolves maven placeholder from deeper POM level
 	});
 
 	const res = await project._resolveMavenPlaceholder("${mvn-pony.some.id}");
-	t.deepEqual(res, "unicorn", "Resolved placeholder correctly");
+	t.is(res, "unicorn", "Resolved placeholder correctly");
 });
 
 test("_resolveMavenPlaceholder: can't resolve from POM", async (t) => {
@@ -176,7 +176,7 @@ test("_resolveMavenPlaceholder: provided value is no placeholder", async (t) => 
 	const project = await Specification.create(basicProjectInput);
 
 	const err = await t.throwsAsync(project._resolveMavenPlaceholder("My ${mvn-pony}"));
-	t.deepEqual(err.message,
+	t.is(err.message,
 		`"My \${mvn-pony}" is not a maven placeholder`,
 		"Rejected with correct error message");
 });
@@ -190,7 +190,7 @@ test("_getPom: reads correctly", async (t) => {
 	const project = await Specification.create(projectInput);
 
 	const res = await project._getPom();
-	t.deepEqual(res.project.modelVersion, "4.0.0", "pom.xml content has been read");
+	t.is(res.project.modelVersion, "4.0.0", "pom.xml content has been read");
 });
 
 test.serial("_getPom: fs read error", async (t) => {
@@ -227,5 +227,5 @@ test.serial("_getPom: result is cached", async (t) => {
 	res = await project._getPom();
 	t.deepEqual(res, {pony: "no unicorn"}, "Correct result on second call");
 
-	t.deepEqual(byPathStub.callCount, 1, "getRootReader().byPath got called exactly once (and then cached)");
+	t.is(byPathStub.callCount, 1, "getRootReader().byPath got called exactly once (and then cached)");
 });

--- a/test/lib/specifications/types/Application.js
+++ b/test/lib/specifications/types/Application.js
@@ -196,7 +196,7 @@ test("_getNamespaceFromManifestJson: No 'sap.app' configuration found", async (t
 	sinon.stub(project, "_getManifest").resolves({});
 
 	const error = await t.throwsAsync(project._getNamespaceFromManifestJson());
-	t.deepEqual(error.message, "No sap.app/id configuration found in manifest.json of project application.a",
+	t.is(error.message, "No sap.app/id configuration found in manifest.json of project application.a",
 		"Rejected with correct error message");
 });
 
@@ -205,7 +205,7 @@ test("_getNamespaceFromManifestJson: No application id in 'sap.app' configuratio
 	sinon.stub(project, "_getManifest").resolves({"sap.app": {}});
 
 	const error = await t.throwsAsync(project._getNamespaceFromManifestJson());
-	t.deepEqual(error.message, "No sap.app/id configuration found in manifest.json of project application.a");
+	t.is(error.message, "No sap.app/id configuration found in manifest.json of project application.a");
 });
 
 test("_getNamespaceFromManifestJson: set namespace to id", async (t) => {
@@ -213,7 +213,7 @@ test("_getNamespaceFromManifestJson: set namespace to id", async (t) => {
 	sinon.stub(project, "_getManifest").resolves({"sap.app": {id: "my.id"}});
 
 	const namespace = await project._getNamespaceFromManifestJson();
-	t.deepEqual(namespace, "my/id", "Returned correct namespace");
+	t.is(namespace, "my/id", "Returned correct namespace");
 });
 
 test("_getNamespaceFromManifestAppDescVariant: No 'id' property found", async (t) => {
@@ -221,7 +221,7 @@ test("_getNamespaceFromManifestAppDescVariant: No 'id' property found", async (t
 	sinon.stub(project, "_getManifest").resolves({});
 
 	const error = await t.throwsAsync(project._getNamespaceFromManifestAppDescVariant());
-	t.deepEqual(error.message, `No "id" property found in manifest.appdescr_variant of project application.a`,
+	t.is(error.message, `No "id" property found in manifest.appdescr_variant of project application.a`,
 		"Rejected with correct error message");
 });
 
@@ -230,7 +230,7 @@ test("_getNamespaceFromManifestAppDescVariant: set namespace to id", async (t) =
 	sinon.stub(project, "_getManifest").resolves({id: "my.id"});
 
 	const namespace = await project._getNamespaceFromManifestAppDescVariant();
-	t.deepEqual(namespace, "my/id", "Returned correct namespace");
+	t.is(namespace, "my/id", "Returned correct namespace");
 });
 
 test("_getNamespace: Correct fallback to manifest.appdescr_variant if manifest.json is missing", async (t) => {
@@ -240,7 +240,7 @@ test("_getNamespace: Correct fallback to manifest.appdescr_variant if manifest.j
 		.onSecondCall().resolves({id: "my.id"});
 
 	const namespace = await project._getNamespace();
-	t.deepEqual(namespace, "my/id", "Returned correct namespace");
+	t.is(namespace, "my/id", "Returned correct namespace");
 	t.is(_getManifestStub.callCount, 2, "_getManifest called exactly twice");
 	t.is(_getManifestStub.getCall(0).args[0], "/manifest.json", "_getManifest called for manifest.json first");
 	t.is(_getManifestStub.getCall(1).args[0], "/manifest.appdescr_variant",
@@ -254,7 +254,7 @@ test("_getNamespace: Correct error message if fallback to manifest.appdescr_vari
 		.onSecondCall().rejects(new Error("EPON: Pony Error"));
 
 	const error = await t.throwsAsync(project._getNamespace());
-	t.deepEqual(error.message, "EPON: Pony Error",
+	t.is(error.message, "EPON: Pony Error",
 		"Rejected with correct error message");
 	t.is(_getManifestStub.callCount, 2, "_getManifest called exactly twice");
 	t.is(_getManifestStub.getCall(0).args[0], "/manifest.json", "_getManifest called for manifest.json first");
@@ -286,7 +286,7 @@ test("_getNamespace: No fallback if manifest.json is present but failed to parse
 		.onFirstCall().rejects(new Error("EPON: Pony Error"));
 
 	const error = await t.throwsAsync(project._getNamespace());
-	t.deepEqual(error.message, "EPON: Pony Error",
+	t.is(error.message, "EPON: Pony Error",
 		"Rejected with correct error message");
 
 	t.is(_getManifestStub.callCount, 1, "_getManifest called exactly once");
@@ -297,7 +297,7 @@ test("_getManifest: reads correctly", async (t) => {
 	const project = await Specification.create(basicProjectInput);
 
 	const content = await project._getManifest("/manifest.json");
-	t.deepEqual(content._version, "1.1.0", "manifest.json content has been read");
+	t.is(content._version, "1.1.0", "manifest.json content has been read");
 });
 
 test("_getManifest: invalid JSON", async (t) => {
@@ -318,8 +318,8 @@ test("_getManifest: invalid JSON", async (t) => {
 		"Failed to read /some-manifest.json for project application.a: " +
 		"Unexpected token o in JSON at position 1",
 		"Rejected with correct error message");
-	t.deepEqual(byPathStub.callCount, 1, "byPath got called once");
-	t.deepEqual(byPathStub.getCall(0).args[0], "/some-manifest.json", "byPath got called with the correct argument");
+	t.is(byPathStub.callCount, 1, "byPath got called once");
+	t.is(byPathStub.getCall(0).args[0], "/some-manifest.json", "byPath got called with the correct argument");
 });
 
 test.serial("_getManifest: File does not exist", async (t) => {
@@ -351,7 +351,7 @@ test.serial("_getManifest: result is cached", async (t) => {
 	const content2 = await project._getManifest("/some-other-manifest.json");
 	t.deepEqual(content2, {pony: "no unicorn"}, "Correct result on second call");
 
-	t.deepEqual(byPathStub.callCount, 2, "byPath got called exactly twice (and then cached)");
+	t.is(byPathStub.callCount, 2, "byPath got called exactly twice (and then cached)");
 });
 
 test.serial("_getManifest: Caches successes and failures", async (t) => {
@@ -388,7 +388,7 @@ test.serial("_getManifest: Caches successes and failures", async (t) => {
 	const content2 = await project._getManifest("/some-other.manifest.json");
 	t.deepEqual(content2, {pony: "no unicorn"}, "From cache: Correct result on first call");
 
-	t.deepEqual(byPathStub.callCount, 2,
+	t.is(byPathStub.callCount, 2,
 		"byPath got called exactly twice (and then cached)");
 });
 
@@ -417,7 +417,7 @@ test("namespace: detect namespace from pom.xml via ${project.artifactId}", async
 	myProject.configuration.resources.configuration.paths.webapp = "webapp-project.artifactId";
 	const project = await Specification.create(myProject);
 
-	t.deepEqual(project.getNamespace(), "application/h",
+	t.is(project.getNamespace(), "application/h",
 		"namespace was successfully set since getJson provides the correct object structure");
 });
 
@@ -426,7 +426,7 @@ test("namespace: detect namespace from pom.xml via ${componentName} from propert
 	myProject.configuration.resources.configuration.paths.webapp = "webapp-properties.componentName";
 	const project = await Specification.create(myProject);
 
-	t.deepEqual(project.getNamespace(), "application/h",
+	t.is(project.getNamespace(), "application/h",
 		"namespace was successfully set since getJson provides the correct object structure");
 });
 

--- a/test/lib/specifications/types/Library.js
+++ b/test/lib/specifications/types/Library.js
@@ -218,7 +218,7 @@ test("_configureAndValidatePaths: Source directory does not exist", async (t) =>
 test("_parseConfiguration: Get copyright", async (t) => {
 	const project = await Specification.create(basicProjectInput);
 
-	t.deepEqual(project.getCopyright(), "Some fancy copyright", "Copyright was read correctly");
+	t.is(project.getCopyright(), "Some fancy copyright", "Copyright was read correctly");
 });
 
 test("_parseConfiguration: Copyright already configured", async (t) => {
@@ -226,7 +226,7 @@ test("_parseConfiguration: Copyright already configured", async (t) => {
 	projectInput.configuration.metadata.copyright = "My copyright";
 	const project = await Specification.create(projectInput);
 
-	t.deepEqual(project.getCopyright(), "My copyright", "Copyright was not altered");
+	t.is(project.getCopyright(), "My copyright", "Copyright was not altered");
 });
 
 test.serial("_parseConfiguration: Copyright retrieval fails", async (t) => {
@@ -235,7 +235,7 @@ test.serial("_parseConfiguration: Copyright retrieval fails", async (t) => {
 	sinon.stub(Library.prototype, "_getCopyrightFromDotLibrary").resolves(null);
 	const project = await Specification.create(basicProjectInput);
 
-	t.deepEqual(project.getCopyright(), undefined, "Copyright was not altered");
+	t.is(project.getCopyright(), undefined, "Copyright was not altered");
 });
 
 test.serial("_parseConfiguration: Preload excludes from .library", async (t) => {
@@ -464,7 +464,7 @@ test("_getManifest: Multiple manifest.json files", async (t) => {
 	};
 	project._pManifest = null; // Clear cache from instantiation
 	const error = await t.throwsAsync(project._getManifest());
-	t.deepEqual(error.message, "Found multiple (2) manifest.json files for project library.d",
+	t.is(error.message, "Found multiple (2) manifest.json files for project library.d",
 		"Rejected with correct error message");
 });
 
@@ -585,7 +585,7 @@ test("_getDotLibrary: Multiple .library files", async (t) => {
 	};
 	project._pDotLibrary = null; // Clear cache from instantiation
 	const error = await t.throwsAsync(project._getDotLibrary());
-	t.deepEqual(error.message, "Found multiple (2) .library files for project library.d",
+	t.is(error.message, "Found multiple (2) .library files for project library.d",
 		"Rejected with correct error message");
 });
 
@@ -628,7 +628,7 @@ test("_getLibraryJsPath: Reads correctly", async (t) => {
 	};
 	project._pLibraryJs = null; // Clear cache from instantiation
 	const filePath = await project._getLibraryJsPath();
-	t.deepEqual(filePath, "some path", "Expected library.js path");
+	t.is(filePath, "some path", "Expected library.js path");
 	t.is(byGlobStub.callCount, 1, "byGlob got called once");
 	t.is(byGlobStub.getCall(0).args[0], "**/library.js", "byGlob got called with the expected arguments");
 });
@@ -680,7 +680,7 @@ test("_getLibraryJsPath: Multiple library.js files", async (t) => {
 	};
 	project._pLibraryJs = null; // Clear cache from instantiation
 	const error = await t.throwsAsync(project._getLibraryJsPath());
-	t.deepEqual(error.message, "Found multiple (2) library.js files for project library.d",
+	t.is(error.message, "Found multiple (2) library.js files for project library.d",
 		"Rejected with correct error message");
 });
 
@@ -697,12 +697,12 @@ test("_getLibraryJsPath: Result is cached", async (t) => {
 	};
 	project._pLibraryJs = null; // Clear cache from instantiation
 	const filePath1 = await project._getLibraryJsPath();
-	t.deepEqual(filePath1, "some path", "Expected library.js path");
+	t.is(filePath1, "some path", "Expected library.js path");
 	t.is(byGlobStub.callCount, 1, "byGlob got called once");
 	t.is(byGlobStub.getCall(0).args[0], "**/library.js", "byGlob got called with the expected arguments");
 
 	const filePath2 = await project._getLibraryJsPath();
-	t.deepEqual(filePath2, "some path", "Expected library.js path");
+	t.is(filePath2, "some path", "Expected library.js path");
 	t.is(filePath2, "some path", "Correct path");
 	t.is(byGlobStub.callCount, 1, "byGlob got called once");
 	t.is(byGlobStub.getCall(0).args[0], "**/library.js", "byGlob got called with the expected arguments");
@@ -729,7 +729,7 @@ test.serial("_getNamespace: namespace resolution fails", async (t) => {
 	t.deepEqual(error.message, "Failed to detect namespace or namespace is empty for project library.d." +
 		" Check verbose log for details.");
 
-	t.deepEqual(loggerVerboseSpy.callCount, 2, "2 calls to log.verbose should be done");
+	t.is(loggerVerboseSpy.callCount, 2, "2 calls to log.verbose should be done");
 	const logVerboseCalls = loggerVerboseSpy.getCalls().map((call) => call.args[0]);
 
 	t.true(logVerboseCalls.includes(
@@ -872,7 +872,7 @@ test.serial("_getNamespace: from manifest.json without sap.app id", async (t) =>
 	const loggerSpy = sinon.spy(loggerInstance, "verbose");
 	const err = await t.throwsAsync(project._getNamespace());
 
-	t.deepEqual(err.message,
+	t.is(err.message,
 		`Failed to detect namespace or namespace is empty for project library.d. Check verbose log for details.`,
 		"Rejected with correct error message");
 	t.is(loggerSpy.callCount, 4, "calls to verbose");
@@ -895,7 +895,7 @@ test("_getNamespace: from .library", async (t) => {
 		filePath: "/dot-pony/.library"
 	});
 	const res = await project._getNamespace();
-	t.deepEqual(res, "dot-pony", "Returned correct namespace");
+	t.is(res, "dot-pony", "Returned correct namespace");
 	t.true(project._isSourceNamespaced, "Project still flagged as namespaced source structure");
 });
 
@@ -916,7 +916,7 @@ test("_getNamespace: from .library with ignored manifest.json on lower level", a
 		filePath: "/dot-pony/.library"
 	});
 	const res = await project._getNamespace();
-	t.deepEqual(res, "dot-pony", "Returned correct namespace");
+	t.is(res, "dot-pony", "Returned correct namespace");
 	t.true(project._isSourceNamespaced, "Project still flagged as namespaced source structure");
 });
 
@@ -965,9 +965,9 @@ test("_getNamespace: from .library with maven placeholder", async (t) => {
 		sinon.stub(project, "_resolveMavenPlaceholder").resolves("mvn-unicorn");
 	const res = await project._getNamespace();
 
-	t.deepEqual(resolveMavenPlaceholderStub.getCall(0).args[0], "${mvn-pony}",
+	t.is(resolveMavenPlaceholderStub.getCall(0).args[0], "${mvn-pony}",
 		"resolveMavenPlaceholder called with correct argument");
-	t.deepEqual(res, "mvn-unicorn", "Returned correct namespace");
+	t.is(res, "mvn-unicorn", "Returned correct namespace");
 	t.true(project._isSourceNamespaced, "Project still flagged as namespaced source structure");
 });
 
@@ -994,7 +994,7 @@ test("_getNamespace: from library.js", async (t) => {
 	sinon.stub(project, "_getDotLibrary").resolves({});
 	sinon.stub(project, "_getLibraryJsPath").resolves("/my/namespace/library.js");
 	const res = await project._getNamespace();
-	t.deepEqual(res, "my/namespace", "Returned correct namespace");
+	t.is(res, "my/namespace", "Returned correct namespace");
 	t.true(project._isSourceNamespaced, "Project still flagged as namespaced source structure");
 });
 
@@ -1016,7 +1016,7 @@ test.serial("_getNamespace: from project root level library.js", async (t) => {
 	sinon.stub(project, "_getLibraryJsPath").resolves("/library.js");
 	const err = await t.throwsAsync(project._getNamespace());
 
-	t.deepEqual(err.message,
+	t.is(err.message,
 		"Failed to detect namespace or namespace is empty for project library.d. Check verbose log for details.",
 		"Rejected with correct error message");
 
@@ -1034,7 +1034,7 @@ test("_getNamespace: neither manifest nor .library or library.js path contain it
 	sinon.stub(project, "_getDotLibrary").resolves({});
 	sinon.stub(project, "_getLibraryJsPath").rejects(new Error("Not found bla"));
 	const err = await t.throwsAsync(project._getNamespace());
-	t.deepEqual(err.message,
+	t.is(err.message,
 		"Failed to detect namespace or namespace is empty for project library.d. Check verbose log for details.",
 		"Rejected with correct error message");
 });
@@ -1054,10 +1054,10 @@ test("_getNamespace: maven placeholder resolution fails", async (t) => {
 		sinon.stub(project, "_resolveMavenPlaceholder")
 			.rejects(new Error("because squirrel"));
 	const err = await t.throwsAsync(project._getNamespace());
-	t.deepEqual(err.message,
+	t.is(err.message,
 		"Failed to resolve namespace maven placeholder of project library.d: because squirrel",
 		"Rejected with correct error message");
-	t.deepEqual(resolveMavenPlaceholderStub.getCall(0).args[0], "${mvn-pony}",
+	t.is(resolveMavenPlaceholderStub.getCall(0).args[0], "${mvn-pony}",
 		"resolveMavenPlaceholder called with correct argument");
 });
 

--- a/test/lib/specifications/types/ThemeLibrary.js
+++ b/test/lib/specifications/types/ThemeLibrary.js
@@ -38,7 +38,7 @@ test("Correct class", async (t) => {
 test("getCopyright", async (t) => {
 	const project = await Specification.create(basicProjectInput);
 
-	t.deepEqual(project.getCopyright(), "Some fancy copyright", "Copyright was read correctly");
+	t.is(project.getCopyright(), "Some fancy copyright", "Copyright was read correctly");
 });
 
 test("Access project resources via reader", async (t) => {

--- a/test/lib/specifications/types/extensions/ServerMiddleware.js
+++ b/test/lib/specifications/types/extensions/ServerMiddleware.js
@@ -37,7 +37,7 @@ test("Correct class", async (t) => {
 
 test("getMiddleware", async (t) => {
 	const extension = await Specification.create(clone(basicServerMiddlewareInput));
-	t.deepEqual(extension.getMiddleware(), "extension module",
+	t.is(extension.getMiddleware(), "extension module",
 		"Returned correct module");
 });
 

--- a/test/lib/specifications/types/extensions/Task.js
+++ b/test/lib/specifications/types/extensions/Task.js
@@ -37,7 +37,7 @@ test("Correct class", async (t) => {
 
 test("getTask", async (t) => {
 	const extension = await Specification.create(clone(basicTaskInput));
-	t.deepEqual(extension.getTask(), "extension module",
+	t.is(extension.getTask(), "extension module",
 		"Returned correct module");
 });
 

--- a/test/lib/ui5framework/AbstractResolver.js
+++ b/test/lib/ui5framework/AbstractResolver.js
@@ -604,7 +604,7 @@ test.serial(
 			`Make sure the version is valid and available in the configured registry.`);
 	});
 
-test.serial("AbstractResolver: SEMVER_VERSION_REGEXP should be aligned with JSON schema", async (t) => {
+test.serial("AbstractResolver: SEMVER_VERSION_REGEXP should be aligned with JSON schema", (t) => {
 	const projectSchema = require("../../../lib/validation/schema/specVersion/2.0/kind/project.json");
 	const schemaPattern = projectSchema.definitions.framework.properties.version.pattern;
 	t.is(schemaPattern, AbstractResolver._SEMVER_VERSION_REGEXP.source);

--- a/test/lib/ui5framework/npm/Installer.js
+++ b/test/lib/ui5framework/npm/Installer.js
@@ -79,7 +79,7 @@ test.serial("Installer: fetchPackageVersions", async (t) => {
 		"requestPackagePackument should be called with pkgName");
 });
 
-test.serial("Installer: _getLockPath", async (t) => {
+test.serial("Installer: _getLockPath", (t) => {
 	const installer = new Installer({
 		cwd: "/cwd/",
 		ui5HomeDir: "/ui5Home/"
@@ -281,13 +281,13 @@ test.serial("Installer: _synchronize", async (t) => {
 		"_mkdirp should be called with expected args");
 
 	t.is(t.context.lockStub.callCount, 1, "lock should be called once");
-	t.deepEqual(t.context.lockStub.getCall(0).args[0], "/locks/lockfile.lock",
+	t.is(t.context.lockStub.getCall(0).args[0], "/locks/lockfile.lock",
 		"lock should be called with expected path");
 	t.deepEqual(t.context.lockStub.getCall(0).args[1], {wait: 10000, stale: 60000, retries: 10},
 		"lock should be called with expected options");
 
 	t.is(t.context.unlockStub.callCount, 1, "unlock should be called once");
-	t.deepEqual(t.context.unlockStub.getCall(0).args[0], "/locks/lockfile.lock",
+	t.is(t.context.unlockStub.getCall(0).args[0], "/locks/lockfile.lock",
 		"unlock should be called with expected path");
 
 	t.is(callback.callCount, 1, "callback should be called once");
@@ -309,12 +309,11 @@ test.serial("Installer: _synchronize should unlock when callback promise has res
 
 	sinon.stub(installer, "_getLockPath").returns("/locks/lockfile.lock");
 
-	const callback = sinon.stub().callsFake(() => {
+	const callback = sinon.stub().callsFake(async () => {
 		t.is(t.context.lockStub.callCount, 1, "lock should have been called when the callback is invoked");
-		return Promise.resolve().then(() => {
-			t.is(t.context.unlockStub.callCount, 0,
-				"unlock should not be called when the callback did not fully resolve, yet");
-		});
+		await Promise.resolve();
+		t.is(t.context.unlockStub.callCount, 0,
+			"unlock should not be called when the callback did not fully resolve, yet");
 	});
 
 	await installer._synchronize({


### PR DESCRIPTION
Introducing [eslint-plugin-ava](https://github.com/avajs/eslint-plugin-ava/) to avoid common pitfalls when writing powerful ava tests.

- Add plugin to eslint config and package.json
- Restructure current code base to latest recommendations