### PR TITLE
[FIX] TaskUtil: Provide framework configuration getters to custom tasks

### DIFF
--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -195,6 +195,9 @@ class TaskUtil {
 	 * @property {Function} getSourcePath Get the local File System path of the project's source directory
 	 * @property {Function} getCustomConfiguration Get the project Custom Configuration
 	 * @property {Function} isFrameworkProject Check whether the project is a UI5-Framework project
+	 * @property {Function} getFrameworkName Get the project's frameworkName configuration
+	 * @property {Function} getFrameworkVersion Get the project's frameworkVersion configuration
+	 * @property {Function} getFrameworkDependencies Get the project's frameworkDependencies configuration
 	 */
 
 	/**
@@ -312,7 +315,8 @@ class TaskUtil {
 				bindFunctions(project, baseProjectInterface, [
 					"getType", "getName", "getVersion", "getNamespace",
 					"getRootReader", "getReader", "getRootPath", "getSourcePath",
-					"getCustomConfiguration", "isFrameworkProject"
+					"getCustomConfiguration", "isFrameworkProject", "getFrameworkName",
+					"getFrameworkVersion", "getFrameworkDependencies"
 				]);
 				return baseProjectInterface;
 			};

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -195,9 +195,9 @@ class TaskUtil {
 	 * @property {Function} getSourcePath Get the local File System path of the project's source directory
 	 * @property {Function} getCustomConfiguration Get the project Custom Configuration
 	 * @property {Function} isFrameworkProject Check whether the project is a UI5-Framework project
-	 * @property {Function} getFrameworkName Get the project's frameworkName configuration
-	 * @property {Function} getFrameworkVersion Get the project's frameworkVersion configuration
-	 * @property {Function} getFrameworkDependencies Get the project's frameworkDependencies configuration
+	 * @property {Function} getFrameworkName Get the project's framework name configuration
+	 * @property {Function} getFrameworkVersion Get the project's framework version configuration
+	 * @property {Function} getFrameworkDependencies Get the project's framework dependencies configuration
 	 */
 
 	/**

--- a/lib/specifications/Project.js
+++ b/lib/specifications/Project.js
@@ -87,30 +87,42 @@ class Project extends Specification {
 	}
 
 	/**
-	 * Get the project's frameworkName configuration
+	 * Get the project's framework name configuration
 	 *
-	 * @private
-	 * @returns {string} FrameworkName configuration
+	 * @public
+	 * @returns {string} Framework name configuration, either <code>OpenUI5</code> or <code>SAPUI5</code>
 	 */
 	getFrameworkName() {
 		return this._config.framework?.name;
 	}
 
 	/**
-	 * Get the project's frameworkVersion configuration
+	 * Get the project's framework version configuration
 	 *
-	 * @private
-	 * @returns {string} FrameworkVersion configuration
+	 * @public
+	 * @returns {string} Framework version configuration, e.g <code>1.110.0</code>
 	 */
 	getFrameworkVersion() {
 		return this._config.framework?.version;
 	}
 
+
 	/**
-	 * Get the project's frameworkDependencies configuration
+	 * Framework dependency entry of the project configuration.
+	 * Also see [Framework Configuration: Dependencies]{@link https://sap.github.io/ui5-tooling/stable/pages/Configuration/#dependencies}
 	 *
-	 * @private
-	 * @returns {object[]} FrameworkDependencies configuration
+	 * @public
+	 * @typedef {object} @ui5/project/specifications/Project~FrameworkDependency
+	 * @property {string} name Name of the framework library. For example <code>sap.ui.core</code>
+	 * @property {boolean} development Whether the dependency is meant for development purposes only
+	 * @property {boolean} optional Whether the dependency should be treated as optional
+	 */
+
+	/**
+	 * Get the project's framework dependencies configuration
+	 *
+	 * @public
+	 * @returns {@ui5/project/specifications/Project~FrameworkDependency[]} Framework dependencies configuration
 	 */
 	getFrameworkDependencies() {
 		return this._config.framework?.libraries || [];

--- a/test/lib/build/helpers/TaskUtil.js
+++ b/test/lib/build/helpers/TaskUtil.js
@@ -415,8 +415,10 @@ test("getInterface: specVersion 3.0", (t) => {
 		getSourcePath: () => "sourcePath",
 		getCustomConfiguration: () => "customConfiguration",
 		isFrameworkProject: () => "isFrameworkProject",
+		getFrameworkVersion: () => "frameworkVersion",
+		getFrameworkName: () => "frameworkName",
+		getFrameworkDependencies: () => ["frameworkDependencies"],
 		hasBuildManifest: () => "hasBuildManifest", // Should not be exposed
-		getFrameworkVersion: () => "frameworkVersion", // Should not be exposed
 	});
 	const getDependenciesStub = sinon.stub().returns(["dep a", "dep b"]);
 
@@ -462,6 +464,9 @@ test("getInterface: specVersion 3.0", (t) => {
 		"getSourcePath",
 		"getCustomConfiguration",
 		"isFrameworkProject",
+		"getFrameworkName",
+		"getFrameworkVersion",
+		"getFrameworkDependencies",
 	], "Correct methods are provided");
 
 	t.is(interfacedProject.getType(), "type", "getType function is bound correctly");
@@ -476,6 +481,12 @@ test("getInterface: specVersion 3.0", (t) => {
 		"getCustomConfiguration function is bound correctly");
 	t.is(interfacedProject.isFrameworkProject(), "isFrameworkProject",
 		"isFrameworkProject function is bound correctly");
+	t.is(interfacedProject.getFrameworkVersion(), "frameworkVersion",
+		"getFrameworkVersion function is bound correctly");
+	t.is(interfacedProject.getFrameworkName(), "frameworkName",
+		"getFrameworkName function is bound correctly");
+	t.deepEqual(interfacedProject.getFrameworkDependencies(), ["frameworkDependencies"],
+		"getFrameworkDependencies function is bound correctly");
 
 	// getDependencies
 	t.deepEqual(interfacedTaskUtil.getDependencies("pony"), ["dep a", "dep b"],


### PR DESCRIPTION
This was missed to add to the initial 3.0.0 release