### PR TITLE
[INTERNAL] specification/Project: Make getSourcePath method public

### DIFF
--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -191,6 +191,7 @@ class TaskUtil {
 	 * @property {Function} getNamespace Get the project namespace
 	 * @property {Function} getRootReader Get the project rootReader
 	 * @property {Function} getReader Get the project reader
+	 * @property {Function} getSourcePath Get the local File System path of the project's source directory
 	 * @property {Function} getCustomConfiguration Get the project Custom Configuration
 	 * @property {Function} isFrameworkProject Check whether the project is a UI5-Framework project
 	 */
@@ -309,7 +310,8 @@ class TaskUtil {
 				const baseProjectInterface = {};
 				bindFunctions(project, baseProjectInterface, [
 					"getType", "getName", "getVersion", "getNamespace",
-					"getRootReader", "getReader", "getCustomConfiguration", "isFrameworkProject"
+					"getRootReader", "getReader", "getSourcePath",
+					"getCustomConfiguration", "isFrameworkProject"
 				]);
 				return baseProjectInterface;
 			};

--- a/lib/specifications/Project.js
+++ b/lib/specifications/Project.js
@@ -78,7 +78,7 @@ class Project extends Specification {
 	 * Get the path of the project's source directory. This might not be POSIX-style on some platforms.
 	 * Projects with multiple source paths will throw an error. For example Modules.
 	 *
-	 * @private
+	 * @public
 	 * @returns {string} Absolute path to the source directory of the project
 	 * @throws {Error} In case a project has multiple source directories
 	 */

--- a/lib/specifications/types/Application.js
+++ b/lib/specifications/types/Application.js
@@ -38,7 +38,7 @@ class Application extends ComponentProject {
 	/**
 	 * Get the path of the project's source directory. This might not be POSIX-style on some platforms.
 	 *
-	 * @private
+	 * @public
 	 * @returns {string} Absolute path to the source directory of the project
 	 */
 	getSourcePath() {

--- a/lib/specifications/types/Library.js
+++ b/lib/specifications/types/Library.js
@@ -49,7 +49,7 @@ class Library extends ComponentProject {
 	/**
 	 * Get the path of the project's source directory. This might not be POSIX-style on some platforms.
 	 *
-	 * @private
+	 * @public
 	 * @returns {string} Absolute path to the source directory of the project
 	 */
 	getSourcePath() {

--- a/lib/specifications/types/Module.js
+++ b/lib/specifications/types/Module.js
@@ -24,7 +24,7 @@ class Module extends Project {
 	/**
 	 * Since Modules have multiple source paths, this function always throws with an exception
 	 *
-	 * @private
+	 * @public
 	 * @throws {Error} Projects of type module have more than one source path
 	 */
 	getSourcePath() {

--- a/lib/specifications/types/ThemeLibrary.js
+++ b/lib/specifications/types/ThemeLibrary.js
@@ -32,7 +32,7 @@ class ThemeLibrary extends Project {
 	/**
 	 * Get the path of the project's source directory
 	 *
-	 * @private
+	 * @public
 	 * @returns {string} Absolute path to the source directory of the project
 	 */
 	getSourcePath() {

--- a/test/lib/build/helpers/TaskUtil.js
+++ b/test/lib/build/helpers/TaskUtil.js
@@ -411,6 +411,7 @@ test("getInterface: specVersion 3.0", (t) => {
 		getNamespace: () => "namespace",
 		getRootReader: () => "rootReader",
 		getReader: () => "reader",
+		getSourcePath: () => "sourcePath",
 		getCustomConfiguration: () => "customConfiguration",
 		isFrameworkProject: () => "isFrameworkProject",
 		hasBuildManifest: () => "hasBuildManifest", // Should not be exposed
@@ -456,6 +457,7 @@ test("getInterface: specVersion 3.0", (t) => {
 		"getNamespace",
 		"getRootReader",
 		"getReader",
+		"getSourcePath",
 		"getCustomConfiguration",
 		"isFrameworkProject",
 	], "Correct methods are provided");
@@ -465,6 +467,7 @@ test("getInterface: specVersion 3.0", (t) => {
 	t.is(interfacedProject.getVersion(), "version", "getVersion function is bound correctly");
 	t.is(interfacedProject.getNamespace(), "namespace", "getNamespace function is bound correctly");
 	t.is(interfacedProject.getRootReader(), "rootReader", "getRootReader function is bound correctly");
+	t.is(interfacedProject.getSourcePath(), "sourcePath", "getSourcePath function is bound correctly");
 	t.is(interfacedProject.getReader(), "reader", "getReader function is bound correctly");
 	t.is(interfacedProject.getCustomConfiguration(), "customConfiguration",
 		"getCustomConfiguration function is bound correctly");


### PR DESCRIPTION
The method will also be provided through TaskUtil and MiddlewareUtil.

This should help use cases like in the ui5-middleware-fe-mockserver:
https://github.com/SAP/open-ux-odata/blob/main/packages/ui5-middleware-fe-mockserver/src/index.ts#L10