### PR TITLE
[INTERNAL] Use new taskRepository API

### DIFF
--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -34,11 +34,12 @@ class ProjectBuilder {
 	 * Executes a project build, including all necessary or requested dependencies
 	 *
 	 * @public
-	 * @param {@ui5/project/graph/ProjectGraph} graph Project graph
-	 * @param {@ui5/builder/tasks/taskRepository} taskRepository Task Repository module
-	 * @param {@ui5/project/build/ProjectBuilder~BuildConfiguration} [buildConfig] Build configuration
+	 * @param {object} parameters
+	 * @param {@ui5/project/graph/ProjectGraph} parameters.graph Project graph
+	 * @param {@ui5/project/build/ProjectBuilder~BuildConfiguration} [parameters.buildConfig] Build configuration
+	 * @param {@ui5/builder/tasks/taskRepository} parameters.taskRepository Task Repository module to use
 	 */
-	constructor(graph, taskRepository, buildConfig) {
+	constructor({graph, buildConfig, taskRepository}) {
 		if (!graph) {
 			throw new Error(`Missing parameter 'graph'`);
 		}
@@ -302,7 +303,7 @@ class ProjectBuilder {
 			const {
 				default: createBuildManifest
 			} = await import("./helpers/createBuildManifest.js");
-			const metadata = await createBuildManifest(project, buildConfig);
+			const metadata = await createBuildManifest(project, buildConfig, this._buildContext.getTaskRepository());
 			await target.write(resourceFactory.createResource({
 				path: `/.ui5/build-manifest.json`,
 				string: JSON.stringify(metadata, null, "\t")

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -23,8 +23,9 @@ class ProjectBuilder {
 	 * @property {boolean} [cssVariables=false] Flag to activate CSS variables generation
 	 * @property {boolean} [jsdoc=false] Flag to activate JSDoc build
 	 * @property {boolean} [createBuildManifest=false]
-	 * 			Whether to create a build manifest file for the root project.
-	 *			This is currently only supported for projects of type 'library' and 'theme-library'
+	 *   Whether to create a build manifest file for the root project.
+	 *   This is currently only supported for projects of type 'library' and 'theme-library'
+	 *   No other dependencies can be included in the build result.
 	 * @property {Array.<string>} [includedTasks=[]] List of tasks to be included
 	 * @property {Array.<string>} [excludedTasks=[]] List of tasks to be excluded.
 	 * 			If the wildcard '*' is provided, only the included tasks will be executed.
@@ -101,6 +102,12 @@ class ProjectBuilder {
 		const requestedProjects = this._graph.getAllProjects().map((p) => p.getName()).filter(function(projectName) {
 			return filterProject(projectName);
 		});
+
+		if (this._buildContext.getBuildConfig().createBuildManifest && requestedProjects.length > 1) {
+			throw new Error(
+				`It is currently not supported to request the creation of a build manifest ` +
+				`while including any dependencies into the build result`);
+		}
 
 		const projectBuildContexts = await this._createRequiredBuildContexts(requestedProjects);
 		const cleanupSigHooks = this._registerCleanupSigHooks();

--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -338,6 +338,13 @@ class TaskRunner {
 			const refTaskName = taskDef.beforeTask || taskDef.afterTask;
 			let refTaskIdx = this._taskExecutionOrder.indexOf(refTaskName);
 			if (refTaskIdx === -1) {
+				if (this._taskRepository.getRemovedTaskNames().includes(refTaskName)) {
+					throw new Error(
+						`Standard task ${refTaskName}, referenced by custom task ${newTaskName} ` +
+						`in project ${project.getName()}, ` +
+						`has been removed in this version of UI5 Tooling and can't be referenced anymore. ` +
+						`Please see the migration guide at https://sap.github.io/ui5-tooling/updates/migrate-v3/`);
+				}
 				throw new Error(`Could not find task ${refTaskName}, referenced by custom task ${newTaskName}, ` +
 					`to be scheduled for project ${project.getName()}`);
 			}

--- a/lib/build/helpers/createBuildManifest.js
+++ b/lib/build/helpers/createBuildManifest.js
@@ -16,7 +16,16 @@ function getSortedTags(project) {
 	return Object.fromEntries(entities);
 }
 
-export default async function(project, buildConfig) {
+export default async function(project, buildConfig, taskRepository) {
+	if (!project) {
+		throw new Error(`Missing parameter 'project'`);
+	}
+	if (!buildConfig) {
+		throw new Error(`Missing parameter 'buildConfig'`);
+	}
+	if (!taskRepository) {
+		throw new Error(`Missing parameter 'taskRepository'`);
+	}
 	const projectName = project.getName();
 	const type = project.getType();
 
@@ -36,6 +45,7 @@ export default async function(project, buildConfig) {
 			`Project type ${type} is currently not supported`);
 	}
 
+	const {builderVersion, fsVersion: builderFsVersion} = await taskRepository.getVersions();
 	const metadata = {
 		project: {
 			specVersion: project.getSpecVersion().toString(),
@@ -50,10 +60,10 @@ export default async function(project, buildConfig) {
 			}
 		},
 		buildManifest: {
-			manifestVersion: "0.1",
+			manifestVersion: "0.2",
 			timestamp: new Date().toISOString(),
 			versions: {
-				builderVersion: await getVersion("@ui5/builder"),
+				builderVersion: builderVersion,
 				projectVersion: await getVersion("@ui5/project"),
 				fsVersion: await getVersion("@ui5/fs"),
 			},
@@ -63,6 +73,13 @@ export default async function(project, buildConfig) {
 			tags: getSortedTags(project)
 		}
 	};
+
+	if (metadata.buildManifest.versions.fsVersion !== builderFsVersion) {
+		// Added in manifestVersion 0.2:
+		// @ui5/project and @ui5/builder use different versions of @ui5/fs.
+		// This should be mentioned in the build manifest:
+		metadata.buildManifest.versions.builderFsVersion = builderFsVersion;
+	}
 
 	return metadata;
 }

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -1,4 +1,3 @@
-import * as taskRepository from "@ui5/builder/internal/taskRepository";
 import logger from "@ui5/logger";
 const log = logger.getLogger("graph:ProjectGraph");
 
@@ -21,8 +20,6 @@ class ProjectGraph {
 		}
 		this._rootProjectName = rootProjectName;
 
-		this._taskRepository = taskRepository;
-
 		this._projects = Object.create(null); // maps project name to instance
 		this._adjList = Object.create(null); // maps project name to edges/dependencies
 		this._optAdjList = Object.create(null); // maps project name to optional dependencies
@@ -31,6 +28,7 @@ class ProjectGraph {
 
 		this._sealed = false;
 		this._hasUnresolvedOptionalDependencies = false; // Performance optimization flag
+		this._taskRepository = null;
 	}
 
 	/**
@@ -492,11 +490,14 @@ class ProjectGraph {
 	}
 
 	// Only to be used by @ui5/builder tests to inject its version of the taskRepository
-	setTaskRepository(taskRepo) {
-		this._taskRepository = taskRepo;
+	setTaskRepository(taskRepository) {
+		this._taskRepository = taskRepository;
 	}
 
-	getTaskRepository() {
+	async _getTaskRepository() {
+		if (!this._taskRepository) {
+			this._taskRepository = await import("@ui5/builder/internal/taskRepository");
+		}
 		return this._taskRepository;
 	}
 
@@ -531,7 +532,7 @@ class ProjectGraph {
 		selfContained = false, cssVariables = false, jsdoc = false, createBuildManifest = false,
 		includedTasks = [], excludedTasks = []
 	}) {
-		this.seal();
+		this.seal(); // Do not allow further changes to the graph
 		if (this._built) {
 			throw new Error(
 				`Project graph with root node ${this._rootProjectName} has already been built. ` +
@@ -541,10 +542,14 @@ class ProjectGraph {
 		const {
 			default: ProjectBuilder
 		} = await import("../build/ProjectBuilder.js");
-		const builder = new ProjectBuilder(this, this.getTaskRepository(), {
-			selfContained, cssVariables, jsdoc,
-			createBuildManifest,
-			includedTasks, excludedTasks,
+		const builder = new ProjectBuilder({
+			graph: this,
+			taskRepository: await this._getTaskRepository(),
+			buildConfig: {
+				selfContained, cssVariables, jsdoc,
+				createBuildManifest,
+				includedTasks, excludedTasks,
+			}
 		});
 		await builder.build({
 			destPath, cleanDest,
@@ -563,7 +568,9 @@ class ProjectGraph {
 	}
 
 	/**
-	 * Check whether the project graph has been sealed
+	 * Check whether the project graph has been sealed.
+	 * This means the graph is read-only. Neither projects, nor dependencies between projects
+	 * can be added or removed.
 	 *
 	 * @public
 	 * @returns {boolean} True if the project graph has been sealed
@@ -580,7 +587,7 @@ class ProjectGraph {
 	 */
 	_checkSealed() {
 		if (this._sealed) {
-			throw new Error(`Project graph with root node ${this._rootProjectName} has been sealed`);
+			throw new Error(`Project graph with root node ${this._rootProjectName} has been sealed and is read-only`);
 		}
 	}
 

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -78,13 +78,13 @@ test.afterEach.always((t) => {
 test("Missing graph parameters", (t) => {
 	const {ProjectBuilder} = t.context;
 	const err1 = t.throws(() => {
-		new ProjectBuilder();
+		new ProjectBuilder({});
 	});
 	t.is(err1.message, "Missing parameter 'graph'",
 		"Threw with expected error message");
 
 	const err2 = t.throws(() => {
-		new ProjectBuilder("graph");
+		new ProjectBuilder({graph: "graph"});
 	});
 	t.is(err2.message, "Missing parameter 'taskRepository'",
 		"Threw with expected error message");
@@ -93,7 +93,7 @@ test("Missing graph parameters", (t) => {
 test("build", async (t) => {
 	const {graph, taskRepository, ProjectBuilder, sinon} = t.context;
 
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const filterProjectStub = sinon.stub().returns(true);
 	const getProjectFilterStub = sinon.stub(builder, "_getProjectFilter").resolves(filterProjectStub);
@@ -156,7 +156,7 @@ test("build", async (t) => {
 test("build: Missing dest parameter", async (t) => {
 	const {graph, taskRepository, ProjectBuilder} = t.context;
 
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const err = await t.throwsAsync(builder.build({
 		destPath: "dest/path",
@@ -174,7 +174,7 @@ test("build: Missing dest parameter", async (t) => {
 test("build: Too many dependency parameters", async (t) => {
 	const {graph, taskRepository, ProjectBuilder} = t.context;
 
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const err = await t.throwsAsync(builder.build({
 		includedDependencies: ["dep a"],
@@ -187,7 +187,7 @@ test("build: Too many dependency parameters", async (t) => {
 test("build: Failure", async (t) => {
 	const {graph, taskRepository, ProjectBuilder, sinon} = t.context;
 
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const filterProjectStub = sinon.stub().returns(true);
 	sinon.stub(builder, "_getProjectFilter").resolves(filterProjectStub);
@@ -229,7 +229,7 @@ test("build: Failure", async (t) => {
 
 test.serial("build: Multiple projects", async (t) => {
 	const {graph, taskRepository, ProjectBuilder, sinon} = t.context;
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const filterProjectStub = sinon.stub().returns(true).onFirstCall().returns(false);
 	const getProjectFilterStub = sinon.stub(builder, "_getProjectFilter").resolves(filterProjectStub);
@@ -327,7 +327,7 @@ test.serial("build: Multiple projects", async (t) => {
 test("_createRequiredBuildContexts", async (t) => {
 	const {graph, taskRepository, ProjectBuilder, sinon} = t.context;
 
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const requiresBuildStub = sinon.stub().returns(true);
 	const getRequiredDependenciesStub = sinon.stub()
@@ -380,7 +380,7 @@ test.serial("_getProjectFilter with complexDependencyIncludes", async (t) => {
 		"../../../lib/build/helpers/composeProjectList.js": composeProjectListStub
 	});
 
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const filterProject = await builder._getProjectFilter({
 		complexDependencyIncludes: "complexDependencyIncludes",
@@ -411,7 +411,7 @@ test.serial("_getProjectFilter with explicit include/exclude", async (t) => {
 		"../../../lib/build/helpers/composeProjectList.js": composeProjectListStub
 	});
 
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const filterProject = await builder._getProjectFilter({
 		explicitIncludes: "explicitIncludes",
@@ -437,9 +437,12 @@ test("_writeResults", async (t) => {
 	const {ProjectBuilder, sinon} = t.context;
 	t.context.getRootTypeStub = sinon.stub().returns("library");
 	const {graph, taskRepository} = t.context;
-	const builder = new ProjectBuilder(graph, taskRepository, {
-		createBuildManifest: false,
-		otherBuildConfig: "yes"
+	const builder = new ProjectBuilder({
+		graph, taskRepository,
+		buildConfig: {
+			createBuildManifest: false,
+			otherBuildConfig: "yes"
+		}
 	});
 
 	const dummyResources = [{
@@ -513,9 +516,12 @@ test.serial("_writeResults: Create build manifest", async (t) => {
 		}
 	});
 
-	const builder = new ProjectBuilder(graph, taskRepository, {
-		createBuildManifest: true,
-		otherBuildConfig: "yes"
+	const builder = new ProjectBuilder({
+		graph, taskRepository,
+		buildConfig: {
+			createBuildManifest: true,
+			otherBuildConfig: "yes"
+		}
 	});
 
 	const dummyResources = [{
@@ -603,8 +609,11 @@ test("_writeResults: Do not create build manifest for non-root project", async (
 	t.context.getRootTypeStub = sinon.stub().returns("library");
 	const {graph, taskRepository} = t.context;
 
-	const builder = new ProjectBuilder(graph, taskRepository, {
-		createBuildManifest: true
+	const builder = new ProjectBuilder({
+		graph, taskRepository,
+		buildConfig: {
+			createBuildManifest: true
+		}
 	});
 
 	const dummyResources = [{
@@ -650,7 +659,7 @@ test("_writeResults: Do not create build manifest for non-root project", async (
 
 test("_executeCleanupTasks", async (t) => {
 	const {graph, taskRepository, ProjectBuilder, sinon} = t.context;
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const executeCleanupTasksStub = sinon.stub(builder._buildContext, "executeCleanupTasks");
 	await builder._executeCleanupTasks();
@@ -669,7 +678,7 @@ test("_registerCleanupSigHooks/_deregisterCleanupSigHooks", (t) => {
 	const listenersBefore = getProcessListenerCount();
 
 	const {graph, taskRepository, ProjectBuilder} = t.context;
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const signals = builder._registerCleanupSigHooks();
 
@@ -687,7 +696,7 @@ test("_registerCleanupSigHooks/_deregisterCleanupSigHooks", (t) => {
 
 test("_getElapsedTime", (t) => {
 	const {graph, taskRepository, ProjectBuilder} = t.context;
-	const builder = new ProjectBuilder(graph, taskRepository);
+	const builder = new ProjectBuilder({graph, taskRepository});
 
 	const res = builder._getElapsedTime(process.hrtime());
 	t.truthy(res, "Returned a value");

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -184,6 +184,28 @@ test("build: Too many dependency parameters", async (t) => {
 	t.is(err.message, "Missing parameter 'destPath'", "Threw with expected error message");
 });
 
+test("build: createBuildManifest in conjunction with dependencies", async (t) => {
+	const {graph, taskRepository, ProjectBuilder, sinon} = t.context;
+	t.context.getRootTypeStub = sinon.stub().returns("library");
+	const builder = new ProjectBuilder({graph, taskRepository,
+		buildConfig: {
+			createBuildManifest: true
+		}
+	});
+
+	const filterProjectStub = sinon.stub().returns(true);
+	sinon.stub(builder, "_getProjectFilter").resolves(filterProjectStub);
+	const err = await t.throwsAsync(builder.build({
+		destPath: "dest/path",
+		includedDependencies: ["dep a"]
+	}));
+
+	t.is(err.message,
+		"It is currently not supported to request the creation of a build manifest while " +
+		"including any dependencies into the build result",
+		"Threw with expected error message");
+});
+
 test("build: Failure", async (t) => {
 	const {graph, taskRepository, ProjectBuilder, sinon} = t.context;
 

--- a/test/lib/build/helpers/createBuildManifest.integration.js
+++ b/test/lib/build/helpers/createBuildManifest.integration.js
@@ -48,7 +48,11 @@ test("Create project from application project providing a build manifest", async
 	const inputProject = await Specification.create(applicationAConfig);
 	inputProject.getResourceTagCollection().setTag("/resources/id1/foo.js", "ui5:HasDebugVariant");
 
-	const metadata = await createBuildManifest(inputProject, buildConfig);
+	const taskRepository = {
+		getVersions: async () => ({a: "a", b: "b"})
+	};
+
+	const metadata = await createBuildManifest(inputProject, buildConfig, taskRepository);
 	const m = new Module({
 		id: "build-descr-application.a.id",
 		version: "2.0.0",
@@ -76,7 +80,11 @@ test("Create project from library project providing a build manifest", async (t)
 	const inputProject = await Specification.create(libraryEConfig);
 	inputProject.getResourceTagCollection().setTag("/resources/library/e/file.js", "ui5:HasDebugVariant");
 
-	const metadata = await createBuildManifest(inputProject, buildConfig);
+	const taskRepository = {
+		getVersions: async () => ({a: "a", b: "b"})
+	};
+
+	const metadata = await createBuildManifest(inputProject, buildConfig, taskRepository);
 	const m = new Module({
 		id: "build-descr-library.e.id",
 		version: "2.0.0",

--- a/test/lib/build/helpers/createBuildManifest.js
+++ b/test/lib/build/helpers/createBuildManifest.js
@@ -43,17 +43,40 @@ const libraryProjectInput = {
 	}
 };
 
+test("Missing parameter: project", async (t) => {
+	await t.throwsAsync(createBuildManifest(), {
+		message: "Missing parameter 'project'"
+	});
+});
+
+test("Missing parameter: buildConfig", async (t) => {
+	const project = await Specification.create(applicationProjectInput);
+
+	await t.throwsAsync(createBuildManifest(project), {
+		message: "Missing parameter 'buildConfig'"
+	});
+});
+
+test("Missing parameter: taskRepository", async (t) => {
+	const project = await Specification.create(applicationProjectInput);
+
+	await t.throwsAsync(createBuildManifest(project, "buildConfig"), {
+		message: "Missing parameter 'taskRepository'"
+	});
+});
+
 test("Create application from project with build manifest", async (t) => {
 	const project = await Specification.create(applicationProjectInput);
 	project.getResourceTagCollection().setTag("/resources/id1/foo.js", "ui5:HasDebugVariant");
 
-	const metadata = await createBuildManifest(project, "buildConfig");
+	const taskRepository = {
+		getVersions: async () => ({builderVersion: "<builder version>", fsVersion: "<builder fs version>"})
+	};
+
+	const metadata = await createBuildManifest(project, "buildConfig", taskRepository);
 
 	t.truthy(new Date(metadata.buildManifest.timestamp), "Timestamp is valid");
 	metadata.buildManifest.timestamp = "<timestamp>";
-
-	t.not(semver.valid(metadata.buildManifest.versions.builderVersion), null, "builder version should be filled");
-	metadata.buildManifest.versions.builderVersion = "<version>";
 
 	t.not(semver.valid(metadata.buildManifest.versions.fsVersion), null, "fs version should be filled");
 	metadata.buildManifest.versions.fsVersion = "<version>";
@@ -77,15 +100,16 @@ test("Create application from project with build manifest", async (t) => {
 			}
 		},
 		buildManifest: {
-			manifestVersion: "0.1",
+			manifestVersion: "0.2",
 			buildConfig: "buildConfig",
 			namespace: "id1",
 			timestamp: "<timestamp>",
 			version: "1.0.0",
 			versions: {
-				builderVersion: "<version>",
+				builderVersion: "<builder version>",
 				fsVersion: "<version>",
 				projectVersion: "<version>",
+				builderFsVersion: "<builder fs version>",
 			},
 			tags: {
 				"/resources/id1/foo.js": {
@@ -100,13 +124,14 @@ test("Create library from project with build manifest", async (t) => {
 	const project = await Specification.create(libraryProjectInput);
 	project.getResourceTagCollection().setTag("/resources/library/d/foo.js", "ui5:HasDebugVariant");
 
-	const metadata = await createBuildManifest(project, "buildConfig");
+	const taskRepository = {
+		getVersions: async () => ({builderVersion: "<builder version>", fsVersion: "<builder fs version>"})
+	};
+
+	const metadata = await createBuildManifest(project, "buildConfig", taskRepository);
 
 	t.truthy(new Date(metadata.buildManifest.timestamp), "Timestamp is valid");
 	metadata.buildManifest.timestamp = "<timestamp>";
-
-	t.not(semver.valid(metadata.buildManifest.versions.builderVersion), null, "builder version should be filled");
-	metadata.buildManifest.versions.builderVersion = "<version>";
 
 	t.not(semver.valid(metadata.buildManifest.versions.fsVersion), null, "fs version should be filled");
 	metadata.buildManifest.versions.fsVersion = "<version>";
@@ -131,15 +156,16 @@ test("Create library from project with build manifest", async (t) => {
 			}
 		},
 		buildManifest: {
-			manifestVersion: "0.1",
+			manifestVersion: "0.2",
 			buildConfig: "buildConfig",
 			namespace: "library/d",
 			timestamp: "<timestamp>",
 			version: "1.0.0",
 			versions: {
-				builderVersion: "<version>",
+				builderVersion: "<builder version>",
 				fsVersion: "<version>",
 				projectVersion: "<version>",
+				builderFsVersion: "<builder fs version>",
 			},
 			tags: {
 				"/resources/library/d/foo.js": {

--- a/test/lib/graph/ProjectGraph.js
+++ b/test/lib/graph/ProjectGraph.js
@@ -1195,7 +1195,7 @@ test("Seal/isSealed", async (t) => {
 	graph.seal();
 	t.is(graph.isSealed(), true, "Graph should be sealed");
 
-	const expectedSealMsg = "Project graph with root node library.a has been sealed";
+	const expectedSealMsg = "Project graph with root node library.a has been sealed and is read-only";
 
 	const libX = await createProject("library.x");
 	t.throws(() => {


### PR DESCRIPTION
* Move requiresBuild() from TaskRunner to ProjectBuildContext
    * This likely needs to be moved into a module of its own at some
      point. For now, TaskRunner was the wrong place. If a project does
      not need to be built, there is no need to instantiate a TaskRunner
      in the first place. This is now implemented.
* TaskRunner can now compile a list of all direct project dependencies
  required by the set of tasks that it will execute for the given build
  options.
* Custom tasks defining specVersion >= 3.0 can now provide a
  'determineRequiredDependencies' callback to define which dependencies
  they require access to.