### PR TITLE
[INTERNAL] Refactor log-calls

### DIFF
--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -3,7 +3,7 @@ import rimraf from "rimraf";
 const rimrafp = promisify(rimraf);
 import * as resourceFactory from "@ui5/fs/resourceFactory";
 import logger from "@ui5/logger";
-const log = logger.getGroupLogger("build");
+const log = logger.getLogger("ProjectBuilder");
 import composeProjectList from "./helpers/composeProjectList.js";
 import BuildContext from "./helpers/BuildContext.js";
 import prettyHrtime from "pretty-hrtime";
@@ -196,8 +196,7 @@ class ProjectBuilder {
 				}
 			}
 		});
-		const buildLogger = log.createTaskLogger("🛠 ");
-		buildLogger.addWork(queue.length - alreadyBuilt.length);
+
 		if (queue.length > 1) { // Do not log if only the root project is being built
 			log.info(`Processing ${queue.length} projects`);
 			if (alreadyBuilt.length) {
@@ -237,10 +236,8 @@ class ProjectBuilder {
 
 				// Only build projects that are not already build (i.e. provide a matching build manifest)
 				if (!alreadyBuilt.includes(projectName)) {
-					buildLogger.startWork(`Building project ${projectName}...`);
+					log.info(`Building project ${projectName}...`);
 					await projectBuildContext.getTaskRunner().runTasks();
-					buildLogger.completeWork(1);
-
 					log.verbose(`Finished building project ${projectName}`);
 				}
 				if (!requestedProjects.includes(projectName)) {
@@ -273,8 +270,7 @@ class ProjectBuilder {
 		for (const projectName of requiredProjects) {
 			log.verbose(`Creating build context for project ${projectName}...`);
 			const projectBuildContext = this._buildContext.createProjectContext({
-				project: this._graph.getProject(projectName),
-				log
+				project: this._graph.getProject(projectName)
 			});
 
 			projectBuildContexts.set(projectName, projectBuildContext);

--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -15,14 +15,14 @@ class TaskRunner {
 	 * @param {object} parameters
 	 * @param {object} parameters.graph
 	 * @param {object} parameters.project
-	 * @param {@ui5/logger/GroupLogger} parameters.parentLogger Logger to use
+	 * @param {@ui5/logger/GroupLogger} parameters.log Logger to use
 	 * @param {@ui5/project/build/helpers/TaskUtil} parameters.taskUtil TaskUtil instance
 	 * @param {@ui5/builder/tasks/taskRepository} parameters.taskRepository Task repository
 	 * @param {@ui5/project/build/ProjectBuilder~BuildConfiguration} parameters.buildConfig
 	 * 			Build configuration
 	 */
-	constructor({graph, project, parentLogger, taskUtil, taskRepository, buildConfig}) {
-		if (!graph || !project || !parentLogger || !taskUtil || !taskRepository || !buildConfig) {
+	constructor({graph, project, log, taskUtil, taskRepository, buildConfig}) {
+		if (!graph || !project || !log || !taskUtil || !taskRepository || !buildConfig) {
 			throw new Error("One or more mandatory parameters not provided");
 		}
 		this._project = project;
@@ -31,8 +31,7 @@ class TaskRunner {
 		this._taskRepository = taskRepository;
 		this._buildConfig = buildConfig;
 
-		this._log = parentLogger.createSubLogger(project.getType() + " " + project.getName(), 0.2);
-		this._taskLog = this._log.createTaskLogger("🔨");
+		this._log = log;
 
 		this._directDependencies = new Set(this._taskUtil.getDependencies());
 	}
@@ -115,8 +114,6 @@ class TaskRunner {
 			const taskWithoutSuffixCounter = taskName.replace(/--\d+$/, "");
 			return tasksToRun.includes(taskWithoutSuffixCounter);
 		});
-
-		this._taskLog.addWork(allTasks.length);
 
 		for (const taskName of allTasks) {
 			const taskFunction = this._tasks[taskName].task;
@@ -403,7 +400,7 @@ class TaskRunner {
 
 			if (specVersion.gte("3.0")) {
 				params.options.taskName = taskName;
-				params.log = logger.getGroupLogger(`builder:custom-task:${taskName}`);
+				params.log = logger.getLogger(`builder:custom-task:${taskName}`);
 			}
 
 			const dependencies = await getDependenciesReader();
@@ -424,12 +421,11 @@ class TaskRunner {
 	 * @returns {Promise} Resolves when task has finished
 	 */
 	async _executeTask(taskName, taskFunction, taskParams) {
-		this._taskLog.startWork(`Running task ${taskName}...`);
+		this._log.info(`Running task ${taskName}...`);
 		this._taskStart = performance.now();
-		await taskFunction(taskParams, this._taskLog);
-		this._taskLog.completeWork(1);
-		if (this._taskLog.isLevelEnabled("perf")) {
-			this._taskLog.perf(`Task ${taskName} finished in ${Math.round((performance.now() - this._taskStart))} ms`);
+		await taskFunction(taskParams, this._log);
+		if (this._log.isLevelEnabled("perf")) {
+			this._log.perf(`Task ${taskName} finished in ${Math.round((performance.now() - this._taskStart))} ms`);
 		}
 	}
 

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -65,11 +65,10 @@ class BuildContext {
 		return this._graph;
 	}
 
-	createProjectContext({project, log}) {
+	createProjectContext({project}) {
 		const projectBuildContext = new ProjectBuildContext({
 			buildContext: this,
-			project,
-			log
+			project
 		});
 		this._projectBuildContexts.push(projectBuildContext);
 		return projectBuildContext;

--- a/lib/build/helpers/ProjectBuildContext.js
+++ b/lib/build/helpers/ProjectBuildContext.js
@@ -1,6 +1,7 @@
 import ResourceTagCollection from "@ui5/fs/internal/ResourceTagCollection";
 import TaskUtil from "./TaskUtil.js";
 import TaskRunner from "../TaskRunner.js";
+import logger from "@ui5/logger";
 
 /**
  * Build context of a single project. Always part of an overall
@@ -10,19 +11,16 @@ import TaskRunner from "../TaskRunner.js";
  * @memberof @ui5/project/build/helpers
  */
 class ProjectBuildContext {
-	constructor({buildContext, log, project}) {
+	constructor({buildContext, project}) {
 		if (!buildContext) {
 			throw new Error(`Missing parameter 'buildContext'`);
-		}
-		if (!log) {
-			throw new Error(`Missing parameter 'log'`);
 		}
 		if (!project) {
 			throw new Error(`Missing parameter 'project'`);
 		}
 		this._buildContext = buildContext;
 		this._project = project;
-		this._log = log;
+		this._log = logger.getLogger(`${project.getType()} ${project.getName()}`);
 		this._queues = {
 			cleanup: []
 		};
@@ -108,7 +106,7 @@ class ProjectBuildContext {
 		if (!this._taskRunner) {
 			this._taskRunner = new TaskRunner({
 				project: this._project,
-				parentLogger: this._log,
+				log: this._log,
 				taskUtil: this.getTaskUtil(),
 				graph: this._buildContext.getGraph(),
 				taskRepository: this._buildContext.getTaskRepository(),

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -383,16 +383,10 @@ test("_createRequiredBuildContexts", async (t) => {
 	t.is(createProjectContextStub.callCount, 3, "BuildContext#createProjectContextStub got called three times");
 	t.is(createProjectContextStub.getCall(0).args[0].project.getName(), "project.a",
 		"First call to BuildContext#createProjectContextStub with expected project");
-	t.truthy(createProjectContextStub.getCall(0).args[0].log,
-		"First call to BuildContext#createProjectContextStub with a log instance");
 	t.is(createProjectContextStub.getCall(1).args[0].project.getName(), "project.c",
 		"Second call to BuildContext#createProjectContextStub with expected project");
-	t.truthy(createProjectContextStub.getCall(1).args[0].log,
-		"Second call to BuildContext#createProjectContextStub with a log instance");
 	t.is(createProjectContextStub.getCall(2).args[0].project.getName(), "project.b",
 		"Third call to BuildContext#createProjectContextStub with expected project");
-	t.truthy(createProjectContextStub.getCall(2).args[0].log,
-		"Third call to BuildContext#createProjectContextStub with a log instance");
 });
 
 test.serial("_getProjectFilter with dependencyIncludes", async (t) => {

--- a/test/lib/build/TaskRunner.js
+++ b/test/lib/build/TaskRunner.js
@@ -3,7 +3,7 @@ import sinonGlobal from "sinon";
 import esmock from "esmock";
 import logger from "@ui5/logger";
 logger.setLevel("perf");
-const parentLogger = logger.getGroupLogger("mygroup");
+const log = logger.getLogger("mygroup");
 
 function noop() {}
 function emptyarray() {
@@ -106,7 +106,7 @@ test.beforeEach(async (t) => {
 	};
 
 	t.context.logger = {
-		getGroupLogger: sinon.stub().returns("group logger")
+		getLogger: sinon.stub().returns("group logger")
 	};
 
 	t.context.resourceFactory = {
@@ -131,7 +131,7 @@ test("Missing parameters", (t) => {
 			graph,
 			taskUtil,
 			taskRepository,
-			parentLogger,
+			log,
 			buildConfig
 		});
 	}, {
@@ -142,7 +142,7 @@ test("Missing parameters", (t) => {
 			project: getMockProject("application"),
 			taskUtil,
 			taskRepository,
-			parentLogger,
+			log,
 			buildConfig
 		});
 	}, {
@@ -153,7 +153,7 @@ test("Missing parameters", (t) => {
 			project: getMockProject("application"),
 			graph,
 			taskRepository,
-			parentLogger,
+			log,
 			buildConfig
 		});
 	}, {
@@ -164,7 +164,7 @@ test("Missing parameters", (t) => {
 			project: getMockProject("application"),
 			graph,
 			taskUtil,
-			parentLogger,
+			log,
 			buildConfig
 		});
 	}, {
@@ -180,14 +180,14 @@ test("Missing parameters", (t) => {
 		});
 	}, {
 		message: "One or more mandatory parameters not provided"
-	}, "Threw with expected error message for missing parentLogger parameter");
+	}, "Threw with expected error message for missing log parameter");
 	t.throws(() => {
 		new TaskRunner({
 			project: getMockProject("application"),
 			graph,
 			taskUtil,
 			taskRepository,
-			parentLogger
+			log
 		});
 	}, {
 		message: "One or more mandatory parameters not provided"
@@ -197,7 +197,7 @@ test("Missing parameters", (t) => {
 test("_initTasks: Project of type 'application'", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const taskRunner = new TaskRunner({
-		project: getMockProject("application"), graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project: getMockProject("application"), graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -220,7 +220,7 @@ test("_initTasks: Project of type 'application'", async (t) => {
 test("_initTasks: Project of type 'library'", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const taskRunner = new TaskRunner({
-		project: getMockProject("library"), graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project: getMockProject("library"), graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -245,7 +245,7 @@ test("_initTasks: Project of type 'library'", async (t) => {
 test("_initTasks: Project of type 'theme-library'", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const taskRunner = new TaskRunner({
-		project: getMockProject("theme-library"), graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project: getMockProject("theme-library"), graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -261,7 +261,7 @@ test("_initTasks: Project of type 'theme-library'", async (t) => {
 test("_initTasks: Project of type 'module'", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const taskRunner = new TaskRunner({
-		project: getMockProject("module"), graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project: getMockProject("module"), graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -271,7 +271,7 @@ test("_initTasks: Project of type 'module'", async (t) => {
 test("_initTasks: Unknown project type", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const taskRunner = new TaskRunner({
-		project: getMockProject("pony"), graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project: getMockProject("pony"), graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(taskRunner._initTasks());
 
@@ -286,7 +286,7 @@ test("_initTasks: Custom tasks", async (t) => {
 		{name: "myOtherTask", beforeTask: "replaceVersion"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -316,7 +316,7 @@ test("_initTasks: Custom tasks with no standard tasks", async (t) => {
 		{name: "myOtherTask", beforeTask: "myTask"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -333,7 +333,7 @@ test("_initTasks: Custom tasks with no standard tasks and second task defining n
 		{name: "myOtherTask"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
@@ -351,7 +351,7 @@ test("_initTasks: Custom tasks with both, before- and afterTask reference", asyn
 		{name: "myTask", beforeTask: "minify", afterTask: "replaceVersion"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
@@ -369,7 +369,7 @@ test("_initTasks: Custom tasks with no before-/afterTask reference", async (t) =
 		{name: "myTask"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
@@ -387,7 +387,7 @@ test("_initTasks: Custom tasks without name", async (t) => {
 		{name: ""}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
@@ -404,7 +404,7 @@ test("_initTasks: Custom task with name of standard tasks", async (t) => {
 		{name: "replaceVersion", afterTask: "minify"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
@@ -424,7 +424,7 @@ test("_initTasks: Multiple custom tasks with same name", async (t) => {
 		{name: "myTask", afterTask: "minify"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 	t.deepEqual(taskRunner._taskExecutionOrder, [
@@ -454,7 +454,7 @@ test("_initTasks: Custom tasks with unknown beforeTask", async (t) => {
 		{name: "myTask", beforeTask: "unknownTask"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
@@ -472,7 +472,7 @@ test("_initTasks: Custom tasks with unknown afterTask", async (t) => {
 		{name: "myTask", afterTask: "unknownTask"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
@@ -491,7 +491,7 @@ test("_initTasks: Custom tasks is unknown", async (t) => {
 		{name: "myTask", afterTask: "minify"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
@@ -509,7 +509,7 @@ test("_initTasks: Custom tasks with removed beforeTask", async (t) => {
 		{name: "myTask", beforeTask: "removedTask"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	const err = await t.throwsAsync(async () => {
 		await taskRunner._initTasks();
@@ -525,7 +525,7 @@ test("_initTasks: Create dependencies reader for all dependencies", async (t) =>
 	const {graph, taskUtil, taskRepository, TaskRunner, resourceFactory} = t.context;
 	const project = getMockProject("application");
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 	t.is(graph.traverseBreadthFirst.callCount, 1, "ProjectGraph#traverseBreadthFirst called once");
@@ -589,7 +589,7 @@ test("Custom task is called correctly", async (t) => {
 	];
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -649,7 +649,7 @@ test("Custom task with legacy spec version", async (t) => {
 	];
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -710,7 +710,7 @@ test("Custom task with legacy spec version and requiredDependenciesCallback", as
 	];
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -779,7 +779,7 @@ test("Custom task with specVersion 3.0", async (t) => {
 	];
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -912,7 +912,7 @@ test("Multiple custom tasks with same name are called correctly", async (t) => {
 		{name: "myTask", afterTask: "myTask", configuration: "bird"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -1060,7 +1060,7 @@ test("Custom task: requiredDependenciesCallback returns unknown dependency", asy
 	];
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await t.throwsAsync(taskRunner._initTasks(), {
 		message:
@@ -1097,7 +1097,7 @@ test("Custom task: requiredDependenciesCallback returns Array instead of Set", a
 	];
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await t.throwsAsync(taskRunner._initTasks(), {
 		message:
@@ -1116,7 +1116,7 @@ test.serial("_addTask", async (t) => {
 
 	const project = getMockProject("module");
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -1154,7 +1154,7 @@ test.serial("_addTask with options", async (t) => {
 	const project = getMockProject("module");
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -1198,7 +1198,7 @@ test("_addTask: Duplicate task", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("module");
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -1219,7 +1219,7 @@ test("_addTask: Task already added to execution order", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const project = getMockProject("module");
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 
@@ -1241,7 +1241,7 @@ test("getRequiredDependencies: Custom Task", async (t) => {
 		{name: "myTask"}
 	];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
 		"Project with custom task >= specVersion 3.0 and no requiredDependenciesCallback " +
@@ -1253,7 +1253,7 @@ test("getRequiredDependencies: Default application", async (t) => {
 	const project = getMockProject("application");
 	project.getBundles = () => [];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
 		"Default application project does not require dependencies");
@@ -1264,7 +1264,7 @@ test("getRequiredDependencies: Default library", async (t) => {
 	const project = getMockProject("library");
 	project.getBundles = () => [];
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set(["dep.a", "dep.b"]),
 		"Default library project requires dependencies");
@@ -1275,7 +1275,7 @@ test("getRequiredDependencies: Default theme-library", async (t) => {
 	const project = getMockProject("theme-library");
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set(["dep.a", "dep.b"]),
 		"Default theme-library project requires dependencies");
@@ -1286,7 +1286,7 @@ test("getRequiredDependencies: Default module", async (t) => {
 	const project = getMockProject("module");
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	t.deepEqual(await taskRunner.getRequiredDependencies(), new Set([]),
 		"Default module project does not require dependencies");
@@ -1297,7 +1297,7 @@ test("_createDependenciesReader", async (t) => {
 	const project = getMockProject("module");
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 	graph.traverseBreadthFirst.reset(); // Ignore the call in initTask
@@ -1358,7 +1358,7 @@ test("_createDependenciesReader: All dependencies required", async (t) => {
 	const project = getMockProject("module");
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 	const res = await taskRunner._createDependenciesReader(new Set(["dep.a", "dep.b"]));
@@ -1372,7 +1372,7 @@ test("_createDependenciesReader: No dependencies required", async (t) => {
 	const project = getMockProject("module");
 
 	const taskRunner = new TaskRunner({
-		project, graph, taskUtil, taskRepository, parentLogger, buildConfig
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 	const res = await taskRunner._createDependenciesReader(new Set());

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -112,8 +112,10 @@ test("getBuildOption", (t) => {
 test("createProjectContext", async (t) => {
 	const buildContext = new BuildContext("graph", "taskRepository");
 	const projectBuildContext = await buildContext.createProjectContext({
-		project: "project",
-		log: "log"
+		project: {
+			getName: () => "project",
+			getType: () => "type",
+		},
 	});
 
 	t.deepEqual(buildContext._projectBuildContexts, [projectBuildContext],

--- a/test/lib/build/helpers/ProjectBuildContext.js
+++ b/test/lib/build/helpers/ProjectBuildContext.js
@@ -17,8 +17,10 @@ import ProjectBuildContext from "../../../../lib/build/helpers/ProjectBuildConte
 test("Missing parameters", (t) => {
 	t.throws(() => {
 		new ProjectBuildContext({
-			project: "project",
-			log: "log",
+			project: {
+				getName: () => "project",
+				getType: () => "type",
+			},
 		});
 	}, {
 		message: `Missing parameter 'buildContext'`
@@ -27,29 +29,22 @@ test("Missing parameters", (t) => {
 	t.throws(() => {
 		new ProjectBuildContext({
 			buildContext: "buildContext",
-			log: "log",
 		});
 	}, {
 		message: `Missing parameter 'project'`
 	}, "Correct error message");
-
-	t.throws(() => {
-		new ProjectBuildContext({
-			buildContext: "buildContext",
-			project: "project",
-		});
-	}, {
-		message: `Missing parameter 'log'`
-	}, "Correct error message");
 });
 
 test("isRootProject: true", (t) => {
+	const rootProject = {
+		getName: () => "root project",
+		getType: () => "type",
+	};
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {
-			getRootProject: () => "root project"
+			getRootProject: () => rootProject
 		},
-		project: "root project",
-		log: "log"
+		project: rootProject
 	});
 
 	t.true(projectBuildContext.isRootProject(), "Correctly identified root project");
@@ -60,8 +55,10 @@ test("isRootProject: false", (t) => {
 		buildContext: {
 			getRootProject: () => "root project"
 		},
-		project: "not the root project",
-		log: "log"
+		project: {
+			getName: () => "not the root project",
+			getType: () => "type",
+		}
 	});
 
 	t.false(projectBuildContext.isRootProject(), "Correctly identified non-root project");
@@ -73,8 +70,10 @@ test("getBuildOption", (t) => {
 		buildContext: {
 			getOption: getOptionStub
 		},
-		project: "project",
-		log: "log"
+		project: {
+			getName: () => "project",
+			getType: () => "type",
+		}
 	});
 
 	t.is(projectBuildContext.getOption("option"), "pony", "Returned value is correct");
@@ -84,8 +83,10 @@ test("getBuildOption", (t) => {
 test("registerCleanupTask", (t) => {
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {},
-		project: "project",
-		log: "log"
+		project: {
+			getName: () => "project",
+			getType: () => "type",
+		}
 	});
 	projectBuildContext.registerCleanupTask("my task 1");
 	projectBuildContext.registerCleanupTask("my task 2");
@@ -97,8 +98,10 @@ test("registerCleanupTask", (t) => {
 test("executeCleanupTasks", (t) => {
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {},
-		project: "project",
-		log: "log"
+		project: {
+			getName: () => "project",
+			getType: () => "type",
+		}
 	});
 	const task1 = sinon.stub().resolves();
 	const task2 = sinon.stub().resolves();
@@ -141,8 +144,10 @@ test.serial("getResourceTagCollection", async (t) => {
 	});
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {},
-		project: "project",
-		log: "log"
+		project: {
+			getName: () => "project",
+			getType: () => "type",
+		}
 	});
 
 	const fakeProjectCollection = {
@@ -173,7 +178,8 @@ test.serial("getResourceTagCollection", async (t) => {
 
 test("getResourceTagCollection: Assigns project to resource if necessary", (t) => {
 	const fakeProject = {
-		getName: () => "project"
+		getName: () => "project",
+		getType: () => "type",
 	};
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {},
@@ -204,7 +210,10 @@ test("getResourceTagCollection: Assigns project to resource if necessary", (t) =
 });
 
 test("getProject", (t) => {
-	const project = "project";
+	const project = {
+		getName: () => "project",
+		getType: () => "type",
+	};
 	const getProjectStub = sinon.stub().returns("pony");
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {
@@ -214,20 +223,22 @@ test("getProject", (t) => {
 				};
 			}
 		},
-		project,
-		log: "log"
+		project
 	});
 
 	t.is(projectBuildContext.getProject("pony project"), "pony", "Returned correct value");
-	t.is(getProjectStub.callCount, 1, "getProject got called once");
-	t.is(getProjectStub.getCall(0).args[0], "pony project", "getProject got called with correct argument");
+	t.is(getProjectStub.callCount, 1, "ProjectGraph#getProject got called once");
+	t.is(getProjectStub.getCall(0).args[0], "pony project", "ProjectGraph#getProject got called with correct argument");
 
 	t.is(projectBuildContext.getProject(), project);
-	t.is(getProjectStub.callCount, 1, "getProject is not called again when requesting current project");
+	t.is(getProjectStub.callCount, 1, "ProjectGraph#getProject is not called when requesting current project");
 });
 
 test("getProject: No name provided", (t) => {
-	const project = "project";
+	const project = {
+		getName: () => "project",
+		getType: () => "type",
+	};
 	const getProjectStub = sinon.stub().returns("pony");
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {
@@ -237,16 +248,18 @@ test("getProject: No name provided", (t) => {
 				};
 			}
 		},
-		project,
-		log: "log"
+		project
 	});
 
-	t.is(projectBuildContext.getProject(), "project", "Returned correct value");
-	t.is(getProjectStub.callCount, 0, "getProject has not been called");
+	t.is(projectBuildContext.getProject(), project, "Returned correct value");
+	t.is(getProjectStub.callCount, 0, "ProjectGraph#getProject has not been called");
 });
 
 test("getDependencies", (t) => {
-	const project = "project";
+	const project = {
+		getName: () => "project",
+		getType: () => "type",
+	};
 	const getDependenciesStub = sinon.stub().returns(["dep a", "dep b"]);
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {
@@ -256,17 +269,20 @@ test("getDependencies", (t) => {
 				};
 			}
 		},
-		project,
-		log: "log"
+		project
 	});
 
 	t.deepEqual(projectBuildContext.getDependencies("pony project"), ["dep a", "dep b"], "Returned correct value");
-	t.is(getDependenciesStub.callCount, 1, "getDependencies got called once");
-	t.is(getDependenciesStub.getCall(0).args[0], "pony project", "getProject got called with correct arguments");
+	t.is(getDependenciesStub.callCount, 1, "ProjectGraph#getDependencies got called once");
+	t.is(getDependenciesStub.getCall(0).args[0], "pony project",
+		"ProjectGraph#getDependencies got called with correct arguments");
 });
 
 test("getDependencies: No name provided", (t) => {
-	const project = {getName: () => "project"};
+	const project = {
+		getName: () => "project",
+		getType: () => "type",
+	};
 	const getDependenciesStub = sinon.stub().returns(["dep a", "dep b"]);
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {
@@ -276,20 +292,22 @@ test("getDependencies: No name provided", (t) => {
 				};
 			}
 		},
-		project,
-		log: "log"
+		project
 	});
 
 	t.deepEqual(projectBuildContext.getDependencies(), ["dep a", "dep b"], "Returned correct value");
-	t.is(getDependenciesStub.callCount, 1, "getDependencies got called once");
-	t.is(getDependenciesStub.getCall(0).args[0], "project", "getProject got called with correct arguments");
+	t.is(getDependenciesStub.callCount, 1, "ProjectGraph#getDependencies got called once");
+	t.is(getDependenciesStub.getCall(0).args[0], "project",
+		"ProjectGraph#getDependencies got called with correct arguments");
 });
 
 test("getTaskUtil", (t) => {
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {},
-		project: "project",
-		log: "log"
+		project: {
+			getName: () => "project",
+			getType: () => "type",
+		}
 	});
 
 	t.truthy(projectBuildContext.getTaskUtil(), "Returned a TaskUtil instance");
@@ -298,12 +316,16 @@ test("getTaskUtil", (t) => {
 
 test.serial("getTaskRunner", async (t) => {
 	t.plan(2);
+	const project = {
+		getName: () => "project",
+		getType: () => "type",
+	};
 	class DummyTaskRunner {
 		constructor(params) {
 			t.deepEqual(params, {
 				graph: "graph",
-				project: "project",
-				parentLogger: "log",
+				project: project,
+				log: "log",
 				taskUtil: "taskUtil",
 				taskRepository: "taskRepository",
 				buildConfig: "buildConfig"
@@ -311,7 +333,10 @@ test.serial("getTaskRunner", async (t) => {
 		}
 	}
 	const ProjectBuildContext = await esmock("../../../../lib/build/helpers/ProjectBuildContext.js", {
-		"../../../../lib/build/TaskRunner.js": DummyTaskRunner
+		"../../../../lib/build/TaskRunner.js": DummyTaskRunner,
+		"@ui5/logger": {
+			getLogger: sinon.stub().withArgs("type project").returns("log")
+		}
 	});
 
 	const projectBuildContext = new ProjectBuildContext({
@@ -320,8 +345,7 @@ test.serial("getTaskRunner", async (t) => {
 			getTaskRepository: () => "taskRepository",
 			getBuildConfig: () => "buildConfig",
 		},
-		project: "project",
-		log: "log"
+		project
 	});
 
 	projectBuildContext.getTaskUtil = () => "taskUtil";
@@ -332,17 +356,17 @@ test.serial("getTaskRunner", async (t) => {
 
 
 test.serial("createProjectContext", async (t) => {
-	t.plan(5);
+	t.plan(4);
 
 	const project = {
-		getType: sinon.stub().returns("foo")
+		getName: sinon.stub().returns("foo"),
+		getType: sinon.stub().returns("bar"),
 	};
 	const taskRunner = {"task": "runner"};
 	class DummyProjectContext {
-		constructor({buildContext, project, log}) {
+		constructor({buildContext, project}) {
 			t.is(buildContext, testBuildContext, "Correct buildContext parameter");
 			t.is(project, project, "Correct project parameter");
-			t.is(log, "log", "Correct log parameter");
 		}
 		getTaskUtil() {
 			return "taskUtil";
@@ -360,8 +384,7 @@ test.serial("createProjectContext", async (t) => {
 	const testBuildContext = new BuildContext("graph", "taskRepository");
 
 	const projectContext = await testBuildContext.createProjectContext({
-		project,
-		log: "log"
+		project
 	});
 
 	t.true(projectContext instanceof DummyProjectContext,
@@ -371,40 +394,49 @@ test.serial("createProjectContext", async (t) => {
 });
 
 test("requiresBuild: has no build-manifest", (t) => {
-	const project = {getBuildManifest: () => null};
+	const project = {
+		getName: sinon.stub().returns("foo"),
+		getType: sinon.stub().returns("bar"),
+		getBuildManifest: () => null
+	};
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {},
-		project,
-		log: "log"
+		project
 	});
 	t.true(projectBuildContext.requiresBuild(), "Project without build-manifest requires to be build");
 });
 
 test("requiresBuild: has build-manifest", (t) => {
-	const project = {getBuildManifest: () => {
-		return {
-			timestamp: "2022-07-28T12:00:00.000Z"
-		};
-	}};
+	const project = {
+		getName: sinon.stub().returns("foo"),
+		getType: sinon.stub().returns("bar"),
+		getBuildManifest: () => {
+			return {
+				timestamp: "2022-07-28T12:00:00.000Z"
+			};
+		}
+	};
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {},
-		project,
-		log: "log"
+		project
 	});
 	t.false(projectBuildContext.requiresBuild(), "Project with build-manifest does not require to be build");
 });
 
 test.serial("getBuildMetadata", (t) => {
-	const project = {getBuildManifest: () => {
-		return {
-			timestamp: "2022-07-28T12:00:00.000Z"
-		};
-	}};
+	const project = {
+		getName: sinon.stub().returns("foo"),
+		getType: sinon.stub().returns("bar"),
+		getBuildManifest: () => {
+			return {
+				timestamp: "2022-07-28T12:00:00.000Z"
+			};
+		}
+	};
 	const getTimeStub = sinon.stub(Date.prototype, "getTime").callThrough().onFirstCall().returns(1659016800000);
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {},
-		project,
-		log: "log"
+		project
 	});
 
 	t.deepEqual(projectBuildContext.getBuildMetadata(), {
@@ -415,11 +447,14 @@ test.serial("getBuildMetadata", (t) => {
 });
 
 test("getBuildMetadata: has no build-manifest", (t) => {
-	const project = {getBuildManifest: () => null};
+	const project = {
+		getName: sinon.stub().returns("foo"),
+		getType: sinon.stub().returns("bar"),
+		getBuildManifest: () => null
+	};
 	const projectBuildContext = new ProjectBuildContext({
 		buildContext: {},
-		project,
-		log: "log"
+		project
 	});
 	t.is(projectBuildContext.getBuildMetadata(), null, "Project has no build manifest");
 });


### PR DESCRIPTION
* Use template literals instead of placeholders.
* Replace GroupLogger with standard Logger instance in ProjectBuilder
* Pass standard Logger instead of GroupLogger to custom tasks

This is in prepration for @ui5/logger changes as per
https://github.com/SAP/ui5-logger/pull/353