### PR TITLE
[INTERNAL] Remove @ui5/builder dependency

### DIFF
--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -319,7 +319,7 @@ class ProjectBuilder {
 			const {
 				default: createBuildManifest
 			} = await import("./helpers/createBuildManifest.js");
-			const metadata = await createBuildManifest(project, buildConfig);
+			const metadata = await createBuildManifest(project, buildConfig, this._buildContext.getTaskRepository());
 			await target.write(resourceFactory.createResource({
 				path: `/.ui5/build-manifest.json`,
 				string: JSON.stringify(metadata, null, "\t")

--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -324,6 +324,13 @@ class TaskRunner {
 				const refTaskName = taskDef.beforeTask || taskDef.afterTask;
 				let refTaskIdx = this._taskExecutionOrder.indexOf(refTaskName);
 				if (refTaskIdx === -1) {
+					if (this._taskRepository.getRemovedTaskNames().includes(refTaskName)) {
+						throw new Error(
+							`Standard task ${refTaskName}, referenced by custom task ${newTaskName} ` +
+							`in project ${project.getName()}, ` +
+							`has been removed in this version of UI5 Tooling and can't be referenced anymore. ` +
+							`Please see the migration guide at https://sap.github.io/ui5-tooling/updates/migrate-v3/`);
+					}
 					throw new Error(`Could not find task ${refTaskName}, referenced by custom task ${newTaskName}, ` +
 						`to be scheduled for project ${project.getName()}`);
 				}

--- a/lib/build/helpers/createBuildManifest.js
+++ b/lib/build/helpers/createBuildManifest.js
@@ -16,7 +16,16 @@ function getSortedTags(project) {
 	return Object.fromEntries(entities);
 }
 
-export default async function(project, buildConfig) {
+export default async function(project, buildConfig, taskRepository) {
+	if (!project) {
+		throw new Error(`Missing parameter 'project'`);
+	}
+	if (!buildConfig) {
+		throw new Error(`Missing parameter 'buildConfig'`);
+	}
+	if (!taskRepository) {
+		throw new Error(`Missing parameter 'taskRepository'`);
+	}
 	const projectName = project.getName();
 	const type = project.getType();
 
@@ -50,12 +59,12 @@ export default async function(project, buildConfig) {
 			}
 		},
 		buildManifest: {
-			manifestVersion: "0.1",
+			manifestVersion: "0.2",
 			timestamp: new Date().toISOString(),
 			versions: {
-				builderVersion: await getVersion("@ui5/builder"),
 				projectVersion: await getVersion("@ui5/project"),
 				fsVersion: await getVersion("@ui5/fs"),
+				builderVersions: await taskRepository.getVersions()
 			},
 			buildConfig,
 			version: project.getVersion(),

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -1,4 +1,3 @@
-import * as taskRepository from "@ui5/builder/internal/taskRepository";
 import logger from "@ui5/logger";
 const log = logger.getLogger("graph:ProjectGraph");
 
@@ -20,8 +19,6 @@ class ProjectGraph {
 			throw new Error(`Could not create ProjectGraph: Missing or empty parameter 'rootProjectName'`);
 		}
 		this._rootProjectName = rootProjectName;
-
-		this._taskRepository = taskRepository;
 
 		this._projects = Object.create(null); // maps project name to instance
 		this._adjList = Object.create(null); // maps project name to edges/dependencies
@@ -459,6 +456,7 @@ class ProjectGraph {
 	}
 
 	// Only to be used by @ui5/builder tests to inject its version of the taskRepository
+	// TODO 3.0: Remove once ui5-builder uses new #build parameter
 	setTaskRepository(taskRepo) {
 		this._taskRepository = taskRepo;
 	}
@@ -473,6 +471,7 @@ class ProjectGraph {
 	 * @public
 	 * @param {object} parameters Build parameters
 	 * @param {string} parameters.destPath Target path
+	 * @param {@ui5/builder/tasks/taskRepository} parameters.taskRepository UI5 Builder task repository
 	 * @param {boolean} [parameters.cleanDest=false] Decides whether project should clean the target path before build
 	 * @param {Array.<string|RegExp>} [parameters.includedDependencies=[]]
 	 *			List of names of projects to include in the build result
@@ -492,13 +491,13 @@ class ProjectGraph {
 	 * @returns {Promise} Promise resolving to <code>undefined</code> once build has finished
 	 */
 	async build({
-		destPath, cleanDest = false,
+		destPath, taskRepository, cleanDest = false,
 		includedDependencies = [], excludedDependencies = [],
 		complexDependencyIncludes,
 		selfContained = false, cssVariables = false, jsdoc = false, createBuildManifest = false,
 		includedTasks = [], excludedTasks = []
 	}) {
-		this.seal();
+		this.seal(); // Do not allow further changes to the graph
 		if (this._built) {
 			throw new Error(
 				`Project graph with root node ${this._rootProjectName} has already been built. ` +
@@ -508,7 +507,7 @@ class ProjectGraph {
 		const {
 			default: ProjectBuilder
 		} = await import("../build/ProjectBuilder.js");
-		const builder = new ProjectBuilder(this, this.getTaskRepository(), {
+		const builder = new ProjectBuilder(this, taskRepository || this.getTaskRepository(), {
 			selfContained, cssVariables, jsdoc,
 			createBuildManifest,
 			includedTasks, excludedTasks,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "3.0.0-beta.2",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ui5/builder": "^3.0.0-beta.1",
 				"@ui5/fs": "^3.0.0-beta.3",
 				"@ui5/logger": "^3.0.1-beta.1",
 				"ajv": "^6.12.6",
@@ -392,6 +391,7 @@
 			"version": "7.20.3",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
 			"integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -674,6 +674,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -682,28 +683,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			}
-		},
-		"node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -711,12 +691,14 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -957,12 +939,14 @@
 		"node_modules/@types/linkify-it": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-			"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
+			"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+			"dev": true
 		},
 		"node_modules/@types/markdown-it": {
 			"version": "12.2.3",
 			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
 			"integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+			"dev": true,
 			"dependencies": {
 				"@types/linkify-it": "*",
 				"@types/mdurl": "*"
@@ -971,7 +955,8 @@
 		"node_modules/@types/mdurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-			"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+			"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+			"dev": true
 		},
 		"node_modules/@types/minimatch": {
 			"version": "3.0.5",
@@ -995,35 +980,6 @@
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
-		},
-		"node_modules/@ui5/builder": {
-			"version": "3.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-3.0.0-beta.1.tgz",
-			"integrity": "sha512-EG7/YkpI46F2TTpx9YCL8e4t/8GgeFSzGFgf1j2Av6YtjcgfPgJq1a+2CgeoBOb2DWvlDcAeQiKrkkgDs9oq1w==",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.14",
-				"@ui5/fs": "^3.0.0-beta.2",
-				"@ui5/logger": "^3.0.1-beta.0",
-				"cheerio": "1.0.0-rc.9",
-				"escape-unicode": "^0.2.0",
-				"escope": "^4.0.0",
-				"espree": "^9.3.1",
-				"graceful-fs": "^4.2.9",
-				"jsdoc": "^3.6.7",
-				"less-openui5": "^0.11.2",
-				"make-dir": "^3.1.0",
-				"pretty-data": "^0.40.0",
-				"replacestream": "^4.0.3",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"terser": "^5.14.2",
-				"xml2js": "^0.4.23",
-				"yazl": "^2.5.1"
-			},
-			"engines": {
-				"node": ">= 16.13.2",
-				"npm": ">= 8"
-			}
 		},
 		"node_modules/@ui5/fs": {
 			"version": "3.0.0-beta.3",
@@ -1250,6 +1206,7 @@
 			"version": "8.8.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
 			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1261,6 +1218,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -1462,17 +1420,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"bin": {
-				"atob": "bin/atob.js"
-			},
-			"engines": {
-				"node": ">= 4.5.0"
-			}
-		},
 		"node_modules/ava": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/ava/-/ava-4.3.3.tgz",
@@ -1604,18 +1551,14 @@
 		"node_modules/bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+			"dev": true
 		},
 		"node_modules/blueimp-md5": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
 			"integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
 			"dev": true
-		},
-		"node_modules/boolbase": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
 		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
@@ -1686,19 +1629,6 @@
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.2.1"
 			}
-		},
-		"node_modules/buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
 		},
 		"node_modules/builtins": {
 			"version": "5.0.1",
@@ -1891,6 +1821,7 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
 			"integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+			"dev": true,
 			"dependencies": {
 				"lodash": "^4.17.15"
 			},
@@ -1954,41 +1885,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-		},
-		"node_modules/cheerio": {
-			"version": "1.0.0-rc.9",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.9.tgz",
-			"integrity": "sha512-QF6XVdrLONO6DXRF5iaolY+odmhj2CLj+xzNod7INPWMi/x9X4SOylH0S/vaPpX+AUU6t04s34SQNh7DbkuCng==",
-			"dependencies": {
-				"cheerio-select": "^1.4.0",
-				"dom-serializer": "^1.3.1",
-				"domhandler": "^4.2.0",
-				"htmlparser2": "^6.1.0",
-				"parse5": "^6.0.1",
-				"parse5-htmlparser2-tree-adapter": "^6.0.1",
-				"tslib": "^2.2.0"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
-			"integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
-			"dependencies": {
-				"css-select": "^4.3.0",
-				"css-what": "^6.0.1",
-				"domelementtype": "^2.2.0",
-				"domhandler": "^4.3.1",
-				"domutils": "^2.8.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
 		},
 		"node_modules/chokidar": {
 			"version": "3.5.3",
@@ -2376,7 +2272,8 @@
 		"node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"node_modules/comment-parser": {
 			"version": "1.3.0",
@@ -2456,7 +2353,8 @@
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.0.1",
@@ -2531,42 +2429,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/css": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-			"integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"source-map": "^0.6.1",
-				"source-map-resolve": "^0.6.0"
-			}
-		},
-		"node_modules/css-select": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-			"integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.0.1",
-				"domhandler": "^4.3.1",
-				"domutils": "^2.8.0",
-				"nth-check": "^2.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/currently-unhandled": {
@@ -2646,14 +2508,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
-			"engines": {
-				"node": ">=0.10"
 			}
 		},
 		"node_modules/deep-is": {
@@ -3015,57 +2869,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/dom-serializer": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-			"integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-			"dependencies": {
-				"domelementtype": "^2.0.1",
-				"domhandler": "^4.2.0",
-				"entities": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			]
-		},
-		"node_modules/domhandler": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-			"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-			"dependencies": {
-				"domelementtype": "^2.2.0"
-			},
-			"engines": {
-				"node": ">= 4"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domhandler?sponsor=1"
-			}
-		},
-		"node_modules/domutils": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-			"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-			"dependencies": {
-				"dom-serializer": "^1.0.1",
-				"domelementtype": "^2.2.0",
-				"domhandler": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
 		"node_modules/duplexer": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -3192,14 +2995,6 @@
 				"node": ">=4.0.0"
 			}
 		},
-		"node_modules/entities": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/env-paths": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -3245,26 +3040,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/escape-unicode": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/escape-unicode/-/escape-unicode-0.2.0.tgz",
-			"integrity": "sha512-7jMQuKb8nm0h/9HYLfu4NCLFwoUsd5XO6OZ1z86PbKcMf8zDK1m7nFR0iA2CCShq4TSValaLIveE8T1UBxgALQ==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/escope": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escope/-/escope-4.0.0.tgz",
-			"integrity": "sha512-E36qlD/r6RJHVpPKArgMoMlNJzoRJFH8z/cAZlI9lbc45zB3+S7i9k6e/MNb+7bZQzNEa6r8WKN3BovpeIBwgA==",
-			"dependencies": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=4.0"
 			}
 		},
 		"node_modules/eslint": {
@@ -3444,6 +3219,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
 			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -3616,6 +3392,7 @@
 			"version": "9.4.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
 			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
@@ -3672,6 +3449,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -3683,14 +3461,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -4249,24 +4020,6 @@
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
-		},
-		"node_modules/htmlparser2": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-			"integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-			"funding": [
-				"https://github.com/fb55/htmlparser2?sponsor=1",
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"dependencies": {
-				"domelementtype": "^2.0.1",
-				"domhandler": "^4.0.0",
-				"domutils": "^2.5.2",
-				"entities": "^2.0.0"
-			}
 		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.0",
@@ -4874,6 +4627,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
 			"integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+			"dev": true,
 			"dependencies": {
 				"xmlcreate": "^2.0.4"
 			}
@@ -4882,6 +4636,7 @@
 			"version": "3.6.11",
 			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
 			"integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.9.4",
 				"@types/markdown-it": "^12.2.3",
@@ -4919,6 +4674,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
 			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4990,22 +4746,9 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
 			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.9"
-			}
-		},
-		"node_modules/less-openui5": {
-			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/less-openui5/-/less-openui5-0.11.2.tgz",
-			"integrity": "sha512-FkAT0JDB3NGroia/hdYInzVzpERINovKEgjeijfYgLK7C4eef8a0midlgdBfTZanv3Gz8zUSjfGYXNWL82jEBA==",
-			"dependencies": {
-				"clone": "^2.1.0",
-				"css": "^3.0.0",
-				"mime": "^1.6.0"
-			},
-			"engines": {
-				"node": ">= 10",
-				"npm": ">= 5"
 			}
 		},
 		"node_modules/levn": {
@@ -5083,6 +4826,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
 			"integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+			"dev": true,
 			"dependencies": {
 				"uc.micro": "^1.0.1"
 			}
@@ -5122,7 +4866,8 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
@@ -5384,6 +5129,7 @@
 			"version": "12.3.2",
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
 			"integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1",
 				"entities": "~2.1.0",
@@ -5399,6 +5145,7 @@
 			"version": "8.6.5",
 			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
 			"integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
+			"dev": true,
 			"peerDependencies": {
 				"@types/markdown-it": "*",
 				"markdown-it": "*"
@@ -5408,6 +5155,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
 			"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
@@ -5416,6 +5164,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.2.tgz",
 			"integrity": "sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==",
+			"dev": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -5453,7 +5202,8 @@
 		"node_modules/mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+			"dev": true
 		},
 		"node_modules/mem": {
 			"version": "9.0.2",
@@ -5641,17 +5391,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -6238,17 +5977,6 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/nth-check": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dependencies": {
-				"boolbase": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/nth-check?sponsor=1"
-			}
-		},
 		"node_modules/nyc": {
 			"version": "15.1.0",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
@@ -6548,14 +6276,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6795,19 +6515,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/parse5": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-		},
-		"node_modules/parse5-htmlparser2-tree-adapter": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-			"dependencies": {
-				"parse5": "^6.0.1"
 			}
 		},
 		"node_modules/path-exists": {
@@ -7116,14 +6823,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/pretty-data": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/pretty-data/-/pretty-data-0.40.0.tgz",
-			"integrity": "sha512-YFLnEdDEDnkt/GEhet5CYZHCvALw6+Elyb/tp8kQG03ZSIuzeaDWpZYndCXwgqu4NAjh1PI534dhDS1mHarRnQ==",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/pretty-hrtime": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -7166,7 +6865,8 @@
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"node_modules/process-on-spawn": {
 			"version": "1.0.0",
@@ -7564,56 +7264,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/replacestream": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
-			"integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
-			"dependencies": {
-				"escape-string-regexp": "^1.0.3",
-				"object-assign": "^4.0.1",
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"node_modules/replacestream/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/replacestream/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-		},
-		"node_modules/replacestream/node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/replacestream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
-		"node_modules/replacestream/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7639,6 +7289,7 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
 			"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+			"dev": true,
 			"dependencies": {
 				"lodash": "^4.17.14"
 			}
@@ -8013,6 +7664,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8024,25 +7676,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/source-map-resolve": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-			"integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-			"deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-			"dependencies": {
-				"atob": "^2.1.2",
-				"decode-uri-component": "^0.2.0"
-			}
-		},
-		"node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/sourcemap-codec": {
@@ -8202,6 +7835,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -8288,7 +7922,8 @@
 		"node_modules/taffydb": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA=="
+			"integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA==",
+			"dev": true
 		},
 		"node_modules/tap-nyan": {
 			"version": "1.1.0",
@@ -8638,23 +8273,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/terser": {
-			"version": "5.15.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-			"integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
-			"dependencies": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			},
-			"bin": {
-				"terser": "bin/terser"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -8821,11 +8439,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8868,12 +8481,14 @@
 		"node_modules/uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+			"dev": true
 		},
 		"node_modules/underscore": {
 			"version": "1.13.6",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+			"dev": true
 		},
 		"node_modules/unique-filename": {
 			"version": "3.0.0",
@@ -9224,7 +8839,8 @@
 		"node_modules/xmlcreate": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-			"integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
+			"integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+			"dev": true
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
@@ -9343,14 +8959,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/yazl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-			"integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-			"dependencies": {
-				"buffer-crc32": "~0.2.3"
 			}
 		},
 		"node_modules/yocto-queue": {
@@ -9619,7 +9227,8 @@
 		"@babel/parser": {
 			"version": "7.20.3",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-			"integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg=="
+			"integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+			"dev": true
 		},
 		"@babel/template": {
 			"version": "7.18.10",
@@ -9840,43 +9449,26 @@
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
-		},
-		"@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-			"requires": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"dependencies": {
-				"@jridgewell/gen-mapping": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-					"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-					"requires": {
-						"@jridgewell/set-array": "^1.0.1",
-						"@jridgewell/sourcemap-codec": "^1.4.10",
-						"@jridgewell/trace-mapping": "^0.3.9"
-					}
-				}
-			}
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -10067,12 +9659,14 @@
 		"@types/linkify-it": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-			"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
+			"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+			"dev": true
 		},
 		"@types/markdown-it": {
 			"version": "12.2.3",
 			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
 			"integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+			"dev": true,
 			"requires": {
 				"@types/linkify-it": "*",
 				"@types/mdurl": "*"
@@ -10081,7 +9675,8 @@
 		"@types/mdurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-			"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+			"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+			"dev": true
 		},
 		"@types/minimatch": {
 			"version": "3.0.5",
@@ -10105,31 +9700,6 @@
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
-		},
-		"@ui5/builder": {
-			"version": "3.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-3.0.0-beta.1.tgz",
-			"integrity": "sha512-EG7/YkpI46F2TTpx9YCL8e4t/8GgeFSzGFgf1j2Av6YtjcgfPgJq1a+2CgeoBOb2DWvlDcAeQiKrkkgDs9oq1w==",
-			"requires": {
-				"@jridgewell/sourcemap-codec": "^1.4.14",
-				"@ui5/fs": "^3.0.0-beta.2",
-				"@ui5/logger": "^3.0.1-beta.0",
-				"cheerio": "1.0.0-rc.9",
-				"escape-unicode": "^0.2.0",
-				"escope": "^4.0.0",
-				"espree": "^9.3.1",
-				"graceful-fs": "^4.2.9",
-				"jsdoc": "^3.6.7",
-				"less-openui5": "^0.11.2",
-				"make-dir": "^3.1.0",
-				"pretty-data": "^0.40.0",
-				"replacestream": "^4.0.3",
-				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"terser": "^5.14.2",
-				"xml2js": "^0.4.23",
-				"yazl": "^2.5.1"
-			}
 		},
 		"@ui5/fs": {
 			"version": "3.0.0-beta.3",
@@ -10322,12 +9892,14 @@
 		"acorn": {
 			"version": "8.8.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
 			"requires": {}
 		},
 		"acorn-walk": {
@@ -10467,11 +10039,6 @@
 			"integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
 			"dev": true
 		},
-		"atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-		},
 		"ava": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/ava/-/ava-4.3.3.tgz",
@@ -10565,18 +10132,14 @@
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+			"dev": true
 		},
 		"blueimp-md5": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
 			"integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
 			"dev": true
-		},
-		"boolbase": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
 		},
 		"brace-expansion": {
 			"version": "2.0.1",
@@ -10614,16 +10177,6 @@
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.2.1"
 			}
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
-		},
-		"buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
 		},
 		"builtins": {
 			"version": "5.0.1",
@@ -10761,6 +10314,7 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
 			"integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.15"
 			}
