### PR TITLE
[INTERNAL] TaskUtil: Provide resourceFactory#createReaderCollection

### DIFF
--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -1,4 +1,5 @@
 import {
+	createReaderCollection,
 	createReaderCollectionPrioritized,
 	createResource,
 	createFilterReader,
@@ -236,6 +237,8 @@ class TaskUtil {
 	 * @typedef {object} @ui5/project/build/helpers/TaskUtil~resourceFactory
 	 * @property {Function} createResource Creates a [Resource]{@link @ui5/fs/Resource}.
 	 * 	Accepts the same parameters as the [Resource]{@link @ui5/fs/Resource} constructor.
+	 * @property {Function} createReaderCollection Creates a reader collection:
+	 *	[ReaderCollection]{@link @ui5/fs/ReaderCollection}
 	 * @property {Function} createReaderCollectionPrioritized Creates a prioritized reader collection:
 	 *	[ReaderCollectionPrioritized]{@link @ui5/fs/ReaderCollectionPrioritized}
 	 * @property {Function} createFilterReader
@@ -258,6 +261,7 @@ class TaskUtil {
 	 */
 	resourceFactory = {
 		createResource,
+		createReaderCollection,
 		createReaderCollectionPrioritized,
 		createFilterReader,
 		createLinkReader,
@@ -305,7 +309,7 @@ class TaskUtil {
 			[
 				// Once new functions get added, extract this array into a variable
 				// and enhance based on spec version once new functions get added
-				"createResource", "createReaderCollectionPrioritized",
+				"createResource", "createReaderCollection", "createReaderCollectionPrioritized",
 				"createFilterReader", "createLinkReader", "createFlatReader",
 			].forEach((factoryFunction) => {
 				baseInterface.resourceFactory[factoryFunction] = this.resourceFactory[factoryFunction];

--- a/test/lib/build/helpers/TaskUtil.js
+++ b/test/lib/build/helpers/TaskUtil.js
@@ -192,6 +192,8 @@ test("resourceFactory", (t) => {
 	});
 	t.is(typeof resourceFactory.createResource, "function",
 		"resourceFactory function createResource is available");
+	t.is(typeof resourceFactory.createReaderCollection, "function",
+		"resourceFactory function createReaderCollection is available");
 	t.is(typeof resourceFactory.createReaderCollectionPrioritized, "function",
 		"resourceFactory function createReaderCollectionPrioritized is available");
 	t.is(typeof resourceFactory.createFilterReader, "function",
@@ -423,6 +425,8 @@ test("getInterface: specVersion 3.0", (t) => {
 	const resourceFactory = interfacedTaskUtil.resourceFactory;
 	t.is(typeof resourceFactory.createResource, "function",
 		"resourceFactory function createResource is available");
+	t.is(typeof resourceFactory.createReaderCollection, "function",
+		"resourceFactory function createReaderCollection is available");
 	t.is(typeof resourceFactory.createReaderCollectionPrioritized, "function",
 		"resourceFactory function createReaderCollectionPrioritized is available");
 	t.is(typeof resourceFactory.createFilterReader, "function",


### PR DESCRIPTION
Follow-up of https://github.com/SAP/ui5-project/pull/514 where this method was somehow missed