### PR TITLE
[INTERNAL] Use native fs.mkdir instead of mkdirp

### DIFF
--- a/lib/ui5Framework/npm/Installer.js
+++ b/lib/ui5Framework/npm/Installer.js
@@ -1,5 +1,4 @@
 import path from "node:path";
-import mkdirp from "mkdirp";
 import fs from "graceful-fs";
 import {promisify} from "node:util";
 import Registry from "./Registry.js";
@@ -8,6 +7,7 @@ const rimraf = promisify(_rimraf);
 const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
 const rename = promisify(fs.rename);
+const mkdir = promisify(fs.mkdir);
 import logger from "@ui5/logger";
 const log = logger.getLogger("ui5Framework:npm:Installer");
 
@@ -100,7 +100,7 @@ class Installer {
 
 					// Do not create target dir itself to prevent EPERM error in following rename operation
 					// (https://github.com/SAP/ui5-tooling/issues/487)
-					await mkdirp(path.dirname(targetDir));
+					await mkdir(path.dirname(targetDir), {recursive: true});
 					log.verbose(`Promoting staging directory from ${stagingDir} to ${targetDir}...`);
 					await rename(stagingDir, targetDir);
 				} else {
@@ -139,7 +139,7 @@ class Installer {
 		const lock = promisify(lockfile.lock);
 		const unlock = promisify(lockfile.unlock);
 		const lockPath = this._getLockPath({pkgName, version});
-		await mkdirp(this._lockDir);
+		await mkdir(this._lockDir, {recursive: true});
 		log.verbose("Locking " + lockPath);
 		await lock(lockPath, {
 			wait: 10000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
 				"js-yaml": "^4.1.0",
 				"libnpmconfig": "^1.2.1",
 				"lockfile": "^1.0.4",
-				"mkdirp": "^1.0.4",
 				"pacote": "^15.0.6",
 				"pretty-hrtime": "^1.0.3",
 				"read-pkg": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
 		"js-yaml": "^4.1.0",
 		"libnpmconfig": "^1.2.1",
 		"lockfile": "^1.0.4",
-		"mkdirp": "^1.0.4",
 		"pacote": "^15.0.6",
 		"pretty-hrtime": "^1.0.3",
 		"read-pkg": "^7.1.0",

--- a/test/lib/graph/helpers/ui5Framework.integration.js
+++ b/test/lib/graph/helpers/ui5Framework.integration.js
@@ -49,9 +49,9 @@ test.beforeEach(async (t) => {
 
 	t.context.Installer = await esmock.p("../../../../lib/ui5Framework/npm/Installer.js", {
 		"@ui5/logger": ui5Logger,
-		"mkdirp": sinon.stub().resolves(),
 		"graceful-fs": {
-			rename: sinon.stub().yieldsAsync()
+			rename: sinon.stub().yieldsAsync(),
+			mkdir: sinon.stub().yieldsAsync()
 		},
 		"lockfile": {
 			lock: sinon.stub().yieldsAsync(),

--- a/test/lib/ui5framework/npm/Installer.js
+++ b/test/lib/ui5framework/npm/Installer.js
@@ -7,16 +7,15 @@ import {fileURLToPath} from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 test.beforeEach(async (t) => {
-	t.context.mkdirpStub = sinon.stub().resolves();
 	t.context.rimrafStub = sinon.stub().yieldsAsync();
 
 	t.context.lockStub = sinon.stub();
 	t.context.unlockStub = sinon.stub();
 	t.context.renameStub = sinon.stub().yieldsAsync();
 	t.context.statStub = sinon.stub().yieldsAsync();
+	t.context.mkdirStub = sinon.stub().yieldsAsync();
 
 	t.context.Installer = await esmock.p("../../../../lib/ui5Framework/npm/Installer.js", {
-		"mkdirp": t.context.mkdirpStub,
 		"rimraf": t.context.rimrafStub,
 		"lockfile": {
 			lock: t.context.lockStub,
@@ -24,7 +23,8 @@ test.beforeEach(async (t) => {
 		},
 		"graceful-fs": {
 			rename: t.context.renameStub,
-			stat: t.context.statStub
+			stat: t.context.statStub,
+			mkdir: t.context.mkdirStub
 		}
 	});
 });
@@ -299,9 +299,11 @@ test.serial("Installer: _synchronize", async (t) => {
 	t.deepEqual(getLockPathStub.getCall(0).args, [{pkgName: "@openui5/sap.ui.lib1", version: "1.2.3"}],
 		"_getLockPath should be called with expected args");
 
-	t.is(t.context.mkdirpStub.callCount, 1, "_mkdirp should be called once");
-	t.deepEqual(t.context.mkdirpStub.getCall(0).args, [path.join("/ui5Home/", "framework", "locks")],
-		"_mkdirp should be called with expected args");
+	t.is(t.context.mkdirStub.callCount, 1, "mkdir should be called once");
+	t.is(t.context.mkdirStub.getCall(0).args[0], path.join("/ui5Home/", "framework", "locks"),
+		"mkdir should be called with expected path");
+	t.deepEqual(t.context.mkdirStub.getCall(0).args[1], {recursive: true},
+		"mkdir should be called with expected options");
 
 	t.is(t.context.lockStub.callCount, 1, "lock should be called once");
 	t.is(t.context.lockStub.getCall(0).args[0], "/locks/lockfile.lock",
@@ -498,11 +500,11 @@ test.serial("Installer: installPackage with new package", async (t) => {
 
 	t.is(extractPackageStub.callCount, 1, "_extractPackage should be called once");
 
-	t.is(t.context.mkdirpStub.callCount, 2, "mkdirp should be called twice");
-	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
-		"mkdirp should be called with the correct arguments on first call");
-	t.is(t.context.mkdirpStub.getCall(1).args[0], path.join("my", "package"),
-		"mkdirp should be called with the correct arguments on second call");
+	t.is(t.context.mkdirStub.callCount, 2, "mkdir should be called twice");
+	t.is(t.context.mkdirStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
+		"mkdir should be called with the correct arguments on first call");
+	t.is(t.context.mkdirStub.getCall(1).args[0], path.join("my", "package"),
+		"mkdir should be called with the correct arguments on second call");
 
 	t.is(t.context.renameStub.callCount, 1, "fs.rename should be called once");
 	t.is(t.context.renameStub.getCall(0).args[0], "staging-dir-path",
@@ -561,7 +563,7 @@ test.serial("Installer: installPackage with already installed package", async (t
 	t.is(pathExistsStub.callCount, 0, "_pathExists should never be called");
 	t.is(t.context.rimrafStub.callCount, 0, "rimraf should never be called");
 	t.is(extractPackageStub.callCount, 0, "_extractPackage should never be called");
-	t.is(t.context.mkdirpStub.callCount, 0, "mkdirp should never be called");
+	t.is(t.context.mkdirStub.callCount, 0, "mkdir should never be called");
 	t.is(t.context.renameStub.callCount, 0, "fs.rename should never be called");
 });
 
@@ -619,9 +621,9 @@ test.serial("Installer: installPackage with install already in progress", async 
 
 	t.is(t.context.rimrafStub.callCount, 0, "rimraf should never be called");
 
-	t.is(t.context.mkdirpStub.callCount, 1, "mkdirp should be called once");
-	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
-		"mkdirp should be called with the correct arguments");
+	t.is(t.context.mkdirStub.callCount, 1, "mkdir should be called once");
+	t.is(t.context.mkdirStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
+		"mkdir should be called with the correct arguments");
 
 	t.is(getStagingDirForPackageStub.callCount, 0, "_getStagingDirForPackage should never be called");
 	t.is(pathExistsStub.callCount, 0, "_pathExists should never be called");
@@ -703,11 +705,11 @@ test.serial("Installer: installPackage with new package and existing target and 
 
 	t.is(extractPackageStub.callCount, 1, "_extractPackage should be called once");
 
-	t.is(t.context.mkdirpStub.callCount, 2, "mkdirp should be called twice");
-	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
-		"mkdirp should be called with the correct arguments on first call");
-	t.is(t.context.mkdirpStub.getCall(1).args[0], path.join("my", "package"),
-		"mkdirp should be called with the correct arguments on second call");
+	t.is(t.context.mkdirStub.callCount, 2, "mkdir should be called twice");
+	t.is(t.context.mkdirStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
+		"mkdir should be called with the correct arguments on first call");
+	t.is(t.context.mkdirStub.getCall(1).args[0], path.join("my", "package"),
+		"mkdir should be called with the correct arguments on second call");
 
 	t.is(t.context.renameStub.callCount, 1, "fs.rename should be called once");
 	t.is(t.context.renameStub.getCall(0).args[0], "staging-dir-path",


### PR DESCRIPTION
The recursive option is available since Node v10.12, which makes the
use of thirdparty packages obsolete for most use cases.
