### PR TITLE
[INTERNAL] Invalid JSON: Fix unit tests for Node 19

### DIFF
--- a/test/lib/specifications/types/Application.js
+++ b/test/lib/specifications/types/Application.js
@@ -317,9 +317,7 @@ test("_getManifest: invalid JSON", async (t) => {
 	};
 
 	const error = await t.throwsAsync(project._getManifest("/some-manifest.json"));
-	t.deepEqual(error.message,
-		"Failed to read /some-manifest.json for project application.a: " +
-		"Unexpected token o in JSON at position 1",
+	t.regex(error.message, /^Failed to read \/some-manifest\.json for project application\.a: /,
 		"Rejected with correct error message");
 	t.is(byPathStub.callCount, 1, "byPath got called once");
 	t.is(byPathStub.getCall(0).args[0], "/some-manifest.json", "byPath got called with the correct argument");

--- a/test/lib/specifications/types/Library.js
+++ b/test/lib/specifications/types/Library.js
@@ -411,9 +411,7 @@ test("_getManifest: Invalid JSON", async (t) => {
 	};
 	project._pManifest = null; // Clear cache from instantiation
 	const error = await t.throwsAsync(project._getManifest());
-	t.is(error.message,
-		"Failed to read some path for project library.d: " +
-		"Unexpected token o in JSON at position 1",
+	t.regex(error.message, /^Failed to read some path for project library\.d: /,
 		"Rejected with correct error message");
 	t.is(byGlobStub.callCount, 1, "byGlob got called once");
 	t.is(byGlobStub.getCall(0).args[0], "**/manifest.json", "byGlob got called with the expected arguments");


### PR DESCRIPTION
Node 19 has a new error message for invalid JSON. Instead of
"Unexpected token o in JSON at position 1" it now reads
"Unexpected token 'o', "no json" is not valid JSON"