@@ -10804,32 +10358,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				}
-			}
-		},
-		"cheerio": {
-			"version": "1.0.0-rc.9",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.9.tgz",
-			"integrity": "sha512-QF6XVdrLONO6DXRF5iaolY+odmhj2CLj+xzNod7INPWMi/x9X4SOylH0S/vaPpX+AUU6t04s34SQNh7DbkuCng==",
-			"requires": {
-				"cheerio-select": "^1.4.0",
-				"dom-serializer": "^1.3.1",
-				"domhandler": "^4.2.0",
-				"htmlparser2": "^6.1.0",
-				"parse5": "^6.0.1",
-				"parse5-htmlparser2-tree-adapter": "^6.0.1",
-				"tslib": "^2.2.0"
-			}
-		},
-		"cheerio-select": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
-			"integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
-			"requires": {
-				"css-select": "^4.3.0",
-				"css-what": "^6.0.1",
-				"domelementtype": "^2.2.0",
-				"domhandler": "^4.3.1",
-				"domutils": "^2.8.0"
 			}
 		},
 		"chokidar": {
@@ -11133,7 +10661,8 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"comment-parser": {
 			"version": "1.3.0",
@@ -11204,7 +10733,8 @@
 		"core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true
 		},
 		"cosmiconfig": {
 			"version": "7.0.1",
@@ -11255,33 +10785,6 @@
 					"dev": true
 				}
 			}
