### PR TITLE
[INTERNAL] Refactor requires build/requires dependencies determination

### DIFF
--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -120,7 +120,7 @@ class ProjectBuilder {
 				//	=> This project needs to be built or, in case it has already
 				//		been built, it's build result needs to be written out (if requested)
 				queue.push(projectBuildContext);
-				if (!projectBuildContext.getTaskRunner().requiresBuild()) {
+				if (!projectBuildContext.requiresBuild()) {
 					alreadyBuilt.push(projectName);
 				}
 			}
@@ -141,7 +141,7 @@ class ProjectBuilder {
 						const projectName = projectBuildContext.getProject().getName();
 						let msg;
 						if (alreadyBuilt.includes(projectName)) {
-							const buildMetadata = projectBuildContext.getTaskRunner().getBuildMetadata();
+							const buildMetadata = projectBuildContext.getBuildMetadata();
 							const ts = new Date(buildMetadata.timestamp).toUTCString();
 							msg = `*> ${projectName} /// already built at ${ts}`;
 						} else {
@@ -167,7 +167,7 @@ class ProjectBuilder {
 				// Only build projects that are not already build (i.e. provide a matching build manifest)
 				if (!alreadyBuilt.includes(projectName)) {
 					buildLogger.startWork(`Building project ${projectName}...`);
-					await this._buildProject(projectBuildContext);
+					await projectBuildContext.getTaskRunner().runTasks();
 					buildLogger.completeWork(1);
 
 					log.verbose(`Finished building project ${projectName}`);
@@ -203,20 +203,28 @@ class ProjectBuilder {
 		for (const project of requiredProjects) {
 			const projectName = project.getName();
 			log.verbose(`Creating build context for project ${projectName}...`);
-			const projectBuildContext = await this._buildContext.createProjectContext({
+			const projectBuildContext = this._buildContext.createProjectContext({
 				project,
 				log
 			});
 
-			const taskRunner = projectBuildContext.getTaskRunner();
 			projectBuildContexts.set(projectName, projectBuildContext);
 
-			if (taskRunner.requiresBuild() && taskRunner.requiresDependencies()) {
+			if (projectBuildContext.requiresBuild()) {
+				const taskRunner = projectBuildContext.getTaskRunner();
+				const requiredDependencies = await taskRunner.getRequiredDependencies();
+
+				if (requiredDependencies.size === 0) {
+					continue;
+				}
 				// This project needs to be built and required dependencies to be built as well
 				this._graph.getDependencies(projectName).forEach((depName) => {
 					if (projectBuildContexts.has(depName)) {
 						// Build context already exists
 						//	=> Dependency will be built
+						return;
+					}
+					if (!requiredDependencies.has(depName)) {
 						return;
 					}
 					// Add dependency to list of projects to build
@@ -277,31 +285,6 @@ class ProjectBuilder {
 
 			return false;
 		};
-	}
-
-	async _buildProject(projectBuildContext) {
-		const project = projectBuildContext.getProject();
-		const taskRunner = projectBuildContext.getTaskRunner();
-
-		// Create readers for all dependencies
-		const readers = [];
-		await this._graph.traverseBreadthFirst(project.getName(), async function({project: dep}) {
-			if (dep.getName() === project.getName()) {
-				// Ignore project itself
-				return;
-			}
-			readers.push(dep.getReader());
-		});
-
-		const dependencies = resourceFactory.createReaderCollection({
-			name: `Dependency reader collection for project ${project.getName()}`,
-			readers
-		});
-
-		await taskRunner.runTasks({
-			workspace: project.getWorkspace(),
-			dependencies,
-		});
 	}
 
 	async _writeResults(projectBuildContext, target) {

--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -131,7 +131,7 @@ class TaskRunner {
 	 * First compiles a list of all tasks that will be executed, then a list of all direct project
 	 * dependencies that those tasks require access to.
 	 *
-	 * @returns {Set} Returns a set containing the names of all required direct project dependencies
+	 * @returns {Set<string>} Returns a set containing the names of all required direct project dependencies
 	 */
 	async getRequiredDependencies() {
 		await this._initTasks();
@@ -327,7 +327,7 @@ class TaskRunner {
 				taskConfiguration: taskDef.configuration,
 				getDependenciesReader: () => {
 					// Create the dependencies reader on-demand
-					return this._createDependencyReader(requiredDependencies);
+					return this._createDependenciesReader(requiredDependencies);
 				},
 			}),
 			requiredDependencies
@@ -426,7 +426,7 @@ class TaskRunner {
 		}
 	}
 
-	async _createDependencyReader(requiredDirectDependencies) {
+	async _createDependenciesReader(requiredDirectDependencies) {
 		if (requiredDirectDependencies.size === 0) {
 			// No dependencies are required, so no reader will be provided
 			return null;

--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -1,5 +1,6 @@
 import composeTaskList from "./helpers/composeTaskList.js";
 import logger from "@ui5/logger";
+import {createReaderCollection} from "@ui5/fs/resourceFactory";
 
 /**
  * TaskRunner
@@ -19,10 +20,9 @@ class TaskRunner {
 	 * @param {@ui5/builder/tasks/taskRepository} parameters.taskRepository Task repository
 	 * @param {@ui5/project/build/ProjectBuilder~BuildConfiguration} parameters.buildConfig
 	 * 			Build configuration
-	 * @param {Map<string, object>} parameters.standardTasks Standard tasks
 	 */
-	constructor({graph, project, parentLogger, taskUtil, taskRepository, buildConfig, standardTasks}) {
-		if (!graph || !project || !parentLogger || !taskUtil || !buildConfig || !standardTasks) {
+	constructor({graph, project, parentLogger, taskUtil, taskRepository, buildConfig}) {
+		if (!graph || !project || !parentLogger || !taskUtil || !taskRepository || !buildConfig) {
 			throw new Error("One or more mandatory parameters not provided");
 		}
 		this._project = project;
@@ -34,33 +34,18 @@ class TaskRunner {
 		this._log = parentLogger.createSubLogger(project.getType() + " " + project.getName(), 0.2);
 		this._taskLog = this._log.createTaskLogger("🔨");
 
+		this._directDependencies = new Set(this._taskUtil.getDependencies());
+	}
+
+	async _initTasks() {
+		if (this._tasks) {
+			return;
+		}
+
 		this._tasks = Object.create(null);
 		this._taskExecutionOrder = [];
 
-		for (const [taskName, params] of standardTasks) {
-			this._addTask(taskName, params);
-		}
-
-		this._addCustomTasks({
-			graph,
-			project,
-			taskUtil
-		});
-	}
-
-	/**
-	 * Creates a new TaskRunner Instance
-	 *
-	 * @param {object} parameters
-	 * @param {object} parameters.graph
-	 * @param {object} parameters.project
-	 * @param {@ui5/logger/GroupLogger} parameters.parentLogger Logger to use
-	 * @param {@ui5/project/build/helpers/TaskUtil} parameters.taskUtil TaskUtil instance
-	 * @param {@ui5/builder/tasks/taskRepository} parameters.taskRepository Task repository
-	 * @param {@ui5/project/build/ProjectBuilder~BuildConfiguration} parameters.buildConfig
-	 * 			Build configuration
-	 */
-	static async create({graph, project, parentLogger, taskUtil, taskRepository, buildConfig}) {
+		const project = this._project;
 		let buildDefinition;
 
 		switch (project.getType()) {
@@ -84,22 +69,39 @@ class TaskRunner {
 
 		const standardTasks = getStandardTasks({
 			project,
-			taskUtil,
-			getTask: taskRepository.getTask
+			taskUtil: this._taskUtil,
+			getTask: this._taskRepository.getTask
 		});
 
-		return new TaskRunner({graph, project, parentLogger, taskUtil, taskRepository, buildConfig, standardTasks});
+		for (const [taskName, params] of standardTasks) {
+			this._addTask(taskName, params);
+		}
+
+		await this._addCustomTasks();
+
+		// Create readers for *all* dependencies
+		const depReaders = [];
+		await this._graph.traverseBreadthFirst(project.getName(), async function({project: dep}) {
+			if (dep.getName() === project.getName()) {
+				// Ignore project itself
+				return;
+			}
+			depReaders.push(dep.getReader());
+		});
+
+		this._allDependenciesReader = createReaderCollection({
+			name: `Dependency reader collection of project ${project.getName()}`,
+			readers: depReaders
+		});
 	}
 
 	/**
 	 * Takes a list of tasks which should be executed from the available task list of the current builder
 	 *
-	 * @param {object} buildParams
-	 * @param {@ui5/fs/DuplexCollection} buildParams.workspace Workspace of the current project
-	 * @param {@ui5/fs/ReaderCollection} buildParams.dependencies Dependencies reader collection
-	 * @returns {Promise} Returns promise chain with tasks
+	 * @returns {Promise} Returns promise resolving once all tasks have been executed
 	 */
-	async runTasks(buildParams) {
+	async runTasks() {
+		await this._initTasks();
 		const tasksToRun = composeTaskList(Object.keys(this._tasks), this._buildConfig);
 		const allTasks = this._taskExecutionOrder.filter((taskName) => {
 			// There might be a numeric suffix in case a custom task is configured multiple times.
@@ -120,17 +122,19 @@ class TaskRunner {
 			const taskFunction = this._tasks[taskName].task;
 
 			if (typeof taskFunction === "function") {
-				await this._executeTask(taskName, taskFunction, buildParams);
+				await this._executeTask(taskName, taskFunction);
 			}
 		}
 	}
 
 	/**
-	 * Takes a list of tasks which should be executed from the available task list of the current builder
+	 * First compiles a list of all tasks that will be executed, then a list of all direct project
+	 * dependencies that those tasks require access to.
 	 *
-	 * @returns {Promise} Returns promise chain with tasks
+	 * @returns {Set} Returns a set containing the names of all required direct project dependencies
 	 */
-	requiresDependencies() {
+	async getRequiredDependencies() {
+		await this._initTasks();
 		const tasksToRun = composeTaskList(Object.keys(this._tasks), this._buildConfig);
 		const allTasks = this._taskExecutionOrder.filter((taskName) => {
 			// There might be a numeric suffix in case a custom task is configured multiple times.
@@ -144,33 +148,15 @@ class TaskRunner {
 			const taskWithoutSuffixCounter = taskName.replace(/--\d+$/, "");
 			return tasksToRun.includes(taskWithoutSuffixCounter);
 		});
-		return allTasks.some((taskName) => {
-			if (this._tasks[taskName].requiresDependencies) {
+		return allTasks.reduce((requiredDependencies, taskName) => {
+			if (this._tasks[taskName].requiredDependencies.size) {
 				this._log.verbose(`Task ${taskName} for project ${this._project.getName()} requires dependencies`);
-				return true;
 			}
-			return false;
-		});
-	}
-
-	requiresBuild() {
-		// TODO: Decide based on build config and manifest content
-		return !this._project.hasBuildManifest();
-	}
-
-	getBuildMetadata() {
-		if (this._project.hasBuildManifest()) {
-			const buildManifest = this._project.getBuildManifest();
-			const timeDiff = (new Date().getTime() - new Date(buildManifest.timestamp).getTime());
-
-			// TODO: Format age properly via a new @ui5/logger util module
-			return {
-				timestamp: buildManifest.timestamp,
-				age: timeDiff / 1000 + " seconds"
-			};
-		} else {
-			return null;
-		}
+			for (const depName of this._tasks[taskName].requiredDependencies) {
+				requiredDependencies.add(depName);
+			}
+			return requiredDependencies;
+		}, new Set());
 	}
 
 	/**
@@ -193,18 +179,18 @@ class TaskRunner {
 				`It has already been scheduled for execution`);
 		}
 
-		const task = async ({workspace, dependencies}, log) => {
+		const task = async (log) => {
 			options.projectName = this._project.getName();
 			options.projectNamespace = this._project.getNamespace();
 
 			const params = {
-				workspace,
+				workspace: this._project.getWorkspace(),
 				taskUtil: this._taskUtil,
 				options
 			};
 
 			if (requiresDependencies) {
-				params.dependencies = dependencies;
+				params.dependencies = this._allDependenciesReader;
 			}
 
 			if (!taskFunction) {
@@ -214,138 +200,211 @@ class TaskRunner {
 		};
 		this._tasks[taskName] = {
 			task,
-			requiresDependencies
+			requiredDependencies: requiresDependencies ? this._directDependencies : new Set()
 		};
 		this._taskExecutionOrder.push(taskName);
 	}
 
 	/**
-	 * Adds custom tasks to execute
 	 *
 	 * @private
-	 * @param {object} parameters
-	 * @param {object} parameters.graph
-	 * @param {object} parameters.project
-	 * @param {object} parameters.taskUtil
 	 */
-	_addCustomTasks({graph, project, taskUtil}) {
-		const projectCustomTasks = project.getCustomTasks();
+	async _addCustomTasks() {
+		const projectCustomTasks = this._project.getCustomTasks();
 		if (!projectCustomTasks || projectCustomTasks.length === 0) {
 			return; // No custom tasks defined
 		}
 		for (let i = 0; i < projectCustomTasks.length; i++) {
-			const taskDef = projectCustomTasks[i];
-			if (!taskDef.name) {
-				throw new Error(`Missing name for custom task in configuration of project ${project.getName()}`);
-			}
-			if (taskDef.beforeTask && taskDef.afterTask) {
-				throw new Error(`Custom task definition ${taskDef.name} of project ${project.getName()} ` +
-					`defines both "beforeTask" and "afterTask" parameters. Only one must be defined.`);
-			}
-			if (this._taskExecutionOrder.length && !taskDef.beforeTask && !taskDef.afterTask) {
-				// Iff there are tasks configured, beforeTask or afterTask must be given
-				throw new Error(`Custom task definition ${taskDef.name} of project ${project.getName()} ` +
-					`defines neither a "beforeTask" nor an "afterTask" parameter. One must be defined.`);
-			}
-			const standardTasks = this._taskRepository.getAllTaskNames();
-			if (standardTasks.includes(taskDef.name)) {
-				throw new Error(
-					`Custom task configuration of project ${project.getName()} ` +
-					`references standard task ${taskDef.name}. Only custom tasks must be provided here.`);
-			}
+			// Add tasks one-by-one to keep order as defined in project configuration
+			await this._addCustomTask(projectCustomTasks[i]);
+		}
+	}
+	/**
+	 * Adds custom tasks to execute
+	 *
+	 * @private
+	 * @param {object} taskDef
+	 */
+	async _addCustomTask(taskDef) {
+		const project = this._project;
+		const graph = this._graph;
+		const taskUtil = this._taskUtil;
 
-			let newTaskName = taskDef.name;
-			if (this._tasks[newTaskName]) {
-				// Task is already known
-				// => add a suffix to allow for multiple configurations of the same task
-				let suffixCounter = 1;
-				while (this._tasks[newTaskName]) {
-					suffixCounter++; // Start at 2
-					newTaskName = `${taskDef.name}--${suffixCounter}`;
-				}
-			}
-			const task = graph.getExtension(taskDef.name);
-			if (!task) {
-				throw new Error(
-					`Could not find custom task ${taskDef.name}, referenced by project ${project.getName()} ` +
-					`in project graph with root node ${graph.getRoot().getName()}`);
-			}
-			// TODO: Create callback for custom tasks to configure "requiresDependencies" and "enabled"
-			// 		Input: task "options" and build mode ("standalone", "preload", etc.)
-			const requiresDependencies = true; // Default to true for old spec versions
-			const execTask = async function({workspace, dependencies}, log) {
-				/* Custom Task Interface
-					Parameters:
-						{Object} parameters Parameters
-						{@ui5/fs/DuplexCollection} parameters.workspace DuplexCollection to read and write files
-						{@ui5/fs/AbstractReader} parameters.dependencies
-							Reader or Collection to read dependency files
-						{@ui5/project/build/helpers/TaskUtil} parameters.taskUtil Specification Version-dependent
-							interface of a [TaskUtil]{@link @ui5/project/build/helpers/TaskUtil} instance
-						{@ui5/logger/GroupLogger} [parameters.log] Logger instance to use by the custom task.
-							This parameter is only available to custom task extensions defining
-	 						<b>Specification Version 3.0 and above</b>.
-						{Object} parameters.options Options
-						{string} parameters.options.projectName Project name
-						{string|null} parameters.options.projectNamespace Project namespace if available
-						{string} [parameters.options.taskName] Runtime name of the task.
-							If a task is executed multiple times, a suffix is added to distinguish the executions.
-							This attribute is only available to custom task extensions defining
-	 						<b>Specification Version 3.0 and above</b>.
-						{string} [parameters.options.configuration] Task configuration if given in ui5.yaml
-					Returns:
-						{Promise<undefined>} Promise resolving with undefined once data has been written
-				*/
-				const params = {
-					workspace,
-					options: {
-						projectName: project.getName(),
-						projectNamespace: project.getNamespace(),
-						configuration: taskDef.configuration,
-					}
-				};
+		if (!taskDef.name) {
+			throw new Error(`Missing name for custom task in configuration of project ${project.getName()}`);
+		}
+		if (taskDef.beforeTask && taskDef.afterTask) {
+			throw new Error(`Custom task definition ${taskDef.name} of project ${project.getName()} ` +
+				`defines both "beforeTask" and "afterTask" parameters. Only one must be defined.`);
+		}
+		if (this._taskExecutionOrder.length && !taskDef.beforeTask && !taskDef.afterTask) {
+			// Iff there are tasks configured, beforeTask or afterTask must be given
+			throw new Error(`Custom task definition ${taskDef.name} of project ${project.getName()} ` +
+				`defines neither a "beforeTask" nor an "afterTask" parameter. One must be defined.`);
+		}
+		const standardTasks = this._taskRepository.getAllTaskNames();
+		if (standardTasks.includes(taskDef.name)) {
+			throw new Error(
+				`Custom task configuration of project ${project.getName()} ` +
+				`references standard task ${taskDef.name}. Only custom tasks must be provided here.`);
+		}
 
-				if (requiresDependencies) {
-					params.dependencies = dependencies;
-				}
-
-				const specVersion = task.getSpecVersion();
-				if (specVersion.gte("3.0")) {
-					params.options.taskName = newTaskName;
-					params.log = logger.getGroupLogger(`builder:custom-task:${newTaskName}`);
-				}
-
-				const taskUtilInterface = taskUtil.getInterface(specVersion);
-				// Interface is undefined if specVersion does not support taskUtil
-				if (taskUtilInterface) {
-					params.taskUtil = taskUtilInterface;
-				}
-				return (await task.getTask())(params);
-			};
-
-			this._tasks[newTaskName] = {
-				task: execTask,
-				requiresDependencies
-			};
-
-			if (this._taskExecutionOrder.length) {
-				// There is at least one task configured. Use before- and afterTask to add the custom task
-				const refTaskName = taskDef.beforeTask || taskDef.afterTask;
-				let refTaskIdx = this._taskExecutionOrder.indexOf(refTaskName);
-				if (refTaskIdx === -1) {
-					throw new Error(`Could not find task ${refTaskName}, referenced by custom task ${newTaskName}, ` +
-						`to be scheduled for project ${project.getName()}`);
-				}
-				if (taskDef.afterTask) {
-					// Insert after index of referenced task
-					refTaskIdx++;
-				}
-				this._taskExecutionOrder.splice(refTaskIdx, 0, newTaskName);
-			} else {
-				// There is no task configured so far. Just add the custom task
-				this._taskExecutionOrder.push(newTaskName);
+		let newTaskName = taskDef.name;
+		if (this._tasks[newTaskName]) {
+			// Task is already known
+			// => add a suffix to allow for multiple configurations of the same task
+			let suffixCounter = 1;
+			while (this._tasks[newTaskName]) {
+				suffixCounter++; // Start at 2
+				newTaskName = `${taskDef.name}--${suffixCounter}`;
 			}
 		}
+		const task = graph.getExtension(taskDef.name);
+		if (!task) {
+			throw new Error(
+				`Could not find custom task ${taskDef.name}, referenced by project ${project.getName()} ` +
+				`in project graph with root node ${graph.getRoot().getName()}`);
+		}
+
+		// Tasks can provide an optional callback to tell build process which dependencies they require
+		const requiredDependenciesCallback = await task.getRequiredDependenciesCallback();
+		const specVersion = task.getSpecVersion();
+		let requiredDependencies;
+		if (!requiredDependenciesCallback) {
+			if (specVersion.gte("3.0")) {
+				// Default for new spec versions: Provide no dependencies if no callback is provided
+				this._log.verbose(
+					`Custom task ${task.getName()} of project ${this._project.getName()} ` +
+					`does not provide a callback for determining its required dependencies. ` +
+					`Defaulting to not providing any dependencies to the task`);
+				requiredDependencies = new Set();
+			} else {
+				// Default for old spec versions: Assume all dependencies are required
+				requiredDependencies = this._directDependencies;
+			}
+		} else {
+			const dependencyDeterminationParams = {
+				availableDependencies: new Set(this._directDependencies)
+			};
+
+			if (specVersion.gte("3.0")) {
+				// Add getProjects, getDependencies and options to parameters
+				const taskUtilInterface = taskUtil.getInterface(specVersion);
+				dependencyDeterminationParams.getProject =
+					taskUtilInterface.getProject.bind(taskUtilInterface);
+				dependencyDeterminationParams.getDependencies =
+					taskUtilInterface.getDependencies.bind(taskUtilInterface);
+				dependencyDeterminationParams.options = {
+					projectName: project.getName(),
+					projectNamespace: project.getNamespace(),
+					configuration: taskDef.configuration,
+					taskName: newTaskName
+				};
+			}
+			requiredDependencies = await requiredDependenciesCallback(dependencyDeterminationParams);
+			if (!(requiredDependencies instanceof Set)) {
+				throw new Error(
+					`'determineRequiredDependencies' callback function of custom task ${task.getName()} of ` +
+					`project ${project.getName()} must resolve with Set.`);
+			}
+			requiredDependencies.forEach((depName) => {
+				// Returned requiredDependencies must be a subset of all direct dependencies of the project
+				if (!this._directDependencies.has(depName)) {
+					throw new Error(
+						`'determineRequiredDependencies' callback function of custom task ${task.getName()} ` +
+						`of project ${project.getName()} must resolve with a subset of the the direct ` +
+						`dependencies of the project. ${depName} is not a direct dependency of the project.`);
+				}
+			});
+		}
+
+		this._tasks[newTaskName] = {
+			task: this._createCustomTaskWrapper({
+				task,
+				project,
+				taskUtil,
+				taskName: newTaskName,
+				taskConfiguration: taskDef.configuration,
+				getDependenciesReader: () => {
+					// Create the dependencies reader on-demand
+					return this._createDependencyReader(requiredDependencies);
+				},
+			}),
+			requiredDependencies
+		};
+
+		if (this._taskExecutionOrder.length) {
+			// There is at least one task configured. Use before- and afterTask to add the custom task
+			const refTaskName = taskDef.beforeTask || taskDef.afterTask;
+			let refTaskIdx = this._taskExecutionOrder.indexOf(refTaskName);
+			if (refTaskIdx === -1) {
+				throw new Error(`Could not find task ${refTaskName}, referenced by custom task ${newTaskName}, ` +
+					`to be scheduled for project ${project.getName()}`);
+			}
+			if (taskDef.afterTask) {
+				// Insert after index of referenced task
+				refTaskIdx++;
+			}
+			this._taskExecutionOrder.splice(refTaskIdx, 0, newTaskName);
+		} else {
+			// There is no task configured so far. Just add the custom task
+			this._taskExecutionOrder.push(newTaskName);
+		}
+	}
+
+	_createCustomTaskWrapper({
+		project, taskUtil, getDependenciesReader, task, taskName, taskConfiguration
+	}) {
+		return async function(log) {
+			/* Custom Task Interface
+				Parameters:
+					{Object} parameters Parameters
+					{@ui5/fs/DuplexCollection} parameters.workspace DuplexCollection to read and write files
+					{@ui5/fs/AbstractReader} parameters.dependencies
+						Reader or Collection to read dependency files
+					{@ui5/project/build/helpers/TaskUtil} parameters.taskUtil Specification Version-dependent
+						interface of a [TaskUtil]{@link @ui5/project/build/helpers/TaskUtil} instance
+					{@ui5/logger/GroupLogger} [parameters.log] Logger instance to use by the custom task.
+						This parameter is only available to custom task extensions defining
+						<b>Specification Version 3.0 and above</b>.
+					{Object} parameters.options Options
+					{string} parameters.options.projectName Project name
+					{string|null} parameters.options.projectNamespace Project namespace if available
+					{string} [parameters.options.taskName] Runtime name of the task.
+						If a task is executed multiple times, a suffix is added to distinguish the executions.
+						This attribute is only available to custom task extensions defining
+						<b>Specification Version 3.0 and above</b>.
+					{string} [parameters.options.configuration] Task configuration if given in ui5.yaml
+				Returns:
+					{Promise<undefined>} Promise resolving with undefined once data has been written
+			*/
+			const params = {
+				workspace: project.getWorkspace(),
+				options: {
+					projectName: project.getName(),
+					projectNamespace: project.getNamespace(),
+					configuration: taskConfiguration,
+				}
+			};
+			const specVersion = task.getSpecVersion();
+			const taskUtilInterface = taskUtil.getInterface(specVersion);
+			// Interface is undefined if specVersion does not support taskUtil
+			if (taskUtilInterface) {
+				params.taskUtil = taskUtilInterface;
+			}
+			const taskFunction = await task.getTask();
+
+			if (specVersion.gte("3.0")) {
+				params.options.taskName = taskName;
+				params.log = logger.getGroupLogger(`builder:custom-task:${taskName}`);
+			}
+
+			const dependencies = await getDependenciesReader();
+			if (dependencies) {
+				params.dependencies = dependencies;
+			}
+			return taskFunction(params);
+		};
 	}
 
 	/**
@@ -365,6 +424,42 @@ class TaskRunner {
 		if (this._taskLog.isLevelEnabled("perf")) {
 			this._taskLog.perf(`Task ${taskName} finished in ${Math.round((performance.now() - this._taskStart))} ms`);
 		}
+	}
+
+	async _createDependencyReader(requiredDirectDependencies) {
+		if (requiredDirectDependencies.size === 0) {
+			// No dependencies are required, so no reader will be provided
+			return null;
+		}
+		if (requiredDirectDependencies.size === this._directDependencies.size) {
+			// Shortcut: If all direct dependencies are required, just return the already created reader
+			return this._allDependenciesReader;
+		}
+		const rootProject = this._project;
+
+		// Collect readers for all requested dependencies
+		const readers = [];
+
+		// Add transitive dependencies to set of required dependencies
+		const requiredDependencies = new Set(requiredDirectDependencies);
+		for (const projectName of requiredDirectDependencies) {
+			this._graph.getAllDependencies(projectName).forEach((depName) => {
+				requiredDependencies.add(depName);
+			});
+		}
+
+		// Collect readers for all (transitive) dependencies
+		await this._graph.traverseBreadthFirst(rootProject.getName(), async ({project}) => {
+			if (requiredDependencies.has(project.getName())) {
+				readers.push(project.getReader());
+			}
+		});
+
+		// Create a reader collection for that
+		return createReaderCollection({
+			name: `Reduced dependency reader collection of project ${rootProject.getName()}`,
+			readers
+		});
 	}
 }
 

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -1,5 +1,4 @@
 import ProjectBuildContext from "./ProjectBuildContext.js";
-import TaskRunner from "../TaskRunner.js";
 
 /**
  * Context of a build process
@@ -66,21 +65,12 @@ class BuildContext {
 		return this._graph;
 	}
 
-	async createProjectContext({project, log}) {
+	createProjectContext({project, log}) {
 		const projectBuildContext = new ProjectBuildContext({
 			buildContext: this,
 			project,
 			log
 		});
-		const taskRunner = await TaskRunner.create({
-			graph: this.getGraph(),
-			project,
-			taskUtil: projectBuildContext.getTaskUtil(),
-			taskRepository: this.getTaskRepository(),
-			parentLogger: log,
-			buildConfig: this.getBuildConfig()
-		});
-		projectBuildContext.setTaskRunner(taskRunner);
 		this._projectBuildContexts.push(projectBuildContext);
 		return projectBuildContext;
 	}

--- a/lib/build/helpers/ProjectBuildContext.js
+++ b/lib/build/helpers/ProjectBuildContext.js
@@ -1,5 +1,6 @@
 import ResourceTagCollection from "@ui5/fs/internal/ResourceTagCollection";
 import TaskUtil from "./TaskUtil.js";
+import TaskRunner from "../TaskRunner.js";
 
 /**
  * Build context of a single project. Always part of an overall
@@ -104,11 +105,41 @@ class ProjectBuildContext {
 	}
 
 	getTaskRunner() {
+		if (!this._taskRunner) {
+			this._taskRunner = new TaskRunner({
+				project: this._project,
+				parentLogger: this._log,
+				taskUtil: this.getTaskUtil(),
+				graph: this._buildContext.getGraph(),
+				taskRepository: this._buildContext.getTaskRepository(),
+				buildConfig: this._buildContext.getBuildConfig()
+			});
+		}
 		return this._taskRunner;
 	}
 
-	setTaskRunner(taskRunner) {
-		this._taskRunner = taskRunner;
+	/**
+	 * Determine whether the project has to be built or is already built
+	 * (typically indicated by the presence of a build manifest)
+	 *
+	 * @returns {boolean} True if the project needs to be built
+	 */
+	requiresBuild() {
+		return !this._project.getBuildManifest();
+	}
+
+	getBuildMetadata() {
+		const buildManifest = this._project.getBuildManifest();
+		if (!buildManifest) {
+			return null;
+		}
+		const timeDiff = (new Date().getTime() - new Date(buildManifest.timestamp).getTime());
+
+		// TODO: Format age properly via a new @ui5/logger util module
+		return {
+			timestamp: buildManifest.timestamp,
+			age: timeDiff / 1000 + " seconds"
+		};
 	}
 }
 

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -234,6 +234,29 @@ class ProjectGraph {
 	}
 
 	/**
+	 * Get all (direct and transitive) dependencies of a project as an array of project names
+	 *
+	 * @public
+	 * @param {string} projectName Name of the project to retrieve the dependencies of
+	 * @returns {string[]} Names of all direct and transitive dependencies
+	 */
+	getAllDependencies(projectName) {
+		const dependencies = new Set();
+
+		const processDependency = (depName) => {
+			const adjacencies = this._adjList[depName];
+			adjacencies.forEach((depName) => {
+				if (!dependencies.has(depName)) {
+					dependencies.add(depName);
+					processDependency(depName);
+				}
+			});
+		};
+
+		processDependency(projectName);
+		return Array.from(dependencies);
+	}
+	/**
 	 * Checks whether a dependency is optional or not.
 	 * Currently only used in tests.
 	 *

--- a/lib/specifications/Project.js
+++ b/lib/specifications/Project.js
@@ -200,20 +200,10 @@ class Project extends Specification {
 	 * Get the project's buildManifest configuration
 	 *
 	 * @private
-	 * @returns {boolean} BuildManifest configuration
-	 */
-	hasBuildManifest() {
-		return !!this._buildManifest;
-	}
-
-	/**
-	 * Get the project's buildManifest configuration
-	 *
-	 * @private
-	 * @returns {object} BuildManifest configuration
+	 * @returns {object|null} BuildManifest configuration or null if none is available
 	 */
 	getBuildManifest() {
-		return this._buildManifest || {};
+		return this._buildManifest || null;
 	}
 
 	/* === Resource Access === */

--- a/lib/specifications/types/extensions/Task.js
+++ b/lib/specifications/types/extensions/Task.js
@@ -21,11 +21,28 @@ class Task extends Extension {
 	* @public
 	*/
 	async getTask() {
-		const taskPath = path.join(this.getPath(), this._config.task.path);
-		const {default: task} = await import(pathToFileURL(taskPath));
-		return task;
+		return (await this._getImplementation()).task;
 	}
+
+	/**
+	* @public
+	*/
+	async getRequiredDependenciesCallback() {
+		return (await this._getImplementation()).determineRequiredDependencies;
+	}
+
 	/* === Internals === */
+	/**
+	 * @private
+	*/
+	async _getImplementation() {
+		const taskPath = path.join(this.getPath(), this._config.task.path);
+		const {default: task, determineRequiredDependencies} = await import(pathToFileURL(taskPath));
+		return {
+			task, determineRequiredDependencies
+		};
+	}
+
 	/**
 	 * @private
 	*/

--- a/test/fixtures/extension.a.esm/lib/extensionModule.js
+++ b/test/fixtures/extension.a.esm/lib/extensionModule.js
@@ -1,1 +1,2 @@
-export default "extension module";
+export default () => "extension module";
+export function determineRequiredDependencies () { return "required dependencies function" };

--- a/test/fixtures/extension.a/lib/extensionModule.js
+++ b/test/fixtures/extension.a/lib/extensionModule.js
@@ -1,1 +1,2 @@
-module.exports = "extension module";
+module.exports = () => "extension module";
+module.exports.determineRequiredDependencies = () => "required dependencies function";

--- a/test/lib/build/TaskRunner.js
+++ b/test/lib/build/TaskRunner.js
@@ -2,6 +2,7 @@ import test from "ava";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import logger from "@ui5/logger";
+logger.setLevel("perf");
 const parentLogger = logger.getGroupLogger("mygroup");
 
 function noop() {}
@@ -56,7 +57,8 @@ function getMockProject(type) {
 		}],
 		getCachebusterSignatureType: noop,
 		getCustomTasks: () => [],
-		hasBuildManifest: () => false
+		hasBuildManifest: () => false,
+		getWorkspace: () => "workspace"
 	};
 }
 
@@ -66,8 +68,11 @@ test.beforeEach(async (t) => {
 	t.context.taskUtil = {
 		isRootProject: sinon.stub().returns(true),
 		getBuildOption: sinon.stub(),
-		getInterface: sinon.stub()
+		getProject: sinon.stub(),
+		getDependencies: sinon.stub().returns(["dep.a", "dep.b"]),
+		getInterface: sinon.stub(),
 	};
+	t.context.taskUtil.getInterface.returns(t.context.taskUtil);
 
 	t.context.taskRepository = {
 		getTask: sinon.stub().callsFake(async (taskName) => {
@@ -76,21 +81,41 @@ test.beforeEach(async (t) => {
 		getAllTaskNames: sinon.stub().returns(["replaceVersion"])
 	};
 
+	t.context.customTaskSpecVersionGteStub = sinon.stub().returns(true);
+	t.context.getRequiredDependenciesCallbackStub = sinon.stub().resolves(null);
+	t.context.customTask = {
+		getName: () => "custom task name",
+		getSpecVersion: () => {
+			return {
+				gte: t.context.customTaskSpecVersionGteStub
+			};
+		},
+		getRequiredDependenciesCallback: t.context.getRequiredDependenciesCallbackStub,
+	};
+
 	t.context.graph = {
 		getRoot: () => {
 			return {
 				getName: () => "graph-root"
 			};
 		},
-		getExtension: sinon.stub().returns("a custom task")
+		getExtension: sinon.stub().returns(t.context.customTask),
+		traverseBreadthFirst: sinon.stub(),
+		getAllDependencies: sinon.stub().returns(["dep.a", "dep.b", "dep.c"])
 	};
 
 	t.context.logger = {
 		getGroupLogger: sinon.stub().returns("group logger")
 	};
 
+	t.context.resourceFactory = {
+		createReaderCollection: sinon.stub()
+			.returns("reader collection")
+	};
+
 	t.context.TaskRunner = await esmock("../../../lib/build/TaskRunner.js", {
-		"@ui5/logger": t.context.logger
+		"@ui5/logger": t.context.logger,
+		"@ui5/fs/resourceFactory": t.context.resourceFactory
 	});
 });
 
@@ -98,11 +123,82 @@ test.afterEach.always((t) => {
 	t.context.sinon.restore();
 });
 
-test("Project of type 'application'", async (t) => {
+test("Missing parameters", (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const taskRunner = await TaskRunner.create({
+	t.throws(() => {
+		new TaskRunner({
+			graph,
+			taskUtil,
+			taskRepository,
+			parentLogger,
+			buildConfig
+		});
+	}, {
+		message: "One or more mandatory parameters not provided"
+	}, "Threw with expected error message for missing project parameter");
+	t.throws(() => {
+		new TaskRunner({
+			project: getMockProject("application"),
+			taskUtil,
+			taskRepository,
+			parentLogger,
+			buildConfig
+		});
+	}, {
+		message: "One or more mandatory parameters not provided"
+	}, "Threw with expected error message for missing graph parameter");
+	t.throws(() => {
+		new TaskRunner({
+			project: getMockProject("application"),
+			graph,
+			taskRepository,
+			parentLogger,
+			buildConfig
+		});
+	}, {
+		message: "One or more mandatory parameters not provided"
+	}, "Threw with expected error message for missing taskUtil parameter");
+	t.throws(() => {
+		new TaskRunner({
+			project: getMockProject("application"),
+			graph,
+			taskUtil,
+			parentLogger,
+			buildConfig
+		});
+	}, {
+		message: "One or more mandatory parameters not provided"
+	}, "Threw with expected error message for missing taskRepository parameter");
+	t.throws(() => {
+		new TaskRunner({
+			project: getMockProject("application"),
+			graph,
+			taskUtil,
+			taskRepository,
+			buildConfig
+		});
+	}, {
+		message: "One or more mandatory parameters not provided"
+	}, "Threw with expected error message for missing parentLogger parameter");
+	t.throws(() => {
+		new TaskRunner({
+			project: getMockProject("application"),
+			graph,
+			taskUtil,
+			taskRepository,
+			parentLogger
+		});
+	}, {
+		message: "One or more mandatory parameters not provided"
+	}, "Threw with expected error message for missing buildConfig parameter");
+});
+
+test("_initTasks: Project of type 'application'", async (t) => {
+	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
+	const taskRunner = new TaskRunner({
 		project: getMockProject("application"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
 		"replaceCopyright",
@@ -120,11 +216,12 @@ test("Project of type 'application'", async (t) => {
 	], "Correct standard tasks");
 });
 
-test("Project of type 'library'", async (t) => {
+test("_initTasks: Project of type 'library'", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project: getMockProject("library"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
@@ -144,11 +241,12 @@ test("Project of type 'library'", async (t) => {
 	], "Correct standard tasks");
 });
 
-test("Project of type 'theme-library'", async (t) => {
+test("_initTasks: Project of type 'theme-library'", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project: getMockProject("theme-library"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"replaceCopyright",
@@ -159,36 +257,37 @@ test("Project of type 'theme-library'", async (t) => {
 	], "Correct standard tasks");
 });
 
-test("Project of type 'module'", async (t) => {
+test("_initTasks: Project of type 'module'", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project: getMockProject("module"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
 	t.deepEqual(taskRunner._taskExecutionOrder, [], "Correct standard tasks");
 });
 
-test("Unknown project type", async (t) => {
+test("_initTasks: Unknown project type", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const err = await t.throwsAsync(async () => {
-		await TaskRunner.create({
-			project: getMockProject("pony"), graph, taskUtil, taskRepository, parentLogger, buildConfig
-		});
+	const taskRunner = new TaskRunner({
+		project: getMockProject("pony"), graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	const err = await t.throwsAsync(taskRunner._initTasks());
 
 	t.is(err.message, "Unknown project type pony", "Threw with expected error message");
 });
 
-test("Custom tasks", async (t) => {
+test("_initTasks: Custom tasks", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "minify"},
 		{name: "myOtherTask", beforeTask: "replaceVersion"}
 	];
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
 		"replaceCopyright",
@@ -208,33 +307,35 @@ test("Custom tasks", async (t) => {
 	], "Custom tasks are inserted correctly");
 });
 
-test("Custom tasks with no standard tasks", async (t) => {
+test("_initTasks: Custom tasks with no standard tasks", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask"},
 		{name: "myOtherTask", beforeTask: "myTask"}
 	];
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"myOtherTask",
 		"myTask",
 	], "ApplicationBuilder is still instantiated with standard tasks");
 });
 
-test("Custom tasks with no standard tasks and second task defining no before-/afterTask", async (t) => {
+test("_initTasks: Custom tasks with no standard tasks and second task defining no before-/afterTask", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask"},
 		{name: "myOtherTask"}
 	];
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
 	const err = await t.throwsAsync(async () => {
-		await TaskRunner.create({
-			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-		});
+		await taskRunner._initTasks();
 	});
 	t.is(err.message,
 		`Custom task definition myOtherTask of project project.b defines neither a ` +
@@ -242,16 +343,17 @@ test("Custom tasks with no standard tasks and second task defining no before-/af
 		"Threw with expected error message");
 });
 
-test("Custom tasks with both, before- and afterTask reference", async (t) => {
+test("_initTasks: Custom tasks with both, before- and afterTask reference", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", beforeTask: "minify", afterTask: "replaceVersion"}
 	];
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
 	const err = await t.throwsAsync(async () => {
-		await TaskRunner.create({
-			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-		});
+		await taskRunner._initTasks();
 	});
 	t.is(err.message,
 		`Custom task definition myTask of project project.b defines both ` +
@@ -259,16 +361,17 @@ test("Custom tasks with both, before- and afterTask reference", async (t) => {
 		"Threw with expected error message");
 });
 
-test("Custom tasks with no before-/afterTask reference", async (t) => {
+test("_initTasks: Custom tasks with no before-/afterTask reference", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask"}
 	];
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
 	const err = await t.throwsAsync(async () => {
-		await TaskRunner.create({
-			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-		});
+		await taskRunner._initTasks();
 	});
 	t.is(err.message,
 		`Custom task definition myTask of project project.b defines neither a ` +
@@ -276,32 +379,34 @@ test("Custom tasks with no before-/afterTask reference", async (t) => {
 		"Threw with expected error message");
 });
 
-test("Custom tasks without name", async (t) => {
+test("_initTasks: Custom tasks without name", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: ""}
 	];
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
 	const err = await t.throwsAsync(async () => {
-		await TaskRunner.create({
-			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-		});
+		await taskRunner._initTasks();
 	});
 	t.is(err.message,
 		`Missing name for custom task in configuration of project project.b`,
 		"Threw with expected error message");
 });
 
-test("Custom task with name of standard tasks", async (t) => {
+test("_initTasks: Custom task with name of standard tasks", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "replaceVersion", afterTask: "minify"}
 	];
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
 	const err = await t.throwsAsync(async () => {
-		await TaskRunner.create({
-			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-		});
+		await taskRunner._initTasks();
 	});
 	t.is(err.message,
 		"Custom task configuration of project project.b references standard task replaceVersion. " +
@@ -309,7 +414,7 @@ test("Custom task with name of standard tasks", async (t) => {
 		"Threw with expected error message");
 });
 
-test("Multiple custom tasks with same name", async (t) => {
+test("_initTasks: Multiple custom tasks with same name", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
@@ -317,9 +422,10 @@ test("Multiple custom tasks with same name", async (t) => {
 		{name: "myTask", afterTask: "myTask"},
 		{name: "myTask", afterTask: "minify"}
 	];
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"escapeNonAsciiCharacters",
 		"replaceCopyright",
@@ -340,16 +446,17 @@ test("Multiple custom tasks with same name", async (t) => {
 	], "Custom tasks are inserted correctly");
 });
 
-test("Custom tasks with unknown beforeTask", async (t) => {
+test("_initTasks: Custom tasks with unknown beforeTask", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", beforeTask: "unknownTask"}
 	];
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
 	const err = await t.throwsAsync(async () => {
-		await TaskRunner.create({
-			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-		});
+		await taskRunner._initTasks();
 	});
 	t.is(err.message,
 		"Could not find task unknownTask, referenced by custom task myTask, " +
@@ -357,16 +464,17 @@ test("Custom tasks with unknown beforeTask", async (t) => {
 		"Threw with expected error message");
 });
 
-test("Custom tasks with unknown afterTask", async (t) => {
+test("_initTasks: Custom tasks with unknown afterTask", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "unknownTask"}
 	];
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
 	const err = await t.throwsAsync(async () => {
-		await TaskRunner.create({
-			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-		});
+		await taskRunner._initTasks();
 	});
 	t.is(err.message,
 		"Could not find task unknownTask, referenced by custom task myTask, " +
@@ -374,22 +482,69 @@ test("Custom tasks with unknown afterTask", async (t) => {
 		"Threw with expected error message");
 });
 
-test("Custom tasks is unknown", async (t) => {
+test("_initTasks: Custom tasks is unknown", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	graph.getExtension.returns(undefined);
 	const project = getMockProject("application");
 	project.getCustomTasks = () => [
 		{name: "myTask", afterTask: "minify"}
 	];
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
 	const err = await t.throwsAsync(async () => {
-		await TaskRunner.create({
-			project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-		});
+		await taskRunner._initTasks();
 	});
 	t.is(err.message,
 		"Could not find custom task myTask, referenced by project project.b in project " +
 		"graph with root node graph-root",
 		"Threw with expected error message");
+});
+
+test("_initTasks: Create dependencies reader for all dependencies", async (t) => {
+	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory} = t.context;
+	const project = getMockProject("application");
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
+	await taskRunner._initTasks();
+	t.is(graph.traverseBreadthFirst.callCount, 1, "ProjectGraph#traverseBreadthFirst called once");
+	t.is(graph.traverseBreadthFirst.getCall(0).args[0], "project.b",
+		"ProjectGraph#traverseBreadthFirst called with correct project name for start");
+	const traversalCallback = graph.traverseBreadthFirst.getCall(0).args[1];
+
+	// Call with root project should be ignored
+	await traversalCallback({
+		project: {
+			getName: () => "project.b",
+			getReader: () => "project.b reader",
+		}
+	});
+	await traversalCallback({
+		project: {
+			getName: () => "dep.a",
+			getReader: () => "dep.a reader",
+		}
+	});
+	await traversalCallback({
+		project: {
+			getName: () => "dep.b",
+			getReader: () => "dep.b reader",
+		}
+	});
+	await traversalCallback({
+		project: {
+			getName: () => "transitive.dep.a",
+			getReader: () => "transitive.dep.a reader",
+		}
+	});
+	t.is(resourceFactory.createReaderCollection.callCount, 1, "createReaderCollection got called once");
+	t.deepEqual(resourceFactory.createReaderCollection.getCall(0).args[0], {
+		name: "Dependency reader collection of project project.b",
+		readers: [
+			"dep.a reader", "dep.b reader", "transitive.dep.a reader"
+		]
+	}, "createReaderCollection got called with correct arguments");
 });
 
 test("Custom task is called correctly", async (t) => {
@@ -400,9 +555,12 @@ test("Custom task is called correctly", async (t) => {
 		toString: () => "2.6",
 		gte: specVersionGteStub
 	};
+
+	const getRequiredDependenciesCallbackStub = sinon.stub().resolves(undefined);
 	graph.getExtension.returns({
 		getTask: () => taskStub,
-		getSpecVersion: () => mockSpecVersion
+		getSpecVersion: () => mockSpecVersion,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
 	});
 	t.context.taskUtil.getInterface.returns("taskUtil interface");
 	const project = getMockProject("module");
@@ -410,20 +568,28 @@ test("Custom task is called correctly", async (t) => {
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
-	t.true(taskRunner._tasks["myTask"].requiresDependencies, "Custom tasks requires dependencies by default");
-	await taskRunner._tasks["myTask"].task({
-		workspace: "workspace",
-		dependencies: "dependencies"
-	});
+	t.deepEqual(taskRunner._tasks["myTask"].requiredDependencies, new Set(["dep.a", "dep.b"]),
+		"Custom tasks requires all dependencies by default");
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	await taskRunner._tasks["myTask"].task();
 
-	t.is(specVersionGteStub.callCount, 1, "SpecificationVersion#gte got called once");
+	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
 	t.is(specVersionGteStub.getCall(0).args[0], "3.0",
-		"SpecificationVersion#gte got called with correct arguments");
+		"SpecificationVersion#gte got called with correct arguments on first call");
+	t.is(specVersionGteStub.getCall(1).args[0], "3.0",
+		"SpecificationVersion#gte got called with correct arguments on second call");
+
+	t.is(createDependencyReaderStub.callCount, 1, "_createDependencyReader got called once");
+	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
+		new Set(["dep.a", "dep.b"]),
+		"_createDependencyReader got called with correct arguments");
+
 	t.is(taskStub.callCount, 1, "Task got called once");
 	t.is(taskStub.getCall(0).args.length, 1, "Task got called with one argument");
 	t.deepEqual(taskStub.getCall(0).args[0], {
@@ -450,9 +616,11 @@ test("Custom task with legacy spec version", async (t) => {
 		toString: () => "1.0",
 		gte: specVersionGteStub
 	};
+	const getRequiredDependenciesCallbackStub = sinon.stub().resolves(undefined);
 	graph.getExtension.returns({
 		getTask: () => taskStub,
-		getSpecVersion: () => mockSpecVersion
+		getSpecVersion: () => mockSpecVersion,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
 	});
 	t.context.taskUtil.getInterface.returns(undefined); // simulating no taskUtil for old specVersion
 	const project = getMockProject("module");
@@ -460,20 +628,95 @@ test("Custom task with legacy spec version", async (t) => {
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
-	t.true(taskRunner._tasks["myTask"].requiresDependencies, "Custom tasks requires dependencies by default");
-	await taskRunner._tasks["myTask"].task({
-		workspace: "workspace",
-		dependencies: "dependencies"
-	});
+	t.deepEqual(taskRunner._tasks["myTask"].requiredDependencies, new Set(["dep.a", "dep.b"]),
+		"Custom tasks requires all dependencies by default");
 
-	t.is(specVersionGteStub.callCount, 1, "SpecificationVersion#gte got called once");
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	await taskRunner._tasks["myTask"].task();
+
+	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
 	t.is(specVersionGteStub.getCall(0).args[0], "3.0",
-		"SpecificationVersion#gte got called with correct arguments");
+		"SpecificationVersion#gte got called with correct arguments on first call");
+	t.is(specVersionGteStub.getCall(1).args[0], "3.0",
+		"SpecificationVersion#gte got called with correct arguments on second call");
+
+	t.is(createDependencyReaderStub.callCount, 1, "_createDependencyReader got called once");
+	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
+		new Set(["dep.a", "dep.b"]),
+		"_createDependencyReader got called with correct arguments");
+
+	t.is(taskStub.callCount, 1, "Task got called once");
+	t.is(taskStub.getCall(0).args.length, 1, "Task got called with one argument");
+	t.deepEqual(taskStub.getCall(0).args[0], {
+		workspace: "workspace",
+		dependencies: "dependencies",
+		options: {
+			projectName: "project.b",
+			projectNamespace: "project/b",
+			configuration: "configuration",
+		}
+	}, "Task got called with one argument");
+
+	t.is(taskUtil.getInterface.callCount, 1, "taskUtil#getInterface got called once");
+	t.is(taskUtil.getInterface.getCall(0).args[0], mockSpecVersion,
+		"taskUtil#getInterface got called with correct argument");
+});
+
+test("Custom task with legacy spec version and requiredDependenciesCallback", async (t) => {
+	const {sinon, graph, taskUtil, taskRepository, TaskRunner} = t.context;
+	const taskStub = sinon.stub();
+	const specVersionGteStub = sinon.stub().returns(false);
+	const mockSpecVersion = {
+		toString: () => "1.0",
+		gte: specVersionGteStub
+	};
+	const requiredDependenciesCallbackStub = sinon.stub().resolves(new Set(["dep.b"]));
+	const getRequiredDependenciesCallbackStub = sinon.stub().resolves(requiredDependenciesCallbackStub);
+	graph.getExtension.returns({
+		getTask: () => taskStub,
+		getSpecVersion: () => mockSpecVersion,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
+	});
+	t.context.taskUtil.getInterface.returns(undefined); // simulating no taskUtil for old specVersion
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask", configuration: "configuration"}
+	];
+
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
+	await taskRunner._initTasks();
+
+	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
+	t.deepEqual(taskRunner._tasks["myTask"].requiredDependencies, new Set(["dep.b"]),
+		"Custom tasks requires all dependencies by default");
+
+	t.is(requiredDependenciesCallbackStub.callCount, 1, "requiredDependenciesCallback got called once");
+	t.deepEqual(requiredDependenciesCallbackStub.getCall(0).args[0], {
+		availableDependencies: new Set(["dep.a", "dep.b"])
+	}, "requiredDependenciesCallback got called with expected arguments");
+
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	await taskRunner._tasks["myTask"].task();
+
+	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
+	t.is(specVersionGteStub.getCall(0).args[0], "3.0",
+		"SpecificationVersion#gte got called with correct arguments on first call");
+	t.is(specVersionGteStub.getCall(1).args[0], "3.0",
+		"SpecificationVersion#gte got called with correct arguments on second call");
+
+	t.is(createDependencyReaderStub.callCount, 1, "_createDependencyReader got called once");
+	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
+		new Set(["dep.b"]),
+		"_createDependencyReader got called with correct arguments");
+
 	t.is(taskStub.callCount, 1, "Task got called once");
 	t.is(taskStub.getCall(0).args.length, 1, "Task got called with one argument");
 	t.deepEqual(taskStub.getCall(0).args[0], {
@@ -499,54 +742,101 @@ test("Custom task with specVersion 3.0", async (t) => {
 		toString: () => "3.0",
 		gte: specVersionGteStub
 	};
+
+	const requiredDependenciesCallbackStub = sinon.stub().resolves(new Set(["dep.b"]));
+	const getRequiredDependenciesCallbackStub = sinon.stub()
+		.resolves(requiredDependenciesCallbackStub);
+
 	graph.getExtension.returns({
 		getTask: () => taskStub,
-		getSpecVersion: () => mockSpecVersion
+		getSpecVersion: () => mockSpecVersion,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
 	});
-	t.context.taskUtil.getInterface.returns(undefined); // simulating no taskUtil for old specVersion
+
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask", configuration: "configuration"}
 	];
 
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
+
+	t.is(requiredDependenciesCallbackStub.callCount, 1, "requiredDependenciesCallback got called once");
+	const requiredDependenciesCallbackArgs = requiredDependenciesCallbackStub.getCall(0).args[0];
+
+	t.is(typeof requiredDependenciesCallbackArgs.getProject, "function", "getProject function provided");
+	requiredDependenciesCallbackArgs.getProject("some.project");
+	t.is(taskUtil.getProject.callCount, 1, "taskUtil.getProject got called once");
+	t.is(taskUtil.getProject.getCall(0).args[0], "some.project",
+		"taskUtil.getProject got called with expected arguments");
+	requiredDependenciesCallbackArgs.getProject = "getProject function";
+
+	t.is(typeof requiredDependenciesCallbackArgs.getDependencies, "function", "getDependencies function provided");
+	requiredDependenciesCallbackArgs.getDependencies("some.project");
+	t.is(taskUtil.getDependencies.callCount, 2, "taskUtil.getDependencies got called twice");
+	t.is(taskUtil.getDependencies.getCall(1).args[0], "some.project",
+		"taskUtil.getDependencies got called with expected arguments");
+	requiredDependenciesCallbackArgs.getDependencies = "getDependencies function";
+
+	t.deepEqual(requiredDependenciesCallbackArgs, {
+		availableDependencies: new Set(["dep.a", "dep.b"]),
+		getProject: "getProject function",
+		getDependencies: "getDependencies function",
+		options: {
+			projectName: "project.b",
+			projectNamespace: "project/b",
+			taskName: "myTask",
+			configuration: "configuration",
+		}
+	}, "requiredDependenciesCallback got called with expected arguments");
 
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
-	t.true(taskRunner._tasks["myTask"].requiresDependencies, "Custom tasks requires dependencies by default");
-	await taskRunner._tasks["myTask"].task({
-		workspace: "workspace",
-		dependencies: "dependencies"
-	}, "log");
+	t.deepEqual(taskRunner._tasks["myTask"].requiredDependencies, new Set(["dep.b"]),
+		"Custom tasks requires all dependencies by default");
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	await taskRunner._tasks["myTask"].task();
 
-	t.is(specVersionGteStub.callCount, 1, "SpecificationVersion#gte got called once");
+	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
 	t.is(specVersionGteStub.getCall(0).args[0], "3.0",
-		"SpecificationVersion#gte got called with correct arguments");
+		"SpecificationVersion#gte got called with correct arguments on first call");
+	t.is(specVersionGteStub.getCall(1).args[0], "3.0",
+		"SpecificationVersion#gte got called with correct arguments on second call");
+
+	t.is(taskUtil.getInterface.callCount, 2, "taskUtil#getInterface got called twice");
+	t.is(taskUtil.getInterface.getCall(0).args[0], mockSpecVersion,
+		"taskUtil#getInterface got called with correct argument on first call");
+	t.is(taskUtil.getInterface.getCall(1).args[0], mockSpecVersion,
+		"taskUtil#getInterface got called with correct argument on second call");
+
+	t.is(createDependencyReaderStub.callCount, 1, "_createDependencyReader got called once");
+	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
+		new Set(["dep.b"]),
+		"_createDependencyReader got called with correct arguments");
+
 	t.is(taskStub.callCount, 1, "Task got called once");
 	t.is(taskStub.getCall(0).args.length, 1, "Task got called with one argument");
 	t.deepEqual(taskStub.getCall(0).args[0], {
 		workspace: "workspace",
 		dependencies: "dependencies",
 		log: "group logger",
+		taskUtil,
 		options: {
 			projectName: "project.b",
 			projectNamespace: "project/b",
 			taskName: "myTask", // specVersion 3.0 feature
 			configuration: "configuration",
-		}
+		},
 	}, "Task got called with one argument");
-
-	t.is(taskUtil.getInterface.callCount, 1, "taskUtil#getInterface got called once");
-	t.is(taskUtil.getInterface.getCall(0).args[0], mockSpecVersion,
-		"taskUtil#getInterface got called with correct argument");
 });
 
 test("Multiple custom tasks with same name are called correctly", async (t) => {
 	const {sinon, graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const taskStub1 = sinon.stub();
-	const taskStub2 = sinon.stub();
-	const taskStub3 = sinon.stub();
+	const taskStubA = sinon.stub();
+	const taskStubB = sinon.stub();
+	const taskStubC = sinon.stub();
+	const taskStubD = sinon.stub();
 	const mockSpecVersionA = {
 		toString: () => "2.5",
 		gte: () => false
@@ -559,92 +849,241 @@ test("Multiple custom tasks with same name are called correctly", async (t) => {
 		toString: () => "3.0",
 		gte: () => true
 	};
+	const mockSpecVersionD = {
+		toString: () => "3.0",
+		gte: () => true
+	};
+	const requiredDependenciesCallbackStubA = sinon.stub().resolves(new Set(["dep.b"]));
+	const requiredDependenciesCallbackStubD = sinon.stub().resolves(new Set(["dep.a"]));
+	const getRequiredDependenciesCallbackStub = sinon.stub()
+		.resolves(null)
+		.onCall(0).resolves(requiredDependenciesCallbackStubA)
+		.onCall(3).resolves(requiredDependenciesCallbackStubD);
+
 	graph.getExtension.onFirstCall().returns({
-		getTask: () => taskStub1,
-		getSpecVersion: () => mockSpecVersionA
+		getName: () => "Task Name A",
+		getTask: () => taskStubA,
+		getSpecVersion: () => mockSpecVersionA,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
 	});
 	graph.getExtension.onSecondCall().returns({
-		getTask: () => taskStub2,
-		getSpecVersion: () => mockSpecVersionB
+		getName: () => "Task Name B",
+		getTask: () => taskStubB,
+		getSpecVersion: () => mockSpecVersionB,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
 	});
 	graph.getExtension.onThirdCall().returns({
-		getTask: () => taskStub3,
-		getSpecVersion: () => mockSpecVersionC
+		getName: () => "Task Name C",
+		getTask: () => taskStubC,
+		getSpecVersion: () => mockSpecVersionC,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
+	});
+	graph.getExtension.onCall(3).returns({
+		getName: () => "Task Name D",
+		getTask: () => taskStubD,
+		getSpecVersion: () => mockSpecVersionD,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
 	});
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask", configuration: "cat"},
 		{name: "myTask", afterTask: "myTask", configuration: "dog"},
+		{name: "myTask", afterTask: "myTask", configuration: "bird"},
 		{name: "myTask", afterTask: "myTask", configuration: "bird"}
 	];
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
-	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
-	t.truthy(taskRunner._tasks["myTask--2"], "Custom tasks has been added to task map");
-	t.truthy(taskRunner._tasks["myTask--3"], "Custom tasks has been added to task map");
-	t.true(taskRunner._tasks["myTask"].requiresDependencies, "Custom tasks requires dependencies by default");
-	t.true(taskRunner._tasks["myTask--2"].requiresDependencies, "Custom tasks requires dependencies by default");
-	t.true(taskRunner._tasks["myTask--3"].requiresDependencies, "Custom tasks requires dependencies by default");
+	// getRequiredDependenciesCallbackStub is only called for specVersion >= 3.0
+	t.is(getRequiredDependenciesCallbackStub.callCount, 4,
+		"getRequiredDependenciesCallback stub was called for all tasks");
+	t.is(requiredDependenciesCallbackStubA.callCount, 1,
+		"requiredDependenciesCallback stub for task A was called once");
+	t.is(requiredDependenciesCallbackStubD.callCount, 1,
+		"requiredDependenciesCallback stub for Task D stub was called once");
+
+	t.truthy(taskRunner._tasks["myTask"], "Custom tasks A has been added to task map");
+	t.truthy(taskRunner._tasks["myTask--2"], "Custom tasks B has been added to task map");
+	t.truthy(taskRunner._tasks["myTask--3"], "Custom tasks C has been added to task map");
+	t.truthy(taskRunner._tasks["myTask--4"], "Custom tasks D has been added to task map");
+	t.deepEqual(taskRunner._tasks["myTask"].requiredDependencies, new Set(["dep.b"]),
+		"Custom tasks with legacy specVersion and requiredDependenciesCallback defines " +
+		"required dependencies");
+	t.deepEqual(taskRunner._tasks["myTask--2"].requiredDependencies, new Set(["dep.a", "dep.b"]),
+		"Custom tasks with legacy specVersion require all dependencies by default");
+	t.deepEqual(taskRunner._tasks["myTask--3"].requiredDependencies, new Set([]),
+		"Custom tasks with specVersion 3.0 but no requiredDependenciesCallback " +
+		"require no dependencies by default");
+	t.deepEqual(taskRunner._tasks["myTask--4"].requiredDependencies, new Set(["dep.a"]),
+		"Custom tasks with specVersion 3.0 and requiredDependenciesCallback defines " +
+		"required dependencies");
 
 	// "Last in is the first out"
 	t.deepEqual(taskRunner._taskExecutionOrder, [
 		"myTask",
+		"myTask--4",
 		"myTask--3",
 		"myTask--2",
 	], "Correct order of custom tasks");
 
-	await taskRunner.runTasks({
-		workspace: "workspace",
-		dependencies: "dependencies"
-	});
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	await taskRunner.runTasks();
 
-	t.is(taskStub1.callCount, 1, "Task 1 got called once");
-	t.is(taskStub1.getCall(0).args.length, 1, "Task 1 got called with one argument");
-	t.deepEqual(taskStub1.getCall(0).args[0], {
+	t.is(taskUtil.getInterface.callCount, 5, "taskUtil#getInterface got called three times");
+	t.is(taskUtil.getInterface.getCall(0).args[0], mockSpecVersionD,
+		"taskUtil#getInterface got called with correct argument on first call");
+	t.is(taskUtil.getInterface.getCall(1).args[0], mockSpecVersionA,
+		"taskUtil#getInterface got called with correct argument on second call");
+	t.is(taskUtil.getInterface.getCall(2).args[0], mockSpecVersionD,
+		"taskUtil#getInterface got called with correct argument on third call");
+	t.is(taskUtil.getInterface.getCall(3).args[0], mockSpecVersionC,
+		"taskUtil#getInterface got called with correct argument on fourth call");
+	t.is(taskUtil.getInterface.getCall(4).args[0], mockSpecVersionB,
+		"taskUtil#getInterface got called with correct argument on fifth call");
+
+	t.is(createDependencyReaderStub.callCount, 4, "_createDependencyReader got called four times");
+	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
+		new Set(["dep.b"]),
+		"_createDependencyReader got called with correct arguments on first call");
+	t.deepEqual(createDependencyReaderStub.getCall(1).args[0],
+		new Set(["dep.a"]),
+		"_createDependencyReader got called with correct arguments on second call");
+	t.deepEqual(createDependencyReaderStub.getCall(2).args[0],
+		new Set([]),
+		"_createDependencyReader got called with correct arguments on third call");
+	t.deepEqual(createDependencyReaderStub.getCall(3).args[0],
+		new Set(["dep.a", "dep.b"]),
+		"_createDependencyReader got called with correct arguments on fourth call");
+
+	t.is(taskStubA.callCount, 1, "Task A got called once");
+	t.is(taskStubA.getCall(0).args.length, 1, "Task A got called with one argument");
+	t.deepEqual(taskStubA.getCall(0).args[0], {
 		workspace: "workspace",
 		dependencies: "dependencies",
+		taskUtil,
 		options: {
 			projectName: "project.b",
 			projectNamespace: "project/b",
 			configuration: "cat",
 		}
-	}, "Task 1 got called with one argument");
+	}, "Task A got called with one argument");
 
-	t.is(taskStub2.callCount, 1, "Task 2 got called once");
-	t.is(taskStub2.getCall(0).args.length, 1, "Task 2 got called with one argument");
-	t.deepEqual(taskStub2.getCall(0).args[0], {
+	t.is(taskStubB.callCount, 1, "Task B got called once");
+	t.is(taskStubB.getCall(0).args.length, 1, "Task B got called with one argument");
+	t.deepEqual(taskStubB.getCall(0).args[0], {
 		workspace: "workspace",
 		dependencies: "dependencies",
+		taskUtil,
 		options: {
 			projectName: "project.b",
 			projectNamespace: "project/b",
 			configuration: "dog",
 		}
-	}, "Task 2 got called with one argument");
+	}, "Task B got called with one argument");
 
-	t.is(taskStub3.callCount, 1, "Task 3 got called once");
-	t.is(taskStub3.getCall(0).args.length, 1, "Task 3 got called with one argument");
-	t.deepEqual(taskStub3.getCall(0).args[0], {
+	t.is(taskStubC.callCount, 1, "Task C got called once");
+	t.is(taskStubC.getCall(0).args.length, 1, "Task C got called with one argument");
+	t.deepEqual(taskStubC.getCall(0).args[0], {
 		workspace: "workspace",
 		dependencies: "dependencies",
 		log: "group logger",
+		taskUtil,
 		options: {
 			projectName: "project.b",
 			projectNamespace: "project/b",
 			taskName: "myTask--3",
 			configuration: "bird",
 		}
-	}, "Task 3 got called with one argument");
+	}, "Task C got called with one argument");
 
-	t.is(taskUtil.getInterface.callCount, 3, "taskUtil#getInterface got called once");
-	t.is(taskUtil.getInterface.getCall(0).args[0], mockSpecVersionA,
-		"taskUtil#getInterface got called with correct argument on first call");
-	t.is(taskUtil.getInterface.getCall(1).args[0], mockSpecVersionC,
-		"taskUtil#getInterface got called with correct argument on second call");
-	t.is(taskUtil.getInterface.getCall(2).args[0], mockSpecVersionB,
-		"taskUtil#getInterface got called with correct argument on third call");
+	t.is(taskStubD.callCount, 1, "Task D got called once");
+	t.is(taskStubD.getCall(0).args.length, 1, "Task D got called with one argument");
+	t.deepEqual(taskStubD.getCall(0).args[0], {
+		workspace: "workspace",
+		dependencies: "dependencies",
+		log: "group logger",
+		taskUtil,
+		options: {
+			projectName: "project.b",
+			projectNamespace: "project/b",
+			taskName: "myTask--4",
+			configuration: "bird",
+		}
+	}, "Task D got called with one argument");
+});
+
+test("Custom task: requiredDependenciesCallback returns unknown dependency", async (t) => {
+	const {sinon, graph, taskUtil, taskRepository, TaskRunner} = t.context;
+	const taskStub = sinon.stub();
+	const specVersionGteStub = sinon.stub().returns(true);
+	const mockSpecVersion = {
+		toString: () => "3.0",
+		gte: specVersionGteStub
+	};
+
+	const requiredDependenciesCallbackStub = sinon.stub().resolves(new Set(["dep.b", "other.dep"]));
+	const getRequiredDependenciesCallbackStub = sinon.stub()
+		.resolves(requiredDependenciesCallbackStub);
+
+	graph.getExtension.returns({
+		getName: () => "custom.task.a",
+		getTask: () => taskStub,
+		getSpecVersion: () => mockSpecVersion,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
+	});
+
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask", configuration: "configuration"}
+	];
+
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
+	await t.throwsAsync(taskRunner._initTasks(), {
+		message:
+		`'determineRequiredDependencies' callback function of custom task custom.task.a ` +
+		`of project project.b must resolve with a subset of the the direct dependencies of the project. ` +
+		`other.dep is not a direct dependency of the project.`
+	}, "Threw with expected error message");
+});
+
+
+test("Custom task: requiredDependenciesCallback returns Array instead of Set", async (t) => {
+	const {sinon, graph, taskUtil, taskRepository, TaskRunner} = t.context;
+	const taskStub = sinon.stub();
+	const specVersionGteStub = sinon.stub().returns(true);
+	const mockSpecVersion = {
+		toString: () => "3.0",
+		gte: specVersionGteStub
+	};
+
+	const requiredDependenciesCallbackStub = sinon.stub().resolves(["dep.b"]);
+	const getRequiredDependenciesCallbackStub = sinon.stub()
+		.resolves(requiredDependenciesCallbackStub);
+
+	graph.getExtension.returns({
+		getName: () => "custom.task.a",
+		getTask: () => taskStub,
+		getSpecVersion: () => mockSpecVersion,
+		getRequiredDependenciesCallback: getRequiredDependenciesCallbackStub
+	});
+
+	const project = getMockProject("module");
+	project.getCustomTasks = () => [
+		{name: "myTask", configuration: "configuration"}
+	];
+
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
+	await t.throwsAsync(taskRunner._initTasks(), {
+		message:
+		`'determineRequiredDependencies' callback function of custom task custom.task.a ` +
+		`of project project.b must resolve with Set.`
+	}, "Threw with expected error message");
 });
 
 test.serial("_addTask", async (t) => {
@@ -656,14 +1095,16 @@ test.serial("_addTask", async (t) => {
 	});
 
 	const project = getMockProject("module");
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
 	taskRunner._addTask("standardTask");
 
 	t.truthy(taskRunner._tasks["standardTask"], "Task has been added to task map");
-	t.false(taskRunner._tasks["standardTask"].requiresDependencies, "requiresDependencies defaults to false");
+	t.deepEqual(taskRunner._tasks["standardTask"].requiredDependencies, new Set(),
+		"By default, no dependencies required");
 	t.truthy(taskRunner._tasks["standardTask"].task, "Task function got set correctly");
 	t.deepEqual(taskRunner._taskExecutionOrder, ["standardTask"], "Task got added to execution order");
 
@@ -692,9 +1133,10 @@ test.serial("_addTask with options", async (t) => {
 	const taskStub = sinon.stub();
 	const project = getMockProject("module");
 
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
 	taskRunner._addTask("standardTask", {
 		requiresDependencies: true,
@@ -705,21 +1147,24 @@ test.serial("_addTask with options", async (t) => {
 	});
 
 	t.truthy(taskRunner._tasks["standardTask"], "Task has been added to task map");
-	t.true(taskRunner._tasks["standardTask"].requiresDependencies, "requiresDependencies set to true");
+	t.deepEqual(taskRunner._tasks["standardTask"].requiredDependencies, new Set(["dep.a", "dep.b"]),
+		"All dependencies required");
 	t.truthy(taskRunner._tasks["standardTask"].task, "Task function got set correctly");
 	t.deepEqual(taskRunner._taskExecutionOrder, ["standardTask"], "Task got added to execution order");
 
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
 	await taskRunner._tasks["standardTask"].task({
 		workspace: "workspace",
 		dependencies: "dependencies",
 	});
 
 	t.is(taskRepository.getTask.callCount, 0, "taskRepository#getTask did not get called");
+	t.is(createDependencyReaderStub.callCount, 0, "_createDependencyReader did not get called");
 
 	t.is(taskStub.callCount, 1, "Task got called once");
 	t.deepEqual(taskStub.getCall(0).args[0], {
 		workspace: "workspace",
-		dependencies: "dependencies",
+		dependencies: taskRunner._allDependenciesReader,
 		options: {
 			projectName: "project.b",
 			projectNamespace: "project/b",
@@ -732,9 +1177,10 @@ test.serial("_addTask with options", async (t) => {
 test("_addTask: Duplicate task", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("module");
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
 	taskRunner._addTask("standardTask", {
 		taskFunction: () => {}
@@ -752,9 +1198,10 @@ test("_addTask: Duplicate task", async (t) => {
 test("_addTask: Task already added to execution order", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("module");
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
+	await taskRunner._initTasks();
 
 	taskRunner._taskExecutionOrder.push("standardTask");
 	const err = t.throws(() => {
@@ -767,106 +1214,148 @@ test("_addTask: Task already added to execution order", async (t) => {
 		"Threw with expected error message");
 });
 
-test("requiresDependencies: Custom Task", async (t) => {
+test("getRequiredDependencies: Custom Task", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("module");
 	project.getCustomTasks = () => [
 		{name: "myTask"}
 	];
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
-	t.true(taskRunner.requiresDependencies(), "Project with custom task requires dependencies");
+	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
+		"Project with custom task >= specVersion 3.0 and no requiredDependenciesCallback " +
+		"requires no dependencies");
 });
 
-test("requiresDependencies: Default application", async (t) => {
+test("getRequiredDependencies: Default application", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("application");
 	project.getBundles = () => [];
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
-	t.false(taskRunner.requiresDependencies(), "Default application project does not require dependencies");
+	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
+		"Default application project does not require dependencies");
 });
 
-test("requiresDependencies: Default library", async (t) => {
+test("getRequiredDependencies: Default library", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("library");
 	project.getBundles = () => [];
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
-	t.true(taskRunner.requiresDependencies(), "Default library project requires dependencies");
+	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set(["dep.a", "dep.b"]),
+		"Default library project requires dependencies");
 });
 
-test("requiresDependencies: Default theme-library", async (t) => {
+test("getRequiredDependencies: Default theme-library", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("theme-library");
 
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
-	t.true(taskRunner.requiresDependencies(), "Default theme-library project requires dependencies");
+	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set(["dep.a", "dep.b"]),
+		"Default theme-library project requires dependencies");
 });
 
-test("requiresDependencies: Default module", async (t) => {
+test("getRequiredDependencies: Default module", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("module");
 
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
-	t.false(taskRunner.requiresDependencies(), "Default module project does not require dependencies");
+	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
+		"Default module project does not require dependencies");
 });
 
-test("requiresBuild: has no build-manifest", async (t) => {
+test("_createDependencyReader", async (t) => {
+	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory} = t.context;
+	const project = getMockProject("module");
+
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
+	await taskRunner._initTasks();
+	graph.traverseBreadthFirst.reset(); // Ignore the call in initTask
+	resourceFactory.createReaderCollection.reset(); // Ignore the call in initTask
+	resourceFactory.createReaderCollection.returns("custom reader collection");
+	const res = await taskRunner._createDependencyReader(new Set(["dep.a"]));
+
+	t.is(graph.traverseBreadthFirst.callCount, 1, "ProjectGraph#traverseBreadthFirst got called once");
+	t.is(graph.traverseBreadthFirst.getCall(0).args[0], "project.b",
+		"ProjectGraph#traverseBreadthFirst called with correct project name for start");
+
+	const traversalCallback = graph.traverseBreadthFirst.getCall(0).args[1];
+
+	// Call with root project should be ignored
+	await traversalCallback({
+		project: {
+			getName: () => "project.b",
+			getReader: () => "project.b reader",
+		}
+	});
+	await traversalCallback({
+		project: {
+			getName: () => "dep.a",
+			getReader: () => "dep.a reader",
+		}
+	});
+	await traversalCallback({
+		project: {
+			getName: () => "dep.b",
+			getReader: () => "dep.b reader",
+		}
+	});
+	await traversalCallback({
+		project: {
+			getName: () => "dep.c",
+			getReader: () => "dep.c reader",
+		}
+	});
+	await traversalCallback({
+		project: {
+			// Will be ignored as it is no (transitive) dependency of the project
+			getName: () => "other project",
+			getReader: () => "other project reader",
+		}
+	});
+	t.is(resourceFactory.createReaderCollection.callCount, 1, "createReaderCollection got called once");
+	t.deepEqual(resourceFactory.createReaderCollection.getCall(0).args[0], {
+		name: "Reduced dependency reader collection of project project.b",
+		readers: [
+			"dep.a reader", "dep.b reader", "dep.c reader"
+		]
+	}, "createReaderCollection got called with correct arguments");
+	t.is(res, "custom reader collection", "Returned expected value");
+});
+
+test("_createDependencyReader: All dependencies required", async (t) => {
+	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory} = t.context;
+	const project = getMockProject("module");
+
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+	});
+	await taskRunner._initTasks();
+	const res = await taskRunner._createDependencyReader(new Set(["dep.a", "dep.b"]));
+	t.is(graph.traverseBreadthFirst.callCount, 1, "ProjectGraph#traverseBreadthFirst got called once");
+	t.is(resourceFactory.createReaderCollection.callCount, 1, "createReaderCollection got called once");
+	t.is(res, "reader collection", "Shared (all-)dependency reader returned");
+});
+
+test("_createDependencyReader: No dependencies required", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const project = getMockProject("library");
+	const project = getMockProject("module");
 
-	const taskRunner = await TaskRunner.create({
+	const taskRunner = new TaskRunner({
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
-	t.true(taskRunner.requiresBuild(), "Project without build-manifest requires to be build");
+	await taskRunner._initTasks();
+	const res = await taskRunner._createDependencyReader(new Set());
+	t.is(res, null, "No dependency reader returned");
 });
 
-test("requiresBuild: has build-manifest", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const project = getMockProject("library");
-	project.hasBuildManifest = () => true;
-
-	const taskRunner = await TaskRunner.create({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-	});
-	t.false(taskRunner.requiresBuild(), "Project with build-manifest does not require to be build");
-});
-
-test.serial("getBuildMetadata", async (t) => {
-	const {sinon, graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const project = getMockProject("library");
-	project.hasBuildManifest = () => true;
-	project.getBuildManifest = () => {
-		return {
-			timestamp: "2022-07-28T12:00:00.000Z"
-		};
-	};
-	const getTimeStub = sinon.stub(Date.prototype, "getTime").callThrough().onFirstCall().returns(1659016800000);
-	const taskRunner = await TaskRunner.create({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-	});
-
-	t.deepEqual(taskRunner.getBuildMetadata(), {
-		timestamp: "2022-07-28T12:00:00.000Z",
-		age: "7200 seconds"
-	}, "Project with build-manifest does not require to be build");
-	getTimeStub.restore();
-});
-
-test("getBuildMetadata: has no build-manifest", async (t) => {
-	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
-	const project = getMockProject("library");
-
-	const taskRunner = await TaskRunner.create({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
-	});
-	t.is(taskRunner.getBuildMetadata(), null, "Project has no build manifest");
-});

--- a/test/lib/build/TaskRunner.js
+++ b/test/lib/build/TaskRunner.js
@@ -576,7 +576,7 @@ test("Custom task is called correctly", async (t) => {
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
 	t.deepEqual(taskRunner._tasks["myTask"].requiredDependencies, new Set(["dep.a", "dep.b"]),
 		"Custom tasks requires all dependencies by default");
-	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependenciesReader").resolves("dependencies");
 	await taskRunner._tasks["myTask"].task();
 
 	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
@@ -585,10 +585,10 @@ test("Custom task is called correctly", async (t) => {
 	t.is(specVersionGteStub.getCall(1).args[0], "3.0",
 		"SpecificationVersion#gte got called with correct arguments on second call");
 
-	t.is(createDependencyReaderStub.callCount, 1, "_createDependencyReader got called once");
+	t.is(createDependencyReaderStub.callCount, 1, "_createDependenciesReader got called once");
 	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
 		new Set(["dep.a", "dep.b"]),
-		"_createDependencyReader got called with correct arguments");
+		"_createDependenciesReader got called with correct arguments");
 
 	t.is(taskStub.callCount, 1, "Task got called once");
 	t.is(taskStub.getCall(0).args.length, 1, "Task got called with one argument");
@@ -637,7 +637,7 @@ test("Custom task with legacy spec version", async (t) => {
 	t.deepEqual(taskRunner._tasks["myTask"].requiredDependencies, new Set(["dep.a", "dep.b"]),
 		"Custom tasks requires all dependencies by default");
 
-	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependenciesReader").resolves("dependencies");
 	await taskRunner._tasks["myTask"].task();
 
 	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
@@ -646,10 +646,10 @@ test("Custom task with legacy spec version", async (t) => {
 	t.is(specVersionGteStub.getCall(1).args[0], "3.0",
 		"SpecificationVersion#gte got called with correct arguments on second call");
 
-	t.is(createDependencyReaderStub.callCount, 1, "_createDependencyReader got called once");
+	t.is(createDependencyReaderStub.callCount, 1, "_createDependenciesReader got called once");
 	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
 		new Set(["dep.a", "dep.b"]),
-		"_createDependencyReader got called with correct arguments");
+		"_createDependenciesReader got called with correct arguments");
 
 	t.is(taskStub.callCount, 1, "Task got called once");
 	t.is(taskStub.getCall(0).args.length, 1, "Task got called with one argument");
@@ -703,7 +703,7 @@ test("Custom task with legacy spec version and requiredDependenciesCallback", as
 		availableDependencies: new Set(["dep.a", "dep.b"])
 	}, "requiredDependenciesCallback got called with expected arguments");
 
-	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependenciesReader").resolves("dependencies");
 	await taskRunner._tasks["myTask"].task();
 
 	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
@@ -712,10 +712,10 @@ test("Custom task with legacy spec version and requiredDependenciesCallback", as
 	t.is(specVersionGteStub.getCall(1).args[0], "3.0",
 		"SpecificationVersion#gte got called with correct arguments on second call");
 
-	t.is(createDependencyReaderStub.callCount, 1, "_createDependencyReader got called once");
+	t.is(createDependencyReaderStub.callCount, 1, "_createDependenciesReader got called once");
 	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
 		new Set(["dep.b"]),
-		"_createDependencyReader got called with correct arguments");
+		"_createDependenciesReader got called with correct arguments");
 
 	t.is(taskStub.callCount, 1, "Task got called once");
 	t.is(taskStub.getCall(0).args.length, 1, "Task got called with one argument");
@@ -795,7 +795,7 @@ test("Custom task with specVersion 3.0", async (t) => {
 	t.truthy(taskRunner._tasks["myTask"], "Custom tasks has been added to task map");
 	t.deepEqual(taskRunner._tasks["myTask"].requiredDependencies, new Set(["dep.b"]),
 		"Custom tasks requires all dependencies by default");
-	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependenciesReader").resolves("dependencies");
 	await taskRunner._tasks["myTask"].task();
 
 	t.is(specVersionGteStub.callCount, 2, "SpecificationVersion#gte got called twice");
@@ -810,10 +810,10 @@ test("Custom task with specVersion 3.0", async (t) => {
 	t.is(taskUtil.getInterface.getCall(1).args[0], mockSpecVersion,
 		"taskUtil#getInterface got called with correct argument on second call");
 
-	t.is(createDependencyReaderStub.callCount, 1, "_createDependencyReader got called once");
+	t.is(createDependencyReaderStub.callCount, 1, "_createDependenciesReader got called once");
 	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
 		new Set(["dep.b"]),
-		"_createDependencyReader got called with correct arguments");
+		"_createDependenciesReader got called with correct arguments");
 
 	t.is(taskStub.callCount, 1, "Task got called once");
 	t.is(taskStub.getCall(0).args.length, 1, "Task got called with one argument");
@@ -928,7 +928,7 @@ test("Multiple custom tasks with same name are called correctly", async (t) => {
 		"myTask--2",
 	], "Correct order of custom tasks");
 
-	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependenciesReader").resolves("dependencies");
 	await taskRunner.runTasks();
 
 	t.is(taskUtil.getInterface.callCount, 5, "taskUtil#getInterface got called three times");
@@ -943,19 +943,19 @@ test("Multiple custom tasks with same name are called correctly", async (t) => {
 	t.is(taskUtil.getInterface.getCall(4).args[0], mockSpecVersionB,
 		"taskUtil#getInterface got called with correct argument on fifth call");
 
-	t.is(createDependencyReaderStub.callCount, 4, "_createDependencyReader got called four times");
+	t.is(createDependencyReaderStub.callCount, 4, "_createDependenciesReader got called four times");
 	t.deepEqual(createDependencyReaderStub.getCall(0).args[0],
 		new Set(["dep.b"]),
-		"_createDependencyReader got called with correct arguments on first call");
+		"_createDependenciesReader got called with correct arguments on first call");
 	t.deepEqual(createDependencyReaderStub.getCall(1).args[0],
 		new Set(["dep.a"]),
-		"_createDependencyReader got called with correct arguments on second call");
+		"_createDependenciesReader got called with correct arguments on second call");
 	t.deepEqual(createDependencyReaderStub.getCall(2).args[0],
 		new Set([]),
-		"_createDependencyReader got called with correct arguments on third call");
+		"_createDependenciesReader got called with correct arguments on third call");
 	t.deepEqual(createDependencyReaderStub.getCall(3).args[0],
 		new Set(["dep.a", "dep.b"]),
-		"_createDependencyReader got called with correct arguments on fourth call");
+		"_createDependenciesReader got called with correct arguments on fourth call");
 
 	t.is(taskStubA.callCount, 1, "Task A got called once");
 	t.is(taskStubA.getCall(0).args.length, 1, "Task A got called with one argument");
@@ -1152,14 +1152,14 @@ test.serial("_addTask with options", async (t) => {
 	t.truthy(taskRunner._tasks["standardTask"].task, "Task function got set correctly");
 	t.deepEqual(taskRunner._taskExecutionOrder, ["standardTask"], "Task got added to execution order");
 
-	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependencyReader").resolves("dependencies");
+	const createDependencyReaderStub = sinon.stub(taskRunner, "_createDependenciesReader").resolves("dependencies");
 	await taskRunner._tasks["standardTask"].task({
 		workspace: "workspace",
 		dependencies: "dependencies",
 	});
 
 	t.is(taskRepository.getTask.callCount, 0, "taskRepository#getTask did not get called");
-	t.is(createDependencyReaderStub.callCount, 0, "_createDependencyReader did not get called");
+	t.is(createDependencyReaderStub.callCount, 0, "_createDependenciesReader did not get called");
 
 	t.is(taskStub.callCount, 1, "Task got called once");
 	t.deepEqual(taskStub.getCall(0).args[0], {
@@ -1272,7 +1272,7 @@ test("getRequiredDependencies: Default module", async (t) => {
 		"Default module project does not require dependencies");
 });
 
-test("_createDependencyReader", async (t) => {
+test("_createDependenciesReader", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory} = t.context;
 	const project = getMockProject("module");
 
@@ -1283,7 +1283,7 @@ test("_createDependencyReader", async (t) => {
 	graph.traverseBreadthFirst.reset(); // Ignore the call in initTask
 	resourceFactory.createReaderCollection.reset(); // Ignore the call in initTask
 	resourceFactory.createReaderCollection.returns("custom reader collection");
-	const res = await taskRunner._createDependencyReader(new Set(["dep.a"]));
+	const res = await taskRunner._createDependenciesReader(new Set(["dep.a"]));
 
 	t.is(graph.traverseBreadthFirst.callCount, 1, "ProjectGraph#traverseBreadthFirst got called once");
 	t.is(graph.traverseBreadthFirst.getCall(0).args[0], "project.b",
@@ -1333,7 +1333,7 @@ test("_createDependencyReader", async (t) => {
 	t.is(res, "custom reader collection", "Returned expected value");
 });
 
-test("_createDependencyReader: All dependencies required", async (t) => {
+test("_createDependenciesReader: All dependencies required", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory} = t.context;
 	const project = getMockProject("module");
 
@@ -1341,13 +1341,13 @@ test("_createDependencyReader: All dependencies required", async (t) => {
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	await taskRunner._initTasks();
-	const res = await taskRunner._createDependencyReader(new Set(["dep.a", "dep.b"]));
+	const res = await taskRunner._createDependenciesReader(new Set(["dep.a", "dep.b"]));
 	t.is(graph.traverseBreadthFirst.callCount, 1, "ProjectGraph#traverseBreadthFirst got called once");
 	t.is(resourceFactory.createReaderCollection.callCount, 1, "createReaderCollection got called once");
 	t.is(res, "reader collection", "Shared (all-)dependency reader returned");
 });
 
-test("_createDependencyReader: No dependencies required", async (t) => {
+test("_createDependenciesReader: No dependencies required", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("module");
 
@@ -1355,7 +1355,7 @@ test("_createDependencyReader: No dependencies required", async (t) => {
 		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
 	});
 	await taskRunner._initTasks();
-	const res = await taskRunner._createDependencyReader(new Set());
+	const res = await taskRunner._createDependenciesReader(new Set());
 	t.is(res, null, "No dependency reader returned");
 });
 

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -1,6 +1,5 @@
 import test from "ava";
 import sinon from "sinon";
-import esmock from "esmock";
 
 test.afterEach.always((t) => {
 	sinon.restore();
@@ -110,44 +109,15 @@ test("getBuildOption", (t) => {
 		"(not exposed as buold option)");
 });
 
-test.serial("createProjectContext", async (t) => {
-	t.plan(6);
-
-	const project = {
-		getType: sinon.stub().returns("foo")
-	};
-	const taskRunner = {"task": "runner"};
-	class DummyProjectContext {
-		constructor({buildContext, project, log}) {
-			t.is(buildContext, testBuildContext, "Correct buildContext parameter");
-			t.is(project, project, "Correct project parameter");
-			t.is(log, "log", "Correct log parameter");
-		}
-		getTaskUtil() {
-			return "taskUtil";
-		}
-		setTaskRunner(_taskRunner) {
-			t.is(_taskRunner, taskRunner);
-		}
-	}
-	const BuildContext = await esmock("../../../../lib/build/helpers/BuildContext.js", {
-		"../../../../lib/build/helpers/ProjectBuildContext.js": DummyProjectContext,
-		"../../../../lib/build/TaskRunner.js": {
-			create: sinon.stub().resolves(taskRunner)
-		},
-
-	});
-	const testBuildContext = new BuildContext("graph", "taskRepository");
-
-	const projectContext = await testBuildContext.createProjectContext({
-		project,
+test("createProjectContext", async (t) => {
+	const buildContext = new BuildContext("graph", "taskRepository");
+	const projectBuildContext = await buildContext.createProjectContext({
+		project: "project",
 		log: "log"
 	});
 
-	t.true(projectContext instanceof DummyProjectContext,
-		"Project context is an instance of DummyProjectContext");
-	t.is(testBuildContext._projectBuildContexts[0], projectContext,
-		"BuildContext stored correct ProjectBuildContext");
+	t.deepEqual(buildContext._projectBuildContexts, [projectBuildContext],
+		"Project build context has been added to internal array");
 });
 
 test("executeCleanupTasks", async (t) => {

--- a/test/lib/graph/ProjectGraph.js
+++ b/test/lib/graph/ProjectGraph.js
@@ -321,6 +321,31 @@ test("declareDependency / getDependencies", async (t) => {
 		"Should declare dependency as non-optional");
 });
 
+test("getAllDependencies", async (t) => {
+	const {ProjectGraph} = t.context;
+	const graph = new ProjectGraph({
+		rootProjectName: "my root project"
+	});
+	graph.addProject(await createProject("library.a"));
+	graph.addProject(await createProject("library.b"));
+	graph.addProject(await createProject("library.c"));
+	graph.addProject(await createProject("library.d"));
+	graph.addProject(await createProject("library.e"));
+
+	graph.declareDependency("library.a", "library.b");
+	graph.declareDependency("library.b", "library.c");
+	graph.declareDependency("library.c", "library.d");
+	graph.declareDependency("library.a", "library.d");
+	graph.declareDependency("library.d", "library.e");
+
+	t.deepEqual(graph.getAllDependencies("library.a"), [
+		"library.b",
+		"library.c",
+		"library.d",
+		"library.e",
+	], "Should store and return correct transitive dependencies for library.a");
+});
+
 test("declareDependency: Unknown source", async (t) => {
 	const {ProjectGraph} = t.context;
 	const graph = new ProjectGraph({

--- a/test/lib/specifications/Project.js
+++ b/test/lib/specifications/Project.js
@@ -118,15 +118,13 @@ test("getBuilderSettings", async (t) => {
 	}, "Returned correct build settings");
 });
 
-test("has-/getBuildManifest", async (t) => {
+test("getBuildManifest", async (t) => {
 	const projectWithoutBuildManifest = await Specification.create(clone(basicProjectInput));
-	t.false(projectWithoutBuildManifest.hasBuildManifest(), "Project has a no build manifest");
-	t.deepEqual(projectWithoutBuildManifest.getBuildManifest(), {}, "Project has a no build manifest");
+	t.is(projectWithoutBuildManifest.getBuildManifest(), null, "Project has a no build manifest");
 
 	const customProjectInput = clone(basicProjectInput);
 	customProjectInput.buildManifest = "buildManifest";
 	const project = await Specification.create(customProjectInput);
-	t.true(project.hasBuildManifest(), "Project has a build manifest");
 	t.is(project.getBuildManifest(), "buildManifest", "Returned correct build manifest");
 });
 

--- a/test/lib/specifications/types/extensions/ServerMiddleware.js
+++ b/test/lib/specifications/types/extensions/ServerMiddleware.js
@@ -61,17 +61,15 @@ test("Correct class (ESM)", async (t) => {
 
 test("getMiddleware (CJS)", async (t) => {
 	const extension = await Specification.create(clone(basicCjsServerMiddlewareInput));
-	const middlewarePromise = extension.getMiddleware();
-	t.is(typeof middlewarePromise.then, "function");
-	t.is(await middlewarePromise, "extension module",
+	const middleware = await extension.getMiddleware();
+	t.is(middleware(), "extension module",
 		"Returned correct module");
 });
 
 test("getMiddleware (ESM)", async (t) => {
 	const extension = await Specification.create(clone(basicEsmServerMiddlewareInput));
-	const middlewarePromise = extension.getMiddleware();
-	t.is(typeof middlewarePromise.then, "function");
-	t.is(await middlewarePromise, "extension module",
+	const middleware = await extension.getMiddleware();
+	t.is(middleware(), "extension module",
 		"Returned correct module");
 });
 

--- a/test/lib/specifications/types/extensions/Task.js
+++ b/test/lib/specifications/types/extensions/Task.js
@@ -64,17 +64,29 @@ test("Correct class (ESM)", async (t) => {
 
 test("getTask (CJS)", async (t) => {
 	const extension = await Specification.create(clone(basicCjsTaskInput));
-	const taskPromise = extension.getTask();
-	t.is(typeof taskPromise.then, "function");
-	t.is(await taskPromise, "extension module",
+	const task = await extension.getTask();
+	t.is(task(), "extension module",
 		"Returned correct module");
 });
 
 test("getTask (ESM)", async (t) => {
 	const extension = await Specification.create(clone(basicEsmTaskInput));
-	const taskPromise = extension.getTask();
-	t.is(typeof taskPromise.then, "function");
-	t.is(await taskPromise, "extension module",
+	const task = await extension.getTask();
+	t.is(task(), "extension module",
+		"Returned correct module");
+});
+
+test("getRequiredDependenciesCallback (CJS)", async (t) => {
+	const extension = await Specification.create(clone(basicCjsTaskInput));
+	const requiredDependenciesCallback = await extension.getRequiredDependenciesCallback();
+	t.is(requiredDependenciesCallback(), "required dependencies function",
+		"Returned correct module");
+});
+
+test("getRequiredDependenciesCallback (ESM)", async (t) => {
+	const extension = await Specification.create(clone(basicEsmTaskInput));
+	const requiredDependenciesCallback = await extension.getRequiredDependenciesCallback();
+	t.is(requiredDependenciesCallback(), "required dependencies function",
 		"Returned correct module");
 });
 


### PR DESCRIPTION
* Move requiresBuild() logic from TaskRunner to ProjectBuildContext
    * This likely needs to be moved into a module of its own at some
      point. For now, TaskRunner was the wrong place. If a project does
      not need to be built, there is no need to instantiate a TaskRunner
      in the first place. This is now implemented.
* TaskRunner can now compile a list of all direct project dependencies
  required by the set of tasks that it will execute for the given build
  options.
* Custom tasks defining specVersion >= 3.0 can now provide a
  'determineRequiredDependencies' callback to define which dependencies
  they require access to.

JIRA: CPOUI5FOUNDATION-568