### PR TITLE
[BREAKING] Run 'generateThemeDesignerResources' only on framework libs

### DIFF
--- a/lib/build/definitions/library.js
+++ b/lib/build/definitions/library.js
@@ -146,12 +146,14 @@ export default function({project, taskUtil, getTask}) {
 		}
 	});
 
-	tasks.set("generateThemeDesignerResources", {
-		requiresDependencies: true,
-		options: {
-			version: project.getVersion()
-		}
-	});
+	if (project.isFrameworkProject()) {
+		tasks.set("generateThemeDesignerResources", {
+			requiresDependencies: true,
+			options: {
+				version: project.getVersion()
+			}
+		});
+	}
 
 	tasks.set("generateResourcesJson", {
 		requiresDependencies: true

--- a/lib/build/definitions/themeLibrary.js
+++ b/lib/build/definitions/themeLibrary.js
@@ -35,12 +35,14 @@ export default function({project, taskUtil, getTask}) {
 		}
 	});
 
-	tasks.set("generateThemeDesignerResources", {
-		requiresDependencies: true,
-		options: {
-			version: project.getVersion()
-		}
-	});
+	if (project.isFrameworkProject()) {
+		tasks.set("generateThemeDesignerResources", {
+			requiresDependencies: true,
+			options: {
+				version: project.getVersion()
+			}
+		});
+	}
 
 	tasks.set("generateResourcesJson", {requiresDependencies: true});
 	return tasks;

--- a/test/lib/build/TaskRunner.js
+++ b/test/lib/build/TaskRunner.js
@@ -58,7 +58,8 @@ function getMockProject(type) {
 		getCachebusterSignatureType: noop,
 		getCustomTasks: () => [],
 		hasBuildManifest: () => false,
-		getWorkspace: () => "workspace"
+		getWorkspace: () => "workspace",
+		isFrameworkProject: () => false
 	};
 }
 
@@ -237,6 +238,34 @@ test("_initTasks: Project of type 'library'", async (t) => {
 		"generateLibraryPreload",
 		"generateBundle",
 		"buildThemes",
+		"generateResourcesJson"
+	], "Correct standard tasks");
+});
+
+test("_initTasks: Project of type 'library' (framework project)", async (t) => {
+	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
+
+	const project = getMockProject("library");
+	project.isFrameworkProject = () => true;
+
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, log, buildConfig
+	});
+	await taskRunner._initTasks();
+
+	t.deepEqual(taskRunner._taskExecutionOrder, [
+		"escapeNonAsciiCharacters",
+		"replaceCopyright",
+		"replaceVersion",
+		"replaceBuildtime",
+		"generateJsdoc",
+		"executeJsdocSdkTransformation",
+		"minify",
+		"generateLibraryManifest",
+		"generateComponentPreload",
+		"generateLibraryPreload",
+		"generateBundle",
+		"buildThemes",
 		"generateThemeDesignerResources",
 		"generateResourcesJson"
 	], "Correct standard tasks");
