### PR TITLE
 [INTERNAL] ui5Framework: Log warning for deprecated and internal libs

### DIFF
--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -303,9 +303,9 @@ class ProjectGraph {
 		});
 
 		let unresolvedOptDeps = false;
-		for (const [projectName, dependencies] of Object.entries(this._optAdjList)) {
-			for (let i = dependencies.length - 1; i >= 0; i--) {
-				const targetProjectName = dependencies[i];
+		for (const [projectName, optDependencies] of Object.entries(this._optAdjList)) {
+			for (let i = optDependencies.length - 1; i >= 0; i--) {
+				const targetProjectName = optDependencies[i];
 				if (resolvedProjects.has(targetProjectName)) {
 					// Target node is already reachable in the graph
 					// => Resolve optional dependency
@@ -321,7 +321,9 @@ class ProjectGraph {
 						unresolvedOptDeps = true;
 					} else {
 						this.declareDependency(projectName, targetProjectName);
-						dependencies.splice(i, 1);
+						// This optional dependency has now been resolved
+						// => Remove it from the list of optional dependencies
+						optDependencies.splice(i, 1);
 					}
 				} else {
 					unresolvedOptDeps = true;

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -30,7 +30,7 @@ class ProjectGraph {
 		this._extensions = Object.create(null); // maps extension name to instance
 
 		this._sealed = false;
-		this._shouldResolveOptionalDependencies = false; // Performance optimization flag
+		this._hasUnresolvedOptionalDependencies = false; // Performance optimization flag
 	}
 
 	/**
@@ -181,7 +181,7 @@ class ProjectGraph {
 			// }
 			log.verbose(`Declaring optional dependency: ${fromProjectName} depends on ${toProjectName}`);
 			this._declareDependency(this._optAdjList, fromProjectName, toProjectName);
-			this._shouldResolveOptionalDependencies = true;
+			this._hasUnresolvedOptionalDependencies = true;
 		} catch (err) {
 			throw new Error(
 				`Failed to declare optional dependency from project ${fromProjectName} to ${toProjectName}: ` +
@@ -290,7 +290,7 @@ class ProjectGraph {
 	 * @public
 	 */
 	async resolveOptionalDependencies() {
-		if (!this._shouldResolveOptionalDependencies) {
+		if (!this._hasUnresolvedOptionalDependencies) {
 			log.verbose(`Skipping resolution of optional dependencies since none have been declared`);
 			return;
 		}
@@ -302,6 +302,7 @@ class ProjectGraph {
 			resolvedProjects.add(project.getName());
 		});
 
+		let unresolvedOptDeps = false;
 		for (const [projectName, dependencies] of Object.entries(this._optAdjList)) {
 			for (let i = dependencies.length - 1; i >= 0; i--) {
 				const targetProjectName = dependencies[i];
@@ -317,11 +318,18 @@ class ProjectGraph {
 						log.verbose(
 							`  Optional dependency from ${projectName} to ${targetProjectName} ` +
 							`will not be declared as it would introduce a cycle`);
+						unresolvedOptDeps = true;
 					} else {
 						this.declareDependency(projectName, targetProjectName);
+						dependencies.splice(i, 1);
 					}
+				} else {
+					unresolvedOptDeps = true;
 				}
 			}
+		}
+		if (!unresolvedOptDeps) {
+			this._hasUnresolvedOptionalDependencies = false;
 		}
 	}
 

--- a/lib/graph/helpers/ui5Framework.js
+++ b/lib/graph/helpers/ui5Framework.js
@@ -106,12 +106,39 @@ const utils = {
 				return;
 			}
 
+			const isRoot = project === rootProject;
 			frameworkDependencies.forEach((dependency) => {
-				if (utils.shouldIncludeDependency(dependency, project === rootProject)) {
-					projectGraph.declareDependency(project.getName(), dependency.name);
+				if (isRoot || !dependency.development) {
+					// Root project should include all dependencies
+					// Otherwise all non-development dependencies should be considered
+
+					if (isRoot) {
+						// Check for deprecated/internal dependencies of the root project
+						const depProject = projectGraph.getProject(dependency.name);
+						if (depProject && depProject.isDeprecated() && rootProject.getName() !== "testsuite") {
+							// No warning for testsuite projects
+							log.warn(`Dependency ${depProject.getName()} is deprecated ` +
+								`and should not be used for new projects!`);
+						}
+						if (depProject && depProject.isSapInternal() && !rootProject.getAllowSapInternal()) {
+							// Do not warn if project defines "allowSapInternal"
+							log.warn(`Dependency ${depProject.getName()} is restricted for use by ` +
+								`SAP internal projects only! ` +
+								`If the project ${rootProject.getName()} is an SAP internal project, ` +
+								`add the attribute "allowSapInternal: true" to its metadata configuration`);
+						}
+					}
+					if (dependency.optional) {
+						if (projectGraph.getProject(dependency.name)) {
+							projectGraph.declareOptionalDependency(project.getName(), dependency.name);
+						}
+					} else {
+						projectGraph.declareDependency(project.getName(), dependency.name);
+					}
 				}
 			});
 		});
+		await projectGraph.resolveOptionalDependencies();
 	},
 	ProjectProcessor
 };

--- a/lib/graph/projectGraphBuilder.js
+++ b/lib/graph/projectGraphBuilder.js
@@ -261,7 +261,7 @@ async function projectGraphBuilder(nodeProvider) {
 					}
 
 					if (project.isDeprecated() && parentProject === rootProject &&
-							!parentProject.getName().endsWith("/testsuite")) {
+							parentProject.getName() !== "testsuite") {
 						// Only warn for direct dependencies of the root project
 						// No warning for testsuite projects
 						log.warn(

--- a/test/lib/graph/helpers/ui5Framework.integration.js
+++ b/test/lib/graph/helpers/ui5Framework.integration.js
@@ -428,6 +428,20 @@ function defineTest(testName, {
 			"test-application",
 		], "Traversed graph in correct order");
 
+		t.deepEqual(projectGraph.getDependencies("test-application"), [
+			"test-dependency",
+			"test-dependency-no-framework",
+			"sap.ui.lib1",
+			"sap.ui.lib8",
+			"sap.ui.lib4",
+		], `Non-framework dependency has correct dependencies`);
+
+		t.deepEqual(projectGraph.getDependencies("test-dependency"), [
+			"sap.ui.lib1",
+			"sap.ui.lib2",
+			"sap.ui.lib8",
+		], `Non-framework dependency has correct dependencies`);
+
 		const frameworkLibAlreadyAddedInfoLogged = (logStub.info.getCalls()
 			.map(($) => $.firstArg)
 			.findIndex(($) => $.includes("defines a dependency to the UI5 framework library")) !== -1);

--- a/test/lib/graph/projectGraphBuilder.js
+++ b/test/lib/graph/projectGraphBuilder.js
@@ -175,7 +175,7 @@ test.serial("No warnings logged", async (t) => {
 
 	const node1 = createNode({
 		id: "id1",
-		name: "@my-comp/testsuite" // "/testsuite" suffix should suppress deprecation warnings
+		name: "testsuite" // "testsuite" name should suppress deprecation warnings
 	});
 	node1.configuration.metadata.allowSapInternal = true;
 	getRootNode.resolves(node1);
@@ -196,7 +196,7 @@ test.serial("No warnings logged", async (t) => {
 	const graph = await projectGraphBuilder(t.context.provider);
 
 	await traverseBreadthFirst(t, graph, [
-		"@my-comp/testsuite",
+		"testsuite",
 		"project-2",
 		"project-3"
 	]);


### PR DESCRIPTION
* Also fix a bug which caused optional framework dependencies to not be
  resolved
* Do not log deprecation warnings for projects named "testsuite" (fixed
  this for projectGraphBuilder)
* (separate commit) ProjectGraph: Cleanup resolved optional dependencies