### PR TITLE
[FIX] ComponentProject#getWorkspace: Apply builder resource excludes

### DIFF
--- a/lib/specifications/ComponentProject.js
+++ b/lib/specifications/ComponentProject.js
@@ -191,9 +191,11 @@ class ComponentProject extends Project {
 	 */
 	getWorkspace() {
 		// Workspace is always of style "buildtime"
+		// Therefore builder resource-excludes are always to be applied
+		const excludes = this.getBuilderResourcesExcludes();
 		return resourceFactory.createWorkspace({
 			name: `Workspace for project ${this.getName()}`,
-			reader: this._getReader(),
+			reader: this._getReader(excludes),
 			writer: this._getWriter().collection
 		});
 	}

--- a/test/lib/specifications/types/Application.js
+++ b/test/lib/specifications/types/Application.js
@@ -155,6 +155,27 @@ test("Access project resources via reader w/ builder excludes", async (t) => {
 		"Found excluded resource for runtime style");
 });
 
+test("Access project resources via workspace w/ builder excludes", async (t) => {
+	const {projectInput} = t.context;
+	const baselineProject = await Specification.create(projectInput);
+
+	projectInput.configuration.builder = {
+		resources: {
+			excludes: ["**/manifest.json"]
+		}
+	};
+	const excludesProject = await Specification.create(projectInput);
+
+	// We now have two projects: One with excludes and one without
+	// Always compare the results of both to make sure a file is really excluded because of the
+	// configuration and not because of a typo or because of it's absence in the fixture
+
+	t.is((await baselineProject.getWorkspace().byGlob("**/manifest.json")).length, 1,
+		"Found resource in baseline project for default style");
+	t.is((await excludesProject.getWorkspace().byGlob("**/manifest.json")).length, 0,
+		"Did not find excluded resource for default style");
+});
+
 test("Modify project resources via workspace and access via flat and runtime readers", async (t) => {
 	const {projectInput} = t.context;
 	const project = await Specification.create(projectInput);

--- a/test/lib/specifications/types/Library.js
+++ b/test/lib/specifications/types/Library.js
@@ -175,6 +175,27 @@ test("Access project resources via reader w/ builder excludes", async (t) => {
 		"Found excluded resource for runtime style");
 });
 
+test("Access project resources via workspace w/ builder excludes", async (t) => {
+	const {projectInput} = t.context;
+	const baselineProject = await (new Library().init(projectInput));
+
+	projectInput.configuration.builder = {
+		resources: {
+			excludes: ["**/.library"]
+		}
+	};
+	const excludesProject = await (new Library().init(projectInput));
+
+	// We now have two projects: One with excludes and one without
+	// Always compare the results of both to make sure a file is really excluded because of the
+	// configuration and not because of a typo or because of it's absence in the fixture
+
+	t.is((await baselineProject.getWorkspace().byGlob("**/.library")).length, 1,
+		"Found resource in baseline project for default style");
+	t.is((await excludesProject.getWorkspace().byGlob("**/.library")).length, 0,
+		"Did not find excluded resource for default style");
+});
+
 test("Modify project resources via workspace and access via flat and runtime reader", async (t) => {
 	const {projectInput} = t.context;
 	const project = await (new Library().init(projectInput));

--- a/test/lib/specifications/types/Module.js
+++ b/test/lib/specifications/types/Module.js
@@ -144,6 +144,33 @@ test("Access project resources via reader w/ builder excludes", async (t) => {
 		"Found excluded resource for runtime style");
 });
 
+test("Access project resources via workspace w/ builder excludes", async (t) => {
+	const {projectInput, sinon} = t.context;
+	const baselineProject = await Specification.create(projectInput);
+	const excludesProject = await Specification.create(projectInput);
+
+	// As of specVersion 3.0, modules are not allowed to have a "builder.resources" configuration.
+	// Hence modules can't practically be configured with builder excludes.
+	// We still simply stub the respective API call to test the code and be prepared
+	//
+	// projectInput.configuration.builder = {
+	// 	resources: {
+	// 		excludes: ["**/devTools.js"]
+	// 	}
+	// };
+	// So stub instead:
+	sinon.stub(excludesProject, "getBuilderResourcesExcludes").returns(["**/devTools.js"]);
+
+	// We now have two projects: One with excludes and one without
+	// Always compare the results of both to make sure a file is really excluded because of the
+	// configuration and not because of a typo or because of it's absence in the fixture
+
+	t.is((await baselineProject.getWorkspace().byGlob("**/devTools.js")).length, 1,
+		"Found resource in baseline project for default style");
+	t.is((await excludesProject.getWorkspace().byGlob("**/devTools.js")).length, 0,
+		"Did not find excluded resource for default style");
+});
+
 test("Modify project resources via workspace and access via reader", async (t) => {
 	const {projectInput} = t.context;
 	const project = await Specification.create(projectInput);

--- a/test/lib/specifications/types/ThemeLibrary.js
+++ b/test/lib/specifications/types/ThemeLibrary.js
@@ -115,6 +115,27 @@ test("Access project resources via reader w/ builder excludes", async (t) => {
 		"Found excluded resource for runtime style");
 });
 
+test("Access project resources via workspace w/ builder excludes", async (t) => {
+	const {projectInput} = t.context;
+	const baselineProject = await Specification.create(projectInput);
+
+	projectInput.configuration.builder = {
+		resources: {
+			excludes: ["**/.theme"]
+		}
+	};
+	const excludesProject = await Specification.create(projectInput);
+
+	// We now have two projects: One with excludes and one without
+	// Always compare the results of both to make sure a file is really excluded because of the
+	// configuration and not because of a typo or because of it's absence in the fixture
+
+	t.is((await baselineProject.getWorkspace().byGlob("**/.theme")).length, 1,
+		"Found resource in baseline project for default style");
+	t.is((await excludesProject.getWorkspace().byGlob("**/.theme")).length, 0,
+		"Did not find excluded resource for default style");
+});
+
 test("Modify project resources via workspace and access via flat and runtime reader", async (t) => {
 	const {projectInput} = t.context;
 	const project = await Specification.create(projectInput);


### PR DESCRIPTION
This resolves a regression caused by
https://github.com/SAP/ui5-project/pull/574 where the application of
builder resource-exclude configuration was moved from the low-level
_getSourceReader/_getTestReader methods to the high-level getReader API.

However, it was missed to also adapt the high-level getWorkspace API in
the same manner.

This caused the created workspace reader/writer to ignore any exclude
configuration as reported in
https://github.com/SAP/ui5-tooling/issues/784#issuecomment-1433625146