### PR TITLE
[FIX] Project#getReader: Do not apply builder resource excludes for style 'runtime'

### DIFF
--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -361,7 +361,7 @@ class ProjectBuilder {
 		const buildConfig = this._buildContext.getBuildConfig();
 		const reader = project.getReader({
 			// Force buildtime (=namespaced) style when writing with a build manifest
-			style: taskUtil.isRootProject() && buildConfig.createBuildManifest ? "buildtime" : "runtime"
+			style: taskUtil.isRootProject() && buildConfig.createBuildManifest ? "buildtime" : "dist"
 		});
 		const resources = await reader.byGlob("/**/*");
 

--- a/lib/specifications/ComponentProject.js
+++ b/lib/specifications/ComponentProject.js
@@ -92,29 +92,54 @@ class ComponentProject extends Project {
 	/* === Resource Access === */
 
 	/**
-	 * Get a resource reader for accessing the project resources in a given style.
+	 * Get a [ReaderCollection]{@link @ui5/fs/ReaderCollection} for accessing all resources of the
+	 * project in the specified "style":
+	 *
+	 * <ul>
+	 * <li><b>buildtime:</b> Resource paths are always prefixed with <code>/resources/</code>
+	 *  or <code>/test-resources/</code> followed by the project's namespace.
+	 *  Any configured build-excludes are applied</li>
+	 * <li><b>dist:</b> Resource paths always match with what the UI5 runtime expects.
+	 *  This means that paths generally depend on the project type. Applications for example use a "flat"-like
+	 *  structure, while libraries use a "buildtime"-like structure.
+	 *  Any configured build-excludes are applied</li>
+	 * <li><b>runtime:</b> Resource paths always match with what the UI5 runtime expects.
+	 *  This means that paths generally depend on the project type. Applications for example use a "flat"-like
+	 *  structure, while libraries use a "buildtime"-like structure.
+	 *  This style is typically used for serving resources directly. Therefore, build-excludes are not applied
+	 * <li><b>flat:</b> Resource paths are never prefixed and namespaces are omitted if possible. Note that
+	 *  project types like "theme-library", which can have multiple namespaces, can't omit them.
+	 *  Any configured build-excludes are applied</li>
+	 * </ul>
+	 *
 	 * If project resources have been changed through the means of a workspace, those changes
 	 * are reflected in the provided reader too.
 	 *
+	 * Resource readers always use POSIX-style paths.
+	 *
 	 * @public
 	 * @param {object} [options]
-	 * @param {string} [options.style=buildtime] Path style to access resources. Can be "buildtime", "runtime" or "flat"
-	 * 												TODO: describe styles
+	 * @param {string} [options.style=buildtime] Path style to access resources.
+	 *   Can be "buildtime", "dist", "runtime" or "flat"
 	 * @returns {@ui5/fs/ReaderCollection} A reader collection instance
 	 */
 	getReader({style = "buildtime"} = {}) {
 		// TODO: Additional style 'ABAP' using "sap.platform.abap".uri from manifest.json?
 
-		if (style === "runtime" && this._isRuntimeNamespaced) {
-			// If the project's runtime paths contains its namespace too,
-			// "runtime" style paths are identical to "buildtime" style paths
+		// Apply builder excludes to all styles but "runtime"
+		const excludes = style === "runtime" ? [] : this.getBuilderResourcesExcludes();
+
+		if ((style === "runtime" || style === "dist") && this._isRuntimeNamespaced) {
+			// If the project's type requires a namespace at runtime, the
+			// dist- and runtime-style paths are identical to buildtime-style paths
 			style = "buildtime";
 		}
-		let reader = this._getReader();
+		let reader = this._getReader(excludes);
 		switch (style) {
 		case "buildtime":
 			break;
 		case "runtime":
+		case "dist":
 			// Use buildtime reader and link it to /
 			// No test-resources for runtime resource access,
 			// unless runtime is namespaced
@@ -204,9 +229,9 @@ class ComponentProject extends Project {
 		return this._writers;
 	}
 
-	_getReader() {
-		let reader = this._getSourceReader();
-		const testReader = this._getTestReader();
+	_getReader(excludes) {
+		let reader = this._getSourceReader(excludes);
+		const testReader = this._getTestReader(excludes);
 		if (testReader) {
 			reader = resourceFactory.createReaderCollection({
 				name: `Reader collection for project ${this.getName()}`,
@@ -219,19 +244,20 @@ class ComponentProject extends Project {
 	_addWriter(reader, style) {
 		const {namespaceWriter, generalWriter} = this._getWriter();
 
-		if (style === "runtime" && this._isRuntimeNamespaced) {
-			// If the project's runtime requires namespaces, "runtime" paths are identical to "buildtime" paths
+		if ((style === "runtime" || style === "dist") && this._isRuntimeNamespaced) {
+			// If the project's type requires a namespace at runtime, the
+			// dist- and runtime-style paths are identical to buildtime-style paths
 			style = "buildtime";
 		}
 		const readers = [];
 		switch (style) {
-		case "buildtime": {
+		case "buildtime":
 			// Writer already uses buildtime style
 			readers.push(namespaceWriter);
 			readers.push(generalWriter);
 			break;
-		}
-		case "runtime": {
+		case "runtime":
+		case "dist":
 			// Runtime is not namespaced: link namespace to /
 			readers.push(resourceFactory.createFlatReader({
 				reader: namespaceWriter,
@@ -240,8 +266,7 @@ class ComponentProject extends Project {
 			// Add general writer as is
 			readers.push(generalWriter);
 			break;
-		}
-		case "flat": {
+		case "flat":
 			// Rewrite paths from "flat" to "buildtime"
 			readers.push(resourceFactory.createFlatReader({
 				reader: namespaceWriter,
@@ -249,7 +274,6 @@ class ComponentProject extends Project {
 			}));
 			// General writer resources can't be flattened, so they are not available
 			break;
-		}
 		default:
 			throw new Error(`Unknown path mapping style ${style}`);
 		}

--- a/lib/specifications/Project.js
+++ b/lib/specifications/Project.js
@@ -212,18 +212,28 @@ class Project extends Specification {
 	 * project in the specified "style":
 	 *
 	 * <ul>
-	 * <li><b>buildtime</b>: Resource paths are always prefixed with <code>/resources/</code>
-	 *  or <code>/test-resources/</code> followed by the project's namespace</li>
-	 * <li><b>runtime</b>: Access resources the same way the UI5 runtime would do</li>
-	 * <li><b>flat:</b> No prefix, no namespace</li>
+	 * <li><b>buildtime:</b> Resource paths are always prefixed with <code>/resources/</code>
+	 *  or <code>/test-resources/</code> followed by the project's namespace.
+	 *  Any configured build-excludes are applied</li>
+	 * <li><b>dist:</b> Resource paths always match with what the UI5 runtime expects.
+	 *  This means that paths generally depend on the project type. Applications for example use a "flat"-like
+	 *  structure, while libraries use a "buildtime"-like structure.
+	 *  Any configured build-excludes are applied</li>
+	 * <li><b>runtime:</b> Resource paths always match with what the UI5 runtime expects.
+	 *  This means that paths generally depend on the project type. Applications for example use a "flat"-like
+	 *  structure, while libraries use a "buildtime"-like structure.
+	 *  This style is typically used for serving resources directly. Therefore, build-excludes are not applied
+	 * <li><b>flat:</b> Resource paths are never prefixed and namespaces are omitted if possible. Note that
+	 *  project types like "theme-library", which can have multiple namespaces, can't omit them.
+	 *  Any configured build-excludes are applied</li>
 	 * </ul>
 	 *
-	 * Resource readers always use POSIX-style.
+	 * Resource readers always use POSIX-style paths.
 	 *
 	 * @public
 	 * @param {object} [options]
-	 * @param {string} [options.style=buildtime] Path style to access resources. Can be "buildtime", "runtime" or "flat"
-	 *											This parameter might be ignored by some project types
+	 * @param {string} [options.style=buildtime] Path style to access resources.
+	 *   Can be "buildtime", "dist", "runtime" or "flat"
 	 * @returns {@ui5/fs/ReaderCollection} Reader collection allowing access to all resources of the project
 	 */
 	getReader(options) {

--- a/lib/specifications/types/Application.js
+++ b/lib/specifications/types/Application.js
@@ -49,15 +49,16 @@ class Application extends ComponentProject {
 	/**
 	* Get a resource reader for the sources of the project (excluding any test resources)
 	*
+	* @param {string[]} excludes List of glob patterns to exclude
 	* @returns {@ui5/fs/ReaderCollection} Reader collection
 	*/
-	_getSourceReader() {
+	_getSourceReader(excludes) {
 		return createReader({
 			fsBasePath: this.getSourcePath(),
 			virBasePath: `/resources/${this._namespace}/`,
 			name: `Source reader for application project ${this.getName()}`,
 			project: this,
-			excludes: this.getBuilderResourcesExcludes()
+			excludes
 		});
 	}
 

--- a/lib/specifications/types/Library.js
+++ b/lib/specifications/types/Library.js
@@ -57,7 +57,13 @@ class Library extends ComponentProject {
 	}
 
 	/* === Resource Access === */
-	_getSourceReader() {
+	/**
+	* Get a resource reader for the sources of the project (excluding any test resources)
+	*
+	* @param {string[]} excludes List of glob patterns to exclude
+	* @returns {@ui5/fs/ReaderCollection} Reader collection
+	*/
+	_getSourceReader(excludes) {
 		// TODO: Throw for libraries with additional namespaces like sap.ui.core?
 		let virBasePath = "/resources/";
 		if (!this._isSourceNamespaced) {
@@ -70,11 +76,17 @@ class Library extends ComponentProject {
 			virBasePath,
 			name: `Source reader for library project ${this.getName()}`,
 			project: this,
-			excludes: this.getBuilderResourcesExcludes()
+			excludes
 		});
 	}
 
-	_getTestReader() {
+	/**
+	* Get a resource reader for the test-resources of the project
+	*
+	* @param {string[]} excludes List of glob patterns to exclude
+	* @returns {@ui5/fs/ReaderCollection} Reader collection
+	*/
+	_getTestReader(excludes) {
 		if (!this._testPathExists) {
 			return null;
 		}
@@ -89,7 +101,7 @@ class Library extends ComponentProject {
 			virBasePath,
 			name: `Runtime test-resources reader for library project ${this.getName()}`,
 			project: this,
-			excludes: this.getBuilderResourcesExcludes()
+			excludes
 		});
 		return testReader;
 	}

--- a/lib/specifications/types/Module.js
+++ b/lib/specifications/types/Module.js
@@ -32,14 +32,52 @@ class Module extends Project {
 	}
 
 	/* === Resource Access === */
+
 	/**
-	* Get a resource reader for accessing the project resources
-	*
-	* @public
-	* @returns {@ui5/fs/ReaderCollection} Reader collection
-	*/
-	getReader() {
-		const readers = this._paths.map((readerArgs) => resourceFactory.createReader(readerArgs));
+	 * Get a [ReaderCollection]{@link @ui5/fs/ReaderCollection} for accessing all resources of the
+	 * project in the specified "style":
+	 *
+	 * <ul>
+	 * <li><b>buildtime:</b> Resource paths are always prefixed with <code>/resources/</code>
+	 *  or <code>/test-resources/</code> followed by the project's namespace.
+	 *  Any configured build-excludes are applied</li>
+	 * <li><b>dist:</b> Resource paths always match with what the UI5 runtime expects.
+	 *  This means that paths generally depend on the project type. Applications for example use a "flat"-like
+	 *  structure, while libraries use a "buildtime"-like structure.
+	 *  Any configured build-excludes are applied</li>
+	 * <li><b>runtime:</b> Resource paths always match with what the UI5 runtime expects.
+	 *  This means that paths generally depend on the project type. Applications for example use a "flat"-like
+	 *  structure, while libraries use a "buildtime"-like structure.
+	 *  This style is typically used for serving resources directly. Therefore, build-excludes are not applied
+	 * <li><b>flat:</b> Resource paths are never prefixed and namespaces are omitted if possible. Note that
+	 *  project types like "theme-library", which can have multiple namespaces, can't omit them.
+	 *  Any configured build-excludes are applied</li>
+	 * </ul>
+	 *
+	 * If project resources have been changed through the means of a workspace, those changes
+	 * are reflected in the provided reader too.
+	 *
+	 * Resource readers always use POSIX-style paths.
+	 *
+	 * @public
+	 * @param {object} [options]
+	 * @param {string} [options.style=buildtime] Path style to access resources.
+	 *   Can be "buildtime", "dist", "runtime" or "flat"
+	 * @returns {@ui5/fs/ReaderCollection} A reader collection instance
+	 */
+	getReader({style = "buildtime"} = {}) {
+		// Apply builder excludes to all styles but "runtime"
+		const excludes = style === "runtime" ? [] : this.getBuilderResourcesExcludes();
+
+		const readers = this._paths.map(({name, virBasePath, fsBasePath}) => {
+			return resourceFactory.createReader({
+				name,
+				virBasePath,
+				fsBasePath,
+				project: this,
+				excludes
+			});
+		});
 		if (readers.length === 1) {
 			return readers[0];
 		}
@@ -107,9 +145,7 @@ class Module extends Project {
 				return {
 					name: `'${relFsPath}'' reader for module project ${this.getName()}`,
 					virBasePath,
-					fsBasePath: fsPath.join(this.getRootPath(), relFsPath),
-					project: this,
-					excludes: config.builder?.resources?.excludes
+					fsBasePath: fsPath.join(this.getRootPath(), relFsPath)
 				};
 			}));
 		} else {
@@ -121,9 +157,7 @@ class Module extends Project {
 			this._paths = [{
 				name: `Root reader for module project ${this.getName()}`,
 				virBasePath: "/",
-				fsBasePath: this.getRootPath(),
-				project: this,
-				excludes: config.builder?.resources?.excludes
+				fsBasePath: this.getRootPath()
 			}];
 		}
 	}

--- a/lib/specifications/types/ThemeLibrary.js
+++ b/lib/specifications/types/ThemeLibrary.js
@@ -42,21 +42,46 @@ class ThemeLibrary extends Project {
 	/* === Resource Access === */
 	/**
 	 * Get a [ReaderCollection]{@link @ui5/fs/ReaderCollection} for accessing all resources of the
-	 * project.
-	 * This is always of style <code>buildtime</code>, wich for theme libraries is identical to style
-	 * <code>runtime</code>.
+	 * project in the specified "style":
+	 *
+	 * <ul>
+	 * <li><b>buildtime:</b> Resource paths are always prefixed with <code>/resources/</code>
+	 *  or <code>/test-resources/</code> followed by the project's namespace.
+	 *  Any configured build-excludes are applied</li>
+	 * <li><b>dist:</b> Resource paths always match with what the UI5 runtime expects.
+	 *  This means that paths generally depend on the project type. Applications for example use a "flat"-like
+	 *  structure, while libraries use a "buildtime"-like structure.
+	 *  Any configured build-excludes are applied</li>
+	 * <li><b>runtime:</b> Resource paths always match with what the UI5 runtime expects.
+	 *  This means that paths generally depend on the project type. Applications for example use a "flat"-like
+	 *  structure, while libraries use a "buildtime"-like structure.
+	 *  This style is typically used for serving resources directly. Therefore, build-excludes are not applied
+	 * <li><b>flat:</b> Resource paths are never prefixed and namespaces are omitted if possible. Note that
+	 *  project types like "theme-library", which can have multiple namespaces, can't omit them.
+	 *  Any configured build-excludes are applied</li>
+	 * </ul>
+	 *
+	 * If project resources have been changed through the means of a workspace, those changes
+	 * are reflected in the provided reader too.
+	 *
+	 * Resource readers always use POSIX-style paths.
 	 *
 	 * @public
-	 * @returns {@ui5/fs/ReaderCollection} Reader collection allowing access to all resources of
-	 *                                                     the project
+	 * @param {object} [options]
+	 * @param {string} [options.style=buildtime] Path style to access resources.
+	 *   Can be "buildtime", "dist", "runtime" or "flat"
+	 * @returns {@ui5/fs/ReaderCollection} A reader collection instance
 	 */
-	getReader() {
+	getReader({style = "buildtime"} = {}) {
+		// Apply builder excludes to all styles but "runtime"
+		const excludes = style === "runtime" ? [] : this.getBuilderResourcesExcludes();
+
 		let reader = resourceFactory.createReader({
 			fsBasePath: this.getSourcePath(),
 			virBasePath: "/resources/",
 			name: `Runtime resources reader for theme-library project ${this.getName()}`,
 			project: this,
-			excludes: this.getBuilderResourcesExcludes()
+			excludes
 		});
 		if (this._testPathExists) {
 			const testReader = resourceFactory.createReader({
@@ -64,7 +89,7 @@ class ThemeLibrary extends Project {
 				virBasePath: "/test-resources/",
 				name: `Runtime test-resources reader for theme-library project ${this.getName()}`,
 				project: this,
-				excludes: this.getBuilderResourcesExcludes()
+				excludes
 			});
 			reader = resourceFactory.createReaderCollection({
 				name: `Reader collection for theme-library project ${this.getName()}`,

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -546,7 +546,7 @@ test("_writeResults", async (t) => {
 
 	t.is(getReaderStub.callCount, 1, "One reader requested");
 	t.deepEqual(getReaderStub.getCall(0).args[0], {
-		style: "runtime"
+		style: "dist"
 	}, "Reader requested expected style");
 
 	t.is(byGlobStub.callCount, 1, "One byGlob call");
@@ -711,7 +711,7 @@ test("_writeResults: Do not create build manifest for non-root project", async (
 
 	t.is(getReaderStub.callCount, 1, "One reader requested");
 	t.deepEqual(getReaderStub.getCall(0).args[0], {
-		style: "runtime"
+		style: "dist"
 	}, "Reader requested expected style");
 
 	t.is(getTagStub.callCount, 1, "TaskUtil#getTag got called once");

--- a/test/lib/specifications/types/Application.js
+++ b/test/lib/specifications/types/Application.js
@@ -2,70 +2,94 @@ import test from "ava";
 import path from "node:path";
 import {fileURLToPath} from "node:url";
 import {createResource} from "@ui5/fs/resourceFactory";
-import sinon from "sinon";
+import sinonGlobal from "sinon";
 import Specification from "../../../../lib/specifications/Specification.js";
 import Application from "../../../../lib/specifications/types/Application.js";
 
-function clone(obj) {
-	return JSON.parse(JSON.stringify(obj));
-}
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 const applicationAPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.a");
-const basicProjectInput = {
-	id: "application.a.id",
-	version: "1.0.0",
-	modulePath: applicationAPath,
-	configuration: {
-		specVersion: "2.3",
-		kind: "project",
-		type: "application",
-		metadata: {name: "application.a"}
-	}
-};
+const applicationHPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.h");
+
+test.beforeEach((t) => {
+	t.context.sinon = sinonGlobal.createSandbox();
+	t.context.projectInput = {
+		id: "application.a.id",
+		version: "1.0.0",
+		modulePath: applicationAPath,
+		configuration: {
+			specVersion: "2.3",
+			kind: "project",
+			type: "application",
+			metadata: {name: "application.a"}
+		}
+	};
+
+	t.context.applicationHInput = {
+		id: "application.h.id",
+		version: "1.0.0",
+		modulePath: applicationHPath,
+		configuration: {
+			specVersion: "2.3",
+			kind: "project",
+			type: "application",
+			metadata: {name: "application.h"},
+			resources: {
+				configuration: {
+					paths: {
+						webapp: "webapp"
+					}
+				}
+			}
+		}
+	};
+});
 
 test.afterEach.always((t) => {
-	sinon.restore();
+	t.context.sinon.restore();
 });
 
 test("Correct class", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	t.true(project instanceof Application, `Is an instance of the Application class`);
 });
 
 test("getNamespace", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	t.is(project.getNamespace(), "id1",
 		"Returned correct namespace");
 });
 
 test("getSourcePath", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	t.is(project.getSourcePath(), path.join(applicationAPath, "webapp"),
 		"Returned correct source path");
 });
 
 test("getCachebusterSignatureType: Default", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	t.is(project.getCachebusterSignatureType(), "time",
 		"Returned correct default cachebuster signature type configuration");
 });
 
 test("getCachebusterSignatureType: Configuration", async (t) => {
-	const customProjectInput = clone(basicProjectInput);
-	customProjectInput.configuration.builder = {
+	const {projectInput} = t.context;
+	projectInput.configuration.builder = {
 		cachebuster: {
 			signatureType: "hash"
 		}
 	};
-	const project = await Specification.create(customProjectInput);
+	const project = await Specification.create(projectInput);
 	t.is(project.getCachebusterSignatureType(), "hash",
 		"Returned correct default cachebuster signature type configuration");
 });
 
 test("Access project resources via reader: buildtime style", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	const reader = project.getReader();
 	const resource = await reader.byPath("/resources/id1/manifest.json");
 	t.truthy(resource, "Found the requested resource");
@@ -73,7 +97,8 @@ test("Access project resources via reader: buildtime style", async (t) => {
 });
 
 test("Access project resources via reader: flat style", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	const reader = project.getReader({style: "flat"});
 	const resource = await reader.byPath("/manifest.json");
 	t.truthy(resource, "Found the requested resource");
@@ -81,15 +106,58 @@ test("Access project resources via reader: flat style", async (t) => {
 });
 
 test("Access project resources via reader: runtime style", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	const reader = project.getReader({style: "runtime"});
 	const resource = await reader.byPath("/manifest.json");
 	t.truthy(resource, "Found the requested resource");
 	t.is(resource.getPath(), "/manifest.json", "Resource has correct path");
 });
 
+test("Access project resources via reader w/ builder excludes", async (t) => {
+	const {projectInput} = t.context;
+	const baselineProject = await Specification.create(projectInput);
+
+	projectInput.configuration.builder = {
+		resources: {
+			excludes: ["**/manifest.json"]
+		}
+	};
+	const excludesProject = await Specification.create(projectInput);
+
+	// We now have two projects: One with excludes and one without
+	// Always compare the results of both to make sure a file is really excluded because of the
+	// configuration and not because of a typo or because of it's absence in the fixture
+
+	t.is((await baselineProject.getReader({}).byGlob("**/manifest.json")).length, 1,
+		"Found resource in baseline project for default style");
+	t.is((await excludesProject.getReader({}).byGlob("**/manifest.json")).length, 0,
+		"Did not find excluded resource for default style");
+
+	t.is((await baselineProject.getReader({style: "buildtime"}).byGlob("**/manifest.json")).length, 1,
+		"Found resource in baseline project for buildtime style");
+	t.is((await excludesProject.getReader({style: "buildtime"}).byGlob("**/manifest.json")).length, 0,
+		"Did not find excluded resource for buildtime style");
+
+	t.is((await baselineProject.getReader({style: "dist"}).byGlob("**/manifest.json")).length, 1,
+		"Found resource in baseline project for dist style");
+	t.is((await excludesProject.getReader({style: "dist"}).byGlob("**/manifest.json")).length, 0,
+		"Did not find excluded resource for dist style");
+
+	t.is((await baselineProject.getReader({style: "flat"}).byGlob("**/manifest.json")).length, 1,
+		"Found resource in baseline project for flat style");
+	t.is((await excludesProject.getReader({style: "flat"}).byGlob("**/manifest.json")).length, 0,
+		"Did not find excluded resource for flat style");
+
+	t.is((await baselineProject.getReader({style: "runtime"}).byGlob("**/manifest.json")).length, 1,
+		"Found resource in baseline project for runtime style");
+	t.is((await excludesProject.getReader({style: "runtime"}).byGlob("**/manifest.json")).length, 1,
+		"Found excluded resource for runtime style");
+});
+
 test("Modify project resources via workspace and access via flat and runtime readers", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	const workspace = project.getWorkspace();
 	const workspaceResource = await workspace.byPath("/resources/id1/index.html");
 	t.truthy(workspaceResource, "Found resource in workspace");
@@ -123,7 +191,8 @@ test("Modify project resources via workspace and access via flat and runtime rea
 
 
 test("Read and write resources outside of app namespace", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	const workspace = project.getWorkspace();
 
 	await workspace.write(createResource({
@@ -161,7 +230,8 @@ test("Read and write resources outside of app namespace", async (t) => {
 });
 
 test("_configureAndValidatePaths: Default paths", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 
 	t.is(project._webappPath, "webapp", "Correct default path");
 });
@@ -193,7 +263,7 @@ test("_configureAndValidatePaths: Custom webapp directory", async (t) => {
 });
 
 test("_configureAndValidatePaths: Webapp directory does not exist", async (t) => {
-	const projectInput = clone(basicProjectInput);
+	const {projectInput} = t.context;
 	projectInput.configuration.resources = {
 		configuration: {
 			paths: {
@@ -207,7 +277,8 @@ test("_configureAndValidatePaths: Webapp directory does not exist", async (t) =>
 });
 
 test("_getNamespaceFromManifestJson: No 'sap.app' configuration found", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 	sinon.stub(project, "_getManifest").resolves({});
 
 	const error = await t.throwsAsync(project._getNamespaceFromManifestJson());
@@ -216,7 +287,8 @@ test("_getNamespaceFromManifestJson: No 'sap.app' configuration found", async (t
 });
 
 test("_getNamespaceFromManifestJson: No application id in 'sap.app' configuration found", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 	sinon.stub(project, "_getManifest").resolves({"sap.app": {}});
 
 	const error = await t.throwsAsync(project._getNamespaceFromManifestJson());
@@ -224,7 +296,8 @@ test("_getNamespaceFromManifestJson: No application id in 'sap.app' configuratio
 });
 
 test("_getNamespaceFromManifestJson: set namespace to id", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 	sinon.stub(project, "_getManifest").resolves({"sap.app": {id: "my.id"}});
 
 	const namespace = await project._getNamespaceFromManifestJson();
@@ -232,7 +305,8 @@ test("_getNamespaceFromManifestJson: set namespace to id", async (t) => {
 });
 
 test("_getNamespaceFromManifestAppDescVariant: No 'id' property found", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 	sinon.stub(project, "_getManifest").resolves({});
 
 	const error = await t.throwsAsync(project._getNamespaceFromManifestAppDescVariant());
@@ -241,7 +315,8 @@ test("_getNamespaceFromManifestAppDescVariant: No 'id' property found", async (t
 });
 
 test("_getNamespaceFromManifestAppDescVariant: set namespace to id", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 	sinon.stub(project, "_getManifest").resolves({id: "my.id"});
 
 	const namespace = await project._getNamespaceFromManifestAppDescVariant();
@@ -249,7 +324,8 @@ test("_getNamespaceFromManifestAppDescVariant: set namespace to id", async (t) =
 });
 
 test("_getNamespace: Correct fallback to manifest.appdescr_variant if manifest.json is missing", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 	const _getManifestStub = sinon.stub(project, "_getManifest")
 		.onFirstCall().rejects({code: "ENOENT"})
 		.onSecondCall().resolves({id: "my.id"});
@@ -263,7 +339,8 @@ test("_getNamespace: Correct fallback to manifest.appdescr_variant if manifest.j
 });
 
 test("_getNamespace: Correct error message if fallback to manifest.appdescr_variant failed", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 	const _getManifestStub = sinon.stub(project, "_getManifest")
 		.onFirstCall().rejects({code: "ENOENT"})
 		.onSecondCall().rejects(new Error("EPON: Pony Error"));
@@ -278,7 +355,8 @@ test("_getNamespace: Correct error message if fallback to manifest.appdescr_vari
 });
 
 test("_getNamespace: Correct error message if fallback to manifest.appdescr_variant is not possible", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 	const _getManifestStub = sinon.stub(project, "_getManifest")
 		.onFirstCall().rejects({message: "No such stable or directory: manifest.json", code: "ENOENT"})
 		.onSecondCall().rejects({code: "ENOENT"}); // both files are missing
@@ -296,7 +374,8 @@ test("_getNamespace: Correct error message if fallback to manifest.appdescr_vari
 });
 
 test("_getNamespace: No fallback if manifest.json is present but failed to parse", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 	const _getManifestStub = sinon.stub(project, "_getManifest")
 		.onFirstCall().rejects(new Error("EPON: Pony Error"));
 
@@ -309,14 +388,16 @@ test("_getNamespace: No fallback if manifest.json is present but failed to parse
 });
 
 test("_getManifest: reads correctly", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 
 	const content = await project._getManifest("/manifest.json");
 	t.is(content._version, "1.1.0", "manifest.json content has been read");
 });
 
 test("_getManifest: invalid JSON", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 
 	const byPathStub = sinon.stub().resolves({
 		getString: async () => "no json"
@@ -336,7 +417,8 @@ test("_getManifest: invalid JSON", async (t) => {
 });
 
 test.serial("_getManifest: File does not exist", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 
 	const error = await t.throwsAsync(project._getManifest("/does-not-exist.json"));
 	t.deepEqual(error.message,
@@ -346,7 +428,8 @@ test.serial("_getManifest: File does not exist", async (t) => {
 });
 
 test.serial("_getManifest: result is cached", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 
 	const byPathStub = sinon.stub().resolves({
 		getString: async () => `{"pony": "no unicorn"}`
@@ -368,7 +451,8 @@ test.serial("_getManifest: result is cached", async (t) => {
 });
 
 test.serial("_getManifest: Caches successes and failures", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput, sinon} = t.context;
+	const project = await Specification.create(projectInput);
 
 	const getStringStub = sinon.stub()
 		.onFirstCall().rejects(new Error("EPON: Pony Error"))
@@ -405,49 +489,29 @@ test.serial("_getManifest: Caches successes and failures", async (t) => {
 		"byPath got called exactly twice (and then cached)");
 });
 
-const applicationHPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.h");
-const applicationH = {
-	id: "application.h.id",
-	version: "1.0.0",
-	modulePath: applicationHPath,
-	configuration: {
-		specVersion: "2.3",
-		kind: "project",
-		type: "application",
-		metadata: {name: "application.h"},
-		resources: {
-			configuration: {
-				paths: {
-					webapp: "webapp"
-				}
-			}
-		}
-	}
-};
-
 test("namespace: detect namespace from pom.xml via ${project.artifactId}", async (t) => {
-	const myProject = clone(applicationH);
-	myProject.configuration.resources.configuration.paths.webapp = "webapp-project.artifactId";
-	const project = await Specification.create(myProject);
+	const {applicationHInput} = t.context;
+	applicationHInput.configuration.resources.configuration.paths.webapp = "webapp-project.artifactId";
+	const project = await Specification.create(applicationHInput);
 
 	t.is(project.getNamespace(), "application/h",
 		"namespace was successfully set since getJson provides the correct object structure");
 });
 
 test("namespace: detect namespace from pom.xml via ${componentName} from properties", async (t) => {
-	const myProject = clone(applicationH);
-	myProject.configuration.resources.configuration.paths.webapp = "webapp-properties.componentName";
-	const project = await Specification.create(myProject);
+	const {applicationHInput} = t.context;
+	applicationHInput.configuration.resources.configuration.paths.webapp = "webapp-properties.componentName";
+	const project = await Specification.create(applicationHInput);
 
 	t.is(project.getNamespace(), "application/h",
 		"namespace was successfully set since getJson provides the correct object structure");
 });
 
 test("namespace: detect namespace from pom.xml via ${appId} from properties", async (t) => {
-	const myProject = clone(applicationH);
-	myProject.configuration.resources.configuration.paths.webapp = "webapp-properties.appId";
+	const {applicationHInput} = t.context;
+	applicationHInput.configuration.resources.configuration.paths.webapp = "webapp-properties.appId";
 
-	const error = await t.throwsAsync(Specification.create(myProject));
+	const error = await t.throwsAsync(Specification.create(applicationHInput));
 	t.deepEqual(error.message, "Failed to resolve namespace of project application.h: \"${appId}\"" +
 		" couldn't be resolved from maven property \"appId\" of pom.xml of project application.h");
 });

--- a/test/lib/specifications/types/Module.js
+++ b/test/lib/specifications/types/Module.js
@@ -1,51 +1,52 @@
 import test from "ava";
 import path from "node:path";
 import {fileURLToPath} from "node:url";
-import sinon from "sinon";
+import sinonGlobal from "sinon";
 import Specification from "../../../../lib/specifications/Specification.js";
 
-function clone(obj) {
-	return JSON.parse(JSON.stringify(obj));
-}
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 const moduleAPath = path.join(__dirname, "..", "..", "..", "fixtures", "module.a");
-const basicProjectInput = {
-	id: "module.a.id",
-	version: "1.0.0",
-	modulePath: moduleAPath,
-	configuration: {
-		specVersion: "2.3",
-		kind: "project",
-		type: "module",
-		metadata: {
-			name: "module.a",
-			copyright: "Some fancy copyright" // allowed but ignored
-		},
-		resources: {
-			configuration: {
-				paths: {
-					"/": "dist",
-					"/dev/": "dev"
+
+test.beforeEach((t) => {
+	t.context.sinon = sinonGlobal.createSandbox();
+	t.context.projectInput = {
+		id: "module.a.id",
+		version: "1.0.0",
+		modulePath: moduleAPath,
+		configuration: {
+			specVersion: "2.3",
+			kind: "project",
+			type: "module",
+			metadata: {
+				name: "module.a",
+				copyright: "Some fancy copyright" // allowed but ignored
+			},
+			resources: {
+				configuration: {
+					paths: {
+						"/": "dist",
+						"/dev/": "dev"
+					}
 				}
 			}
 		}
-	}
-};
+	};
+});
 
 test.afterEach.always((t) => {
-	sinon.restore();
+	t.context.sinon.restore();
 });
 
 test("Correct class", async (t) => {
+	const {projectInput} = t.context;
 	const {default: Module} = await import("../../../../lib/specifications/types/Module.js");
-	const project = await Specification.create(basicProjectInput);
+	const project = await Specification.create(projectInput);
 	t.true(project instanceof Module, `Is an instance of the Module class`);
 });
 
 test("getSourcePath: Throws", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	const err = t.throws(() => {
 		project.getSourcePath();
 	});
@@ -54,13 +55,15 @@ test("getSourcePath: Throws", async (t) => {
 });
 
 test("getNamespace", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	t.is(project.getNamespace(), null,
 		"Returned no namespace");
 });
 
 test("Access project resources via reader", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	t.throws(() => {
 		project.getSourcePath();
 	}, {
@@ -69,7 +72,8 @@ test("Access project resources via reader", async (t) => {
 });
 
 test("Access project resources via reader (multiple mappings)", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	const reader = project.getReader();
 	const resource1 = await reader.byPath("/dev/devTools.js");
 	t.truthy(resource1, "Found the requested resource");
@@ -81,7 +85,7 @@ test("Access project resources via reader (multiple mappings)", async (t) => {
 });
 
 test("Access project resources via reader (one mapping)", async (t) => {
-	const projectInput = clone(basicProjectInput);
+	const {projectInput} = t.context;
 	delete projectInput.configuration.resources.configuration.paths["/"];
 	const project = await Specification.create(projectInput);
 	const reader = project.getReader();
@@ -93,8 +97,56 @@ test("Access project resources via reader (one mapping)", async (t) => {
 	t.falsy(resource2, "Could not find resource in unmapped path");
 });
 
+test("Access project resources via reader w/ builder excludes", async (t) => {
+	const {projectInput, sinon} = t.context;
+	const baselineProject = await Specification.create(projectInput);
+	const excludesProject = await Specification.create(projectInput);
+
+	// As of specVersion 3.0, modules are not allowed to have a "builder.resources" configuration.
+	// Hence modules can't practically be configured with builder excludes.
+	// We still simply stub the respective API call to test the code and be prepared
+	//
+	// projectInput.configuration.builder = {
+	// 	resources: {
+	// 		excludes: ["**/devTools.js"]
+	// 	}
+	// };
+	// So stub instead:
+	sinon.stub(excludesProject, "getBuilderResourcesExcludes").returns(["**/devTools.js"]);
+
+	// We now have two projects: One with excludes and one without
+	// Always compare the results of both to make sure a file is really excluded because of the
+	// configuration and not because of a typo or because of it's absence in the fixture
+
+	t.is((await baselineProject.getReader({}).byGlob("**/devTools.js")).length, 1,
+		"Found resource in baseline project for default style");
+	t.is((await excludesProject.getReader({}).byGlob("**/devTools.js")).length, 0,
+		"Did not find excluded resource for default style");
+
+	t.is((await baselineProject.getReader({style: "buildtime"}).byGlob("**/devTools.js")).length, 1,
+		"Found resource in baseline project for buildtime style");
+	t.is((await excludesProject.getReader({style: "buildtime"}).byGlob("**/devTools.js")).length, 0,
+		"Did not find excluded resource for buildtime style");
+
+	t.is((await baselineProject.getReader({style: "dist"}).byGlob("**/devTools.js")).length, 1,
+		"Found resource in baseline project for dist style");
+	t.is((await excludesProject.getReader({style: "dist"}).byGlob("**/devTools.js")).length, 0,
+		"Did not find excluded resource for dist style");
+
+	t.is((await baselineProject.getReader({style: "flat"}).byGlob("**/devTools.js")).length, 1,
+		"Found resource in baseline project for flat style");
+	t.is((await excludesProject.getReader({style: "flat"}).byGlob("**/devTools.js")).length, 0,
+		"Did not find excluded resource for flat style");
+
+	t.is((await baselineProject.getReader({style: "runtime"}).byGlob("**/devTools.js")).length, 1,
+		"Found resource in baseline project for runtime style");
+	t.is((await excludesProject.getReader({style: "runtime"}).byGlob("**/devTools.js")).length, 1,
+		"Found excluded resource for runtime style");
+});
+
 test("Modify project resources via workspace and access via reader", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	const workspace = project.getWorkspace();
 	const workspaceResource = await workspace.byPath("/dev/devTools.js");
 	t.truthy(workspaceResource, "Found resource in workspace");
@@ -118,7 +170,8 @@ test("Modify project resources via workspace and access via reader", async (t) =
 });
 
 test("Modify project resources via workspace and access via reader for other path mapping", async (t) => {
-	const project = await Specification.create(basicProjectInput);
+	const {projectInput} = t.context;
+	const project = await Specification.create(projectInput);
 	const workspace = project.getWorkspace();
 	const workspaceResource = await workspace.byPath("/index.js");
 	t.truthy(workspaceResource, "Found resource in workspace");
@@ -142,7 +195,7 @@ test("Modify project resources via workspace and access via reader for other pat
 });
 
 test("_configureAndValidatePaths: Default path mapping", async (t) => {
-	const projectInput = clone(basicProjectInput);
+	const {projectInput} = t.context;
 	projectInput.configuration.resources = {};
 	const project = await Specification.create(projectInput);
 
@@ -152,7 +205,7 @@ test("_configureAndValidatePaths: Default path mapping", async (t) => {
 });
 
 test("_configureAndValidatePaths: Configured path mapping", async (t) => {
-	const projectInput = clone(basicProjectInput);
+	const {projectInput} = t.context;
 	const project = await Specification.create(projectInput);
 
 	t.is(project._paths.length, 2, "Two path mappings");
@@ -163,7 +216,7 @@ test("_configureAndValidatePaths: Configured path mapping", async (t) => {
 });
 
 test("_configureAndValidatePaths: Default directory does not exist", async (t) => {
-	const projectInput = clone(basicProjectInput);
+	const {projectInput} = t.context;
 	projectInput.configuration.resources = {};
 	projectInput.modulePath = "/does/not/exist";
 	const err = await t.throwsAsync(Specification.create(projectInput));
@@ -172,7 +225,7 @@ test("_configureAndValidatePaths: Default directory does not exist", async (t) =
 });
 
 test("_configureAndValidatePaths: Directory does not exist", async (t) => {
-	const projectInput = clone(basicProjectInput);
+	const {projectInput} = t.context;
 	projectInput.configuration.resources.configuration.paths.doesNotExist = "does/not/exist";
 	const err = await t.throwsAsync(Specification.create(projectInput));
 


### PR DESCRIPTION
Introduce new style `dist` to reflect the standard build output
structure which can be used with any HTTP server. It is identical to the
`runtime` style, but also applies any configured [builder resource
excludes](https://sap.github.io/ui5-tooling/stable/pages/Configuration/#exclude-resources).

ProjectBuilder now uses style 'dist' instead of 'runtime'.

Fixes https://github.com/SAP/ui5-tooling/issues/779