-		},
-		"css": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-			"integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-			"requires": {
-				"inherits": "^2.0.4",
-				"source-map": "^0.6.1",
-				"source-map-resolve": "^0.6.0"
-			}
-		},
-		"css-select": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-			"integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-			"requires": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.0.1",
-				"domhandler": "^4.3.1",
-				"domutils": "^2.8.0",
-				"nth-check": "^2.0.1"
-			}
-		},
-		"css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -11339,11 +10842,6 @@
 					"dev": true
 				}
 			}
-		},
-		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
 		},
 		"deep-is": {
 			"version": "0.1.4",
@@ -11621,39 +11119,6 @@
 				"esutils": "^2.0.2"
 			}
 		},
-		"dom-serializer": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-			"integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-			"requires": {
-				"domelementtype": "^2.0.1",
-				"domhandler": "^4.2.0",
-				"entities": "^2.0.0"
-			}
-		},
-		"domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
-		},
-		"domhandler": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-			"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-			"requires": {
-				"domelementtype": "^2.2.0"
-			}
-		},
-		"domutils": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-			"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-			"requires": {
-				"dom-serializer": "^1.0.1",
-				"domelementtype": "^2.2.0",
-				"domhandler": "^4.2.0"
-			}
-		},
 		"duplexer": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -11769,11 +11234,6 @@
 				"lodash": "^4.13.1"
 			}
 		},
