### PR TITLE
[FIX] Registry: Do not use custom logger for pacote

### DIFF
--- a/lib/ui5Framework/npm/Registry.js
+++ b/lib/ui5Framework/npm/Registry.js
@@ -41,9 +41,6 @@ class Registry {
 			const opts = {
 				cache: this._cacheDir
 			};
-			if (log.isLevelEnabled("verbose")) {
-				opts.log = log._getLogger();
-			}
 			const config = libnpmconfig.read(opts, {
 				cwd: this._cwd
 			}).toJSON();


### PR DESCRIPTION
@ui5/logger used to be based on 'npmlog', which allowed us to pass the
same instance to pacote. Since this is no longer the case, remove the
respective code.