@@ -246,6 +275,25 @@ test("_initTasks: Project of type 'theme-library'", async (t) => {
 	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
 	const taskRunner = new TaskRunner({
 		project: getMockProject("theme-library"), graph, taskUtil, taskRepository, log, buildConfig
+	});
+	await taskRunner._initTasks();
+
+	t.deepEqual(taskRunner._taskExecutionOrder, [
+		"replaceCopyright",
+		"replaceVersion",
+		"buildThemes",
+		"generateResourcesJson"
+	], "Correct standard tasks");
+});
+
+test("_initTasks: Project of type 'theme-library' (framework project)", async (t) => {
+	const {graph, taskUtil, taskRepository, TaskRunner} = t.context;
+
+	const project = getMockProject("theme-library");
+	project.isFrameworkProject = () => true;
+
+	const taskRunner = new TaskRunner({
+		project, graph, taskUtil, taskRepository, log, buildConfig
 	});
 	await taskRunner._initTasks();
 

--- a/test/lib/build/definitions/library.js
+++ b/test/lib/build/definitions/library.js
@@ -29,6 +29,7 @@ function getMockProject() {
 		getCachebusterSignatureType: () => "PONY",
 		getJsdocExcludes: () => [],
 		getCustomTasks: emptyarray,
+		isFrameworkProject: () => false
 	};
 }
 
@@ -113,11 +114,6 @@ test("Standard build", async (t) => {
 				cssVariables: undefined
 			}
 		},
-		generateThemeDesignerResources: {
-			requiresDependencies: true, options: {
-				version: "version"
-			}
-		},
 		generateResourcesJson: {
 			requiresDependencies: true
 		}
@@ -152,6 +148,27 @@ test("Standard build", async (t) => {
 	t.is(taskUtil.getBuildOption.callCount, 1, "taskUtil#getBuildOption got called once");
 	t.is(taskUtil.getBuildOption.getCall(0).args[0], "cssVariables",
 		"taskUtil#getBuildOption got called with correct argument");
+});
+
+test("Standard build (framework project)", (t) => {
+	const {project, taskUtil, getTask} = t.context;
+
+	project.isFrameworkProject = () => true;
+
+	const generateJsdocTaskStub = sinon.stub();
+	getTask.returns({
+		task: generateJsdocTaskStub
+	});
+
+	const tasks = library({
+		project, taskUtil, getTask
+	});
+
+	t.deepEqual(tasks.get("generateThemeDesignerResources"), {
+		requiresDependencies: true, options: {
+			version: "version"
+		}
+	});
 });
 
 test("Standard build with legacy spec version", (t) => {
@@ -222,11 +239,6 @@ test("Standard build with legacy spec version", (t) => {
 				themesPattern: undefined,
 				inputPattern: "/resources/project/b/themes/*/library.source.less",
 				cssVariables: undefined
-			}
-		},
-		generateThemeDesignerResources: {
-			requiresDependencies: true, options: {
-				version: "version"
 			}
 		},
 		generateResourcesJson: {
@@ -347,11 +359,6 @@ test("Custom bundles", async (t) => {
 				themesPattern: undefined,
 				inputPattern: "/resources/project/b/themes/*/library.source.less",
 				cssVariables: undefined
-			}
-		},
-		generateThemeDesignerResources: {
-			requiresDependencies: true, options: {
-				version: "version"
 			}
 		},
 		generateResourcesJson: {

--- a/test/lib/build/definitions/themeLibrary.js
+++ b/test/lib/build/definitions/themeLibrary.js
@@ -26,6 +26,7 @@ function getMockProject() {
 		getBundles: emptyarray,
 		getCachebusterSignatureType: () => "PONY",
 		getCustomTasks: emptyarray,
+		isFrameworkProject: () => false
 	};
 }
 
@@ -69,12 +70,6 @@ test("Standard build", (t) => {
 				cssVariables: undefined
 			}
 		},
-		generateThemeDesignerResources: {
-			requiresDependencies: true,
-			options: {
-				version: "version"
-			}
-		},
 		generateResourcesJson: {
 			requiresDependencies: true
 		}
@@ -83,6 +78,22 @@ test("Standard build", (t) => {
 	t.is(taskUtil.getBuildOption.callCount, 1, "taskUtil#getBuildOption got called once");
 	t.is(taskUtil.getBuildOption.getCall(0).args[0], "cssVariables",
 		"taskUtil#getBuildOption got called with correct argument");
+});
+
+test("Standard build (framework project)", (t) => {
+	const {project, taskUtil, getTask} = t.context;
+
+	project.isFrameworkProject = () => true;
+
+	const tasks = themeLibrary({
+		project, taskUtil, getTask
+	});
+
+	t.deepEqual(tasks.get("generateThemeDesignerResources"), {
+		requiresDependencies: true, options: {
+			version: "version"
+		}
+	});
 });
 
 test("Standard build for non root project", (t) => {
@@ -113,12 +124,6 @@ test("Standard build for non root project", (t) => {
 				themesPattern: "/resources/sap/ui/core/themes/*",
 				inputPattern: "/resources/**/themes/*/library.source.less",
 				cssVariables: undefined
-			}
-		},
-		generateThemeDesignerResources: {
-			requiresDependencies: true,
-			options: {
-				version: "version"
 			}
 		},
 		generateResourcesJson: {


### PR DESCRIPTION
The generateThemeDesignerResources task is currently only relevant for
framework libraries as those libraries are supported by SAP Theme Designer.

Other libraries are not expected to require the task, so it is skipped.