-		"entities": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-		},
 		"env-paths": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -11808,20 +11268,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
 			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-		},
-		"escape-unicode": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/escape-unicode/-/escape-unicode-0.2.0.tgz",
-			"integrity": "sha512-7jMQuKb8nm0h/9HYLfu4NCLFwoUsd5XO6OZ1z86PbKcMf8zDK1m7nFR0iA2CCShq4TSValaLIveE8T1UBxgALQ=="
-		},
-		"escope": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/escope/-/escope-4.0.0.tgz",
-			"integrity": "sha512-E36qlD/r6RJHVpPKArgMoMlNJzoRJFH8z/cAZlI9lbc45zB3+S7i9k6e/MNb+7bZQzNEa6r8WKN3BovpeIBwgA==",
-			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
-			}
 		},
 		"eslint": {
 			"version": "8.27.0",
@@ -12058,7 +11504,8 @@
 		"eslint-visitor-keys": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"dev": true
 		},
 		"esmock": {
 			"version": "2.0.7",
@@ -12070,6 +11517,7 @@
 			"version": "9.4.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
 			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
@@ -12109,6 +11557,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
 			"requires": {
 				"estraverse": "^5.2.0"
 			},
@@ -12116,14 +11565,10 @@
 				"estraverse": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true
 				}
 			}
