### PR TITLE
[INTERNAL] TaskUtil#getProject: Retrieve Project for a given Resource

### DIFF
--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -283,7 +283,7 @@ class TaskRunner {
 						{@ui5/project/build/helpers/TaskUtil} parameters.taskUtil Specification Version-dependent
 							interface of a [TaskUtil]{@link @ui5/project/build/helpers/TaskUtil} instance
 						{@ui5/logger/GroupLogger} [parameters.log] Logger instance to use by the custom task.
-							This method is only available to custom task extensions defining
+							This parameter is only available to custom task extensions defining
 	 						<b>Specification Version 3.0 and above</b>.
 						{Object} parameters.options Options
 						{string} parameters.options.projectName Project name

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -206,8 +206,8 @@ class TaskUtil {
 	 * Name of the project to retrieve or a Resource instance to retrieve the associated project for.
 	 * Defaults to the name of the project currently being built
 	 * @returns {@ui5/project/build/helpers/TaskUtil~ProjectInterface|undefined}
-	 * Specification Version-dependent interface to the Project instance or
-	 * undefined if the project name is unknown or the provided resource is not associated with any project.
+	 * Specification Version-dependent interface to the Project instance or <code>undefined</code>
+	 * if the project name is unknown or the provided resource is not associated with any project.
 	 * @public
 	 */
 	getProject(projectNameOrResource) {

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -202,13 +202,26 @@ class TaskUtil {
 	 * This method is only available to custom task extensions defining
 	 * <b>Specification Version 3.0 and above</b>.
 	 *
-	 * @param {string} [projectName] Name of the project to retrieve. Defaults to the project currently being built
+	 * @param {string|@ui5/fs/Resource} [projectNameOrResource]
+	 * Name of the project to retrieve or a Resource instance to retrieve the associated project for.
+	 * Defaults to the name of the project currently being built
 	 * @returns {@ui5/project/build/helpers/TaskUtil~ProjectInterface|undefined}
-	 *					project instance or undefined if the project is unknown to the graph
+	 * Specification Version-dependent interface to the Project instance or
+	 * undefined if the project name is unknown or the provided resource is not associated with any project.
 	 * @public
 	 */
-	getProject(projectName) {
-		return this._projectBuildContext.getProject(projectName);
+	getProject(projectNameOrResource) {
+		if (projectNameOrResource) {
+			if (typeof projectNameOrResource === "string" || projectNameOrResource instanceof String) {
+				// A project name has been provided
+				return this._projectBuildContext.getProject(projectNameOrResource);
+			} else {
+				// A Resource instance has been provided
+				return projectNameOrResource.getProject();
+			}
+		}
+		// No parameter has been provided, default to the project currently being built.
+		return this._projectBuildContext.getProject();
 	}
 
 	/**

--- a/test/lib/build/helpers/TaskUtil.js
+++ b/test/lib/build/helpers/TaskUtil.js
@@ -169,7 +169,43 @@ test("getProject", (t) => {
 	const res = taskUtil.getProject("pony farm");
 
 	t.is(getProjectStub.callCount, 1, "ProjectBuildContext#getProject got called once");
+	t.is(getProjectStub.getCall(0).args[0], "pony farm",
+		"ProjectBuildContext#getProject got called with expected arguments");
 	t.is(res, "Pony farm!", "Correct result");
+});
+
+test("getProject: Default name", (t) => {
+	const getProjectStub = sinon.stub().returns("Pony farm!");
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			getProject: getProjectStub
+		}
+	});
+
+	const res = taskUtil.getProject();
+
+	t.is(getProjectStub.callCount, 1, "ProjectBuildContext#getProject got called once");
+	t.is(getProjectStub.getCall(0).args[0], undefined,
+		"ProjectBuildContext#getProject got called with no arguments");
+	t.is(res, "Pony farm!", "Correct result");
+});
+
+test("getProject: Resource", (t) => {
+	const getProjectStub = sinon.stub();
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			getProject: getProjectStub
+		}
+	});
+
+	const mockResource = {
+		getProject: sinon.stub().returns("Pig farm!")
+	};
+	const res = taskUtil.getProject(mockResource);
+
+	t.is(getProjectStub.callCount, 0, "ProjectBuildContext#getProject has not been called");
+	t.is(mockResource.getProject.callCount, 1, "Resource#getProject has been called once");
+	t.is(res, "Pig farm!", "Correct result");
 });
 
 test("getDependencies", (t) => {
@@ -183,6 +219,24 @@ test("getDependencies", (t) => {
 	const res = taskUtil.getDependencies("pony farm");
 
 	t.is(getDependenciesStub.callCount, 1, "ProjectBuildContext#getDependencies got called once");
+	t.is(getDependenciesStub.getCall(0).args[0], "pony farm",
+		"ProjectBuildContext#getDependencies got called with expected arguments");
+	t.is(res, "Pony farm!", "Correct result");
+});
+
+test("getDependencies: Default name", (t) => {
+	const getDependenciesStub = sinon.stub().returns("Pony farm!");
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			getDependencies: getDependenciesStub
+		}
+	});
+
+	const res = taskUtil.getDependencies();
+
+	t.is(getDependenciesStub.callCount, 1, "ProjectBuildContext#getDependencies got called once");
+	t.is(getDependenciesStub.getCall(0).args[0], undefined,
+		"ProjectBuildContext#getDependencies got called with no arguments");
 	t.is(res, "Pony farm!", "Correct result");
 });
 


### PR DESCRIPTION
For custom task, this will return a Specification Version-dependent
(=compatible) interface of the Project instance a Resource is associated
with.

This was already described in RFC12[1] but not part of the initial
implementation of TaskUtil#getProject.

[1] https://github.com/SAP/ui5-tooling/pull/664