### PR TITLE
[INTERNAL] Schema: Allow metadata.name to be up to 80 characters long

### DIFF
--- a/lib/validation/schema/specVersion/kind/extension.json
+++ b/lib/validation/schema/specVersion/kind/extension.json
@@ -79,7 +79,7 @@
 				"name": {
 					"type": "string",
 					"minLength": 3,
-					"maxLength": 50,
+					"maxLength": 80,
 					"pattern": "^(?:@[0-9a-z-_.]+\\/)?[a-z][0-9a-z-_.]*$",
 					"title": "Extension Name",
 					"description": "Unique identifier for the extension, for example: ui5-task-fearless-rock",

--- a/lib/validation/schema/specVersion/kind/project.json
+++ b/lib/validation/schema/specVersion/kind/project.json
@@ -101,7 +101,7 @@
 				"name": {
 					"type": "string",
 					"minLength": 3,
-					"maxLength": 50,
+					"maxLength": 80,
 					"pattern": "^(?:@[0-9a-z-_.]+\\/)?[a-z][0-9a-z-_.]*$",
 					"title": "Project Name",
 					"description": "Unique identifier for the project, for example: organization.product.project",

--- a/lib/validation/schema/ui5-workspace.json
+++ b/lib/validation/schema/ui5-workspace.json
@@ -28,7 +28,7 @@
 				"name": {
 					"type": "string",
 					"minLength": 3,
-					"maxLength": 50,
+					"maxLength": 80,
 					"pattern": "^(?:@[0-9a-z-_.]+\\/)?[a-z][0-9a-z-_.]*$",
 					"title": "Workspace Name",
 					"description": "Identifier for the workspace configuration. Workspaces named 'default' will be used automatically by UI5 Tooling",

--- a/test/lib/validation/schema/specVersion/kind/extension.js
+++ b/test/lib/validation/schema/specVersion/kind/extension.js
@@ -159,7 +159,7 @@ test("Legacy: Special characters in name (task)", async (t) => {
 		"kind": "extension",
 		"type": "task",
 		"metadata": {
-			"name": "ä".repeat(51)
+			"name": "ä".repeat(81)
 		},
 		"task": {
 			"path": "task.js"

--- a/test/lib/validation/schema/specVersion/kind/extension/project-shim.js
+++ b/test/lib/validation/schema/specVersion/kind/extension/project-shim.js
@@ -180,7 +180,7 @@ test.after.always((t) => {
 			"kind": "extension",
 			"type": "project-shim",
 			"metadata": {
-				"name": "a".repeat(51)
+				"name": "a".repeat(81)
 			},
 			"shims": {}
 		}, [{
@@ -191,9 +191,9 @@ test.after.always((t) => {
 				errors: [{
 					dataPath: "/metadata/name",
 					keyword: "maxLength",
-					message: "should NOT be longer than 50 characters",
+					message: "should NOT be longer than 80 characters",
 					params: {
-						limit: 50,
+						limit: 80,
 					}
 				}]
 			},

--- a/test/lib/validation/schema/specVersion/kind/extension/server-middleware.js
+++ b/test/lib/validation/schema/specVersion/kind/extension/server-middleware.js
@@ -102,7 +102,7 @@ test.after.always((t) => {
 			"kind": "extension",
 			"type": "server-middleware",
 			"metadata": {
-				"name": "a".repeat(51)
+				"name": "a".repeat(81)
 			},
 			"middleware": {
 				"path": "/bar"
@@ -115,9 +115,9 @@ test.after.always((t) => {
 				errors: [{
 					dataPath: "/metadata/name",
 					keyword: "maxLength",
-					message: "should NOT be longer than 50 characters",
+					message: "should NOT be longer than 80 characters",
 					params: {
-						limit: 50,
+						limit: 80,
 					}
 				}]
 			},

--- a/test/lib/validation/schema/specVersion/kind/extension/task.js
+++ b/test/lib/validation/schema/specVersion/kind/extension/task.js
@@ -102,7 +102,7 @@ test.after.always((t) => {
 			"kind": "extension",
 			"type": "task",
 			"metadata": {
-				"name": "a".repeat(51)
+				"name": "a".repeat(81)
 			},
 			"task": {
 				"path": "/bar"
@@ -115,9 +115,9 @@ test.after.always((t) => {
 				errors: [{
 					dataPath: "/metadata/name",
 					keyword: "maxLength",
-					message: "should NOT be longer than 50 characters",
+					message: "should NOT be longer than 80 characters",
 					params: {
-						limit: 50,
+						limit: 80,
 					}
 				}]
 			},

--- a/test/lib/validation/schema/specVersion/kind/project.js
+++ b/test/lib/validation/schema/specVersion/kind/project.js
@@ -201,7 +201,7 @@ test("Legacy: Special characters in name (application)", async (t) => {
 		"specVersion": "2.0",
 		"type": "application",
 		"metadata": {
-			"name": "/".repeat(51)
+			"name": "/".repeat(81)
 		}
 	});
 });

--- a/test/lib/validation/schema/specVersion/kind/project/application.js
+++ b/test/lib/validation/schema/specVersion/kind/project/application.js
@@ -990,7 +990,7 @@ test.after.always((t) => {
 			"specVersion": specVersion,
 			"type": "application",
 			"metadata": {
-				"name": "a".repeat(51)
+				"name": "a".repeat(81)
 			}
 		}, [{
 			dataPath: "/metadata/name",
@@ -1000,9 +1000,9 @@ test.after.always((t) => {
 				errors: [{
 					dataPath: "/metadata/name",
 					keyword: "maxLength",
-					message: "should NOT be longer than 50 characters",
+					message: "should NOT be longer than 80 characters",
 					params: {
-						limit: 50,
+						limit: 80,
 					},
 				}]
 			},

--- a/test/lib/validation/schema/specVersion/kind/project/library.js
+++ b/test/lib/validation/schema/specVersion/kind/project/library.js
@@ -1163,7 +1163,7 @@ test.after.always((t) => {
 			"specVersion": specVersion,
 			"type": "library",
 			"metadata": {
-				"name": "a".repeat(51)
+				"name": "a".repeat(81)
 			}
 		}, [{
 			dataPath: "/metadata/name",
@@ -1173,9 +1173,9 @@ test.after.always((t) => {
 				errors: [{
 					dataPath: "/metadata/name",
 					keyword: "maxLength",
-					message: "should NOT be longer than 50 characters",
+					message: "should NOT be longer than 80 characters",
 					params: {
-						limit: 50,
+						limit: 80,
 					},
 				}]
 			},

--- a/test/lib/validation/schema/specVersion/kind/project/module.js
+++ b/test/lib/validation/schema/specVersion/kind/project/module.js
@@ -397,7 +397,7 @@ test.after.always((t) => {
 			"specVersion": specVersion,
 			"type": "module",
 			"metadata": {
-				"name": "a".repeat(51)
+				"name": "a".repeat(81)
 			}
 		}, [{
 			dataPath: "/metadata/name",
@@ -407,9 +407,9 @@ test.after.always((t) => {
 				errors: [{
 					dataPath: "/metadata/name",
 					keyword: "maxLength",
-					message: "should NOT be longer than 50 characters",
+					message: "should NOT be longer than 80 characters",
 					params: {
-						limit: 50,
+						limit: 80,
 					},
 				}]
 			},

--- a/test/lib/validation/schema/specVersion/kind/project/theme-library.js
+++ b/test/lib/validation/schema/specVersion/kind/project/theme-library.js
@@ -396,7 +396,7 @@ test.after.always((t) => {
 			"specVersion": specVersion,
 			"type": "theme-library",
 			"metadata": {
-				"name": "a".repeat(51)
+				"name": "a".repeat(81)
 			}
 		}, [{
 			dataPath: "/metadata/name",
@@ -406,9 +406,9 @@ test.after.always((t) => {
 				errors: [{
 					dataPath: "/metadata/name",
 					keyword: "maxLength",
-					message: "should NOT be longer than 50 characters",
+					message: "should NOT be longer than 80 characters",
 					params: {
-						limit: 50,
+						limit: 80,
 					},
 				}]
 			},

--- a/test/lib/validation/schema/ui5-workspace.js
+++ b/test/lib/validation/schema/ui5-workspace.js
@@ -226,7 +226,7 @@ test("Invalid metadata.name: Too long", async (t) => {
 		{
 			specVersion: "workspace/1.0",
 			metadata: {
-				name: "b".repeat(51)
+				name: "b".repeat(81)
 			},
 			dependencyManagement: {
 				resolutions: [
@@ -246,9 +246,9 @@ test("Invalid metadata.name: Too long", async (t) => {
 						{
 							dataPath: "/metadata/name",
 							keyword: "maxLength",
-							message: "should NOT be longer than 50 characters",
+							message: "should NOT be longer than 80 characters",
 							params: {
-								limit: 50,
+								limit: 80,
 							},
 						}
 					],


### PR DESCRIPTION
As discussed, raise the limit since we already encountered projects
using more than 60 characters for their name.