### PR TITLE
[FIX] Library: Do not throw for missing .library file

### DIFF
--- a/lib/specifications/types/Library.js
+++ b/lib/specifications/types/Library.js
@@ -175,6 +175,8 @@ class Library extends ComponentProject {
 		}
 
 		if (this.isFrameworkProject()) {
+			// Only framework projects are allowed to provide preload-excludes in their .library file,
+			// and only if it is not already defined in the ui5.yaml
 			if (config.builder?.libraryPreload?.excludes) {
 				this._log.verbose(
 					`Using preload excludes for framework library ${this.getName()} from project configuration`);
@@ -393,17 +395,24 @@ class Library extends ComponentProject {
 	 * @returns {string|null} Copyright of the project
 	 */
 	async _getCopyrightFromDotLibrary() {
-		// If no copyright replacement was provided by ui5.yaml,
-		// check if the .library file has a valid copyright replacement
-		const {content: dotLibrary, filePath} = await this._getDotLibrary();
-		if (dotLibrary?.library?.copyright?._) {
+		try {
+			// If no copyright replacement was provided by ui5.yaml,
+			// check if the .library file has a valid copyright replacement
+			const {content: dotLibrary, filePath} = await this._getDotLibrary();
+			if (dotLibrary?.library?.copyright?._) {
+				this._log.verbose(
+					`Using copyright from ${filePath} for project ${this.getName()}...`);
+				return dotLibrary.library.copyright._;
+			} else {
+				this._log.verbose(
+					`No copyright configuration found in ${filePath} ` +
+					`of project ${this.getName()}`);
+				return null;
+			}
+		} catch (err) {
 			this._log.verbose(
-				`Using copyright from ${filePath} for project ${this.getName()}...`);
-			return dotLibrary.library.copyright._;
-		} else {
-			this._log.verbose(
-				`No copyright configuration found in ${filePath} ` +
-				`of project ${this.getName()}`);
+				`Copyright determination from .library failed for project ` +
+				`${this.getName()}: ${err.message}`);
 			return null;
 		}
 	}

--- a/test/lib/specifications/types/Library.js
+++ b/test/lib/specifications/types/Library.js
@@ -1066,8 +1066,8 @@ test("_getNamespace: from library.js", async (t) => {
 	const {projectInput, sinon} = t.context;
 
 	const project = await (new Library().init(projectInput));
-	sinon.stub(project, "_getManifest").resolves({});
-	sinon.stub(project, "_getDotLibrary").resolves({});
+	sinon.stub(project, "_getManifest").resolves({}); // Empty result or exception should not matter
+	sinon.stub(project, "_getDotLibrary").rejects(new Error("Because bird"));
 	sinon.stub(project, "_getLibraryJsPath").resolves("/my/namespace/library.js");
 	const res = await project._getNamespace();
 	t.is(res, "my/namespace", "Returned correct namespace");
@@ -1168,15 +1168,14 @@ test("_getCopyrightFromDotLibrary: No copyright in .library file", async (t) => 
 	t.is(copyright, null, "No copyright returned");
 });
 
-test("_getCopyrightFromDotLibrary: Propagates exception", async (t) => {
+test("_getCopyrightFromDotLibrary: Does not propagate exception", async (t) => {
 	const {projectInput, sinon} = t.context;
 
 	const project = await (new Library().init(projectInput));
 
 	sinon.stub(project, "_getDotLibrary").rejects(new Error("because shark"));
-	const err = await t.throwsAsync(project._getCopyrightFromDotLibrary());
-	t.is(err.message, "because shark",
-		"Threw with excepted error message");
+	const res = await project._getCopyrightFromDotLibrary();
+	t.is(res, null, "Returned with null");
 });
 
 test("_getPreloadExcludesFromDotLibrary: Single exclude", async (t) => {


### PR DESCRIPTION
Copyright determination should not enforce the existence of a .library
file.
This restores the v2 behavior where a failed copyright determination did
not cause an exception:
https://github.com/SAP/ui5-builder/blob/5846c4dfe3bb45e8e61b0458520787211438d872/lib/types/library/LibraryFormatter.js#L56-L58