### PR TITLE
[FIX] Resolve properly absolute path for ui5HomeDir

### DIFF
--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -43,11 +43,11 @@ class AbstractResolver {
 			throw new Error(`AbstractResolver: Missing parameter "version"`);
 		}
 
-		this._ui5HomeDir = ui5HomeDir ?
-			path.resolve(ui5HomeDir) :
-			// In some CI environments, the homedir might be set explicitly to a relative
-			// path (e.g. "./"), but tooling requires an absolute path
-			path.resolve(path.join(os.homedir(), ".ui5"));
+		// In some CI environments, the homedir might be set explicitly to a relative
+		// path (e.g. "./"), but tooling requires an absolute path
+		this._ui5HomeDir = path.resolve(
+			ui5HomeDir || path.join(os.homedir(), ".ui5")
+		);
 		this._cwd = cwd ? path.resolve(cwd) : process.cwd();
 		this._version = version;
 	}

--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -46,7 +46,7 @@ class AbstractResolver {
 		this._ui5HomeDir = ui5HomeDir ?
 			path.resolve(ui5HomeDir) :
 			// In some CI environments, the homedir might be set explicitly to a relative
-			// path (e.g. "./"), but tooling requires explicitly an absolute path
+			// path (e.g. "./"), but tooling requires an absolute path
 			path.resolve(path.join(os.homedir(), ".ui5"));
 		this._cwd = cwd ? path.resolve(cwd) : process.cwd();
 		this._version = version;

--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -43,7 +43,11 @@ class AbstractResolver {
 			throw new Error(`AbstractResolver: Missing parameter "version"`);
 		}
 
-		this._ui5HomeDir = ui5HomeDir ? path.resolve(ui5HomeDir) : path.join(os.homedir(), ".ui5");
+		this._ui5HomeDir = ui5HomeDir ?
+			path.resolve(ui5HomeDir) :
+			// In some CI environments, the homedir might be set explicitly to a relative
+			// path (e.g. "./"), but tooling requires explicitly an absolute path
+			path.resolve(path.join(os.homedir(), ".ui5"));
 		this._cwd = cwd ? path.resolve(cwd) : process.cwd();
 		this._version = version;
 	}


### PR DESCRIPTION
This fix resolves https://github.com/SAP/ui5-tooling/issues/796

The core issue is that in particular CI environments `os.homedir()` might be enforced to return a relative path.
We rely only on absolute paths in the tooling, so we'd need to ensure this.