-		},
-		"estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
 		},
 		"estree-walker": {
 			"version": "2.0.2",
@@ -12536,17 +11981,6 @@
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-			"integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-			"requires": {
-				"domelementtype": "^2.0.1",
-				"domhandler": "^4.0.0",
-				"domutils": "^2.5.2",
-				"entities": "^2.0.0"
-			}
 		},
 		"http-cache-semantics": {
 			"version": "4.1.0",
@@ -12991,6 +12425,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
 			"integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+			"dev": true,
 			"requires": {
 				"xmlcreate": "^2.0.4"
 			}
@@ -12999,6 +12434,7 @@
 			"version": "3.6.11",
 			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
 			"integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
+			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.9.4",
 				"@types/markdown-it": "^12.2.3",
@@ -13020,7 +12456,8 @@
 				"escape-string-regexp": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
 				}
 			}
 		},
@@ -13079,18 +12516,9 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
 			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.9"
-			}
-		},
-		"less-openui5": {
-			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/less-openui5/-/less-openui5-0.11.2.tgz",
-			"integrity": "sha512-FkAT0JDB3NGroia/hdYInzVzpERINovKEgjeijfYgLK7C4eef8a0midlgdBfTZanv3Gz8zUSjfGYXNWL82jEBA==",
-			"requires": {
-				"clone": "^2.1.0",
-				"css": "^3.0.0",
-				"mime": "^1.6.0"
 			}
 		},
 		"levn": {
@@ -13154,6 +12582,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
 			"integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+			"dev": true,
 			"requires": {
 				"uc.micro": "^1.0.1"
 			}
@@ -13184,7 +12613,8 @@
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
@@ -13393,6 +12823,7 @@
 			"version": "12.3.2",
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
 			"integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+			"dev": true,
 			"requires": {
 				"argparse": "^2.0.1",
 				"entities": "~2.1.0",
@@ -13404,7 +12835,8 @@
 				"entities": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-					"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+					"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+					"dev": true
 				}
 			}
 		},
@@ -13412,12 +12844,14 @@
 			"version": "8.6.5",
 			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
 			"integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
+			"dev": true,
 			"requires": {}
 		},
 		"marked": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.2.tgz",
-			"integrity": "sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ=="
+			"integrity": "sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==",
+			"dev": true
 		},
 		"matcher": {
 			"version": "5.0.0",
@@ -13440,7 +12874,8 @@
 		"mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+			"dev": true
 		},
 		"mem": {
 			"version": "9.0.2",
@@ -13565,11 +13000,6 @@
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
 			}
-		},
-		"mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mimic-fn": {
 			"version": "4.0.0",
@@ -14028,14 +13458,6 @@
 				"set-blocking": "^2.0.0"
 			}
 		},
-		"nth-check": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"requires": {
-				"boolbase": "^1.0.0"
-			}
-		},
 		"nyc": {
 			"version": "15.1.0",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
@@ -14274,11 +13696,6 @@
 				}
 			}
 		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -14446,19 +13863,6 @@
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
 			"integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
 			"dev": true
-		},
-		"parse5": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-		},
-		"parse5-htmlparser2-tree-adapter": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-			"requires": {
-				"parse5": "^6.0.1"
-			}
 		},
 		"path-exists": {
 			"version": "4.0.0",
@@ -14657,11 +14061,6 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true
 		},
-		"pretty-data": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/pretty-data/-/pretty-data-0.40.0.tgz",
-			"integrity": "sha512-YFLnEdDEDnkt/GEhet5CYZHCvALw6+Elyb/tp8kQG03ZSIuzeaDWpZYndCXwgqu4NAjh1PI534dhDS1mHarRnQ=="
-		},
 		"pretty-hrtime": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -14689,7 +14088,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"process-on-spawn": {
 			"version": "1.0.0",
@@ -14951,55 +14351,6 @@
 				"es6-error": "^4.0.1"
 			}
 		},
-		"replacestream": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
-			"integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
-			"requires": {
-				"escape-string-regexp": "^1.0.3",
-				"object-assign": "^4.0.1",
-				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -15022,6 +14373,7 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
 			"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.14"
 			}
@@ -15279,31 +14631,14 @@
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
 		},
 		"source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true
-		},
-		"source-map-resolve": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-			"integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-			"requires": {
-				"atob": "^2.1.2",
-				"decode-uri-component": "^0.2.0"
-			}
-		},
-		"source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
 		},
 		"sourcemap-codec": {
 			"version": "1.4.8",
@@ -15430,7 +14765,8 @@
 		"strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true
 		},
 		"strtok3": {
 			"version": "7.0.0",
@@ -15491,7 +14827,8 @@
 		"taffydb": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA=="
+			"integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA==",
+			"dev": true
 		},
 		"tap-nyan": {
 			"version": "1.1.0",
@@ -15781,17 +15118,6 @@
 				}
 			}
 		},
-		"terser": {
-			"version": "5.15.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-			"integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
-			"requires": {
-				"@jridgewell/source-map": "^0.3.2",
-				"acorn": "^8.5.0",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			}
-		},
 		"test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -15928,11 +15254,6 @@
 			"integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
 			"dev": true
 		},
-		"tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-		},
 		"type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -15966,12 +15287,14 @@
 		"uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+			"dev": true
 		},
 		"underscore": {
 			"version": "1.13.6",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+			"integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+			"dev": true
 		},
 		"unique-filename": {
 			"version": "3.0.0",
@@ -16231,7 +15554,8 @@
 		"xmlcreate": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-			"integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
+			"integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.2",
@@ -16323,14 +15647,6 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"dev": true
-		},
-		"yazl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-			"integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-			"requires": {
-				"buffer-crc32": "~0.2.3"
-			}
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
 		"url": "git@github.com:SAP/ui5-project.git"
 	},
 	"dependencies": {
-		"@ui5/builder": "^3.0.0-beta.1",
 		"@ui5/fs": "^3.0.0-beta.3",
 		"@ui5/logger": "^3.0.1-beta.1",
 		"ajv": "^6.12.6",

--- a/test/lib/build/helpers/createBuildManifest.integration.js
+++ b/test/lib/build/helpers/createBuildManifest.integration.js
@@ -48,7 +48,11 @@ test("Create project from application project providing a build manifest", async
 	const inputProject = await Specification.create(applicationAConfig);
 	inputProject.getResourceTagCollection().setTag("/resources/id1/foo.js", "ui5:HasDebugVariant");
 
-	const metadata = await createBuildManifest(inputProject, buildConfig);
+	const taskRepository = {
+		getVersions: async () => ({a: "a", b: "b"})
+	};
+
+	const metadata = await createBuildManifest(inputProject, buildConfig, taskRepository);
 	const m = new Module({
 		id: "build-descr-application.a.id",
 		version: "2.0.0",
@@ -76,7 +80,11 @@ test("Create project from library project providing a build manifest", async (t)
 	const inputProject = await Specification.create(libraryEConfig);
 	inputProject.getResourceTagCollection().setTag("/resources/library/e/file.js", "ui5:HasDebugVariant");
 
-	const metadata = await createBuildManifest(inputProject, buildConfig);
+	const taskRepository = {
+		getVersions: async () => ({a: "a", b: "b"})
+	};
+
+	const metadata = await createBuildManifest(inputProject, buildConfig, taskRepository);
 	const m = new Module({
 		id: "build-descr-library.e.id",
 		version: "2.0.0",

--- a/test/lib/build/helpers/createBuildManifest.js
+++ b/test/lib/build/helpers/createBuildManifest.js
@@ -43,17 +43,40 @@ const libraryProjectInput = {
 	}
 };
 
+test("Missing parameter: project", async (t) => {
+	await t.throwsAsync(createBuildManifest(), {
+		message: "Missing parameter 'project'"
+	});
+});
+
+test("Missing parameter: buildConfig", async (t) => {
+	const project = await Specification.create(applicationProjectInput);
+
+	await t.throwsAsync(createBuildManifest(project), {
+		message: "Missing parameter 'buildConfig'"
+	});
+});
+
+test("Missing parameter: taskRepository", async (t) => {
+	const project = await Specification.create(applicationProjectInput);
+
+	await t.throwsAsync(createBuildManifest(project, "buildConfig"), {
+		message: "Missing parameter 'taskRepository'"
+	});
+});
+
 test("Create application from project with build manifest", async (t) => {
 	const project = await Specification.create(applicationProjectInput);
 	project.getResourceTagCollection().setTag("/resources/id1/foo.js", "ui5:HasDebugVariant");
 
-	const metadata = await createBuildManifest(project, "buildConfig");
+	const taskRepository = {
+		getVersions: async () => ({a: "a", b: "b"})
+	};
+
+	const metadata = await createBuildManifest(project, "buildConfig", taskRepository);
 
 	t.truthy(new Date(metadata.buildManifest.timestamp), "Timestamp is valid");
 	metadata.buildManifest.timestamp = "<timestamp>";
-
-	t.not(semver.valid(metadata.buildManifest.versions.builderVersion), null, "builder version should be filled");
-	metadata.buildManifest.versions.builderVersion = "<version>";
 
 	t.not(semver.valid(metadata.buildManifest.versions.fsVersion), null, "fs version should be filled");
 	metadata.buildManifest.versions.fsVersion = "<version>";
@@ -77,13 +100,13 @@ test("Create application from project with build manifest", async (t) => {
 			}
 		},
 		buildManifest: {
-			manifestVersion: "0.1",
+			manifestVersion: "0.2",
 			buildConfig: "buildConfig",
 			namespace: "id1",
 			timestamp: "<timestamp>",
 			version: "1.0.0",
 			versions: {
-				builderVersion: "<version>",
+				builderVersions: {a: "a", b: "b"},
 				fsVersion: "<version>",
 				projectVersion: "<version>",
 			},
@@ -100,13 +123,14 @@ test("Create library from project with build manifest", async (t) => {
 	const project = await Specification.create(libraryProjectInput);
 	project.getResourceTagCollection().setTag("/resources/library/d/foo.js", "ui5:HasDebugVariant");
 
-	const metadata = await createBuildManifest(project, "buildConfig");
+	const taskRepository = {
+		getVersions: async () => ({a: "a", b: "b"})
+	};
+
+	const metadata = await createBuildManifest(project, "buildConfig", taskRepository);
 
 	t.truthy(new Date(metadata.buildManifest.timestamp), "Timestamp is valid");
 	metadata.buildManifest.timestamp = "<timestamp>";
-
-	t.not(semver.valid(metadata.buildManifest.versions.builderVersion), null, "builder version should be filled");
-	metadata.buildManifest.versions.builderVersion = "<version>";
 
 	t.not(semver.valid(metadata.buildManifest.versions.fsVersion), null, "fs version should be filled");
 	metadata.buildManifest.versions.fsVersion = "<version>";
@@ -131,13 +155,13 @@ test("Create library from project with build manifest", async (t) => {
 			}
 		},
 		buildManifest: {
-			manifestVersion: "0.1",
+			manifestVersion: "0.2",
 			buildConfig: "buildConfig",
 			namespace: "library/d",
 			timestamp: "<timestamp>",
 			version: "1.0.0",
 			versions: {
-				builderVersion: "<version>",
+				builderVersions: {a: "a", b: "b"},
 				fsVersion: "<version>",
 				projectVersion: "<version>",
 			},


### PR DESCRIPTION
With this change, a 'taskRepository' instance is required to be passed to the #build function of a project graph (dependency injection).
This removes the requirement of having a direct @ui5/builder dependency
in @ui5/project

In the future, we might add checks to ensure version compatibility with the injected module.

Depends on https://github.com/SAP/ui5-builder/pull/842