### PR TITLE
[INTERNAL] AbstractResolver: Add env var to enforce usage of framework lib sources

### DIFF
--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -55,7 +55,13 @@ class AbstractResolver {
 		);
 		this._cwd = cwd ? path.resolve(cwd) : process.cwd();
 		this._version = version;
+
+		// Environment variable should always enforce usage of sources
+		if (process.env.UI5_PROJECT_USE_FRAMEWORK_SOURCES) {
+			sources = true;
+		}
 		this._sources = !!sources;
+
 		this._providedLibraryMetadata = providedLibraryMetadata;
 	}
 

--- a/test/lib/ui5framework/AbstractResolver.js
+++ b/test/lib/ui5framework/AbstractResolver.js
@@ -22,6 +22,7 @@ test.beforeEach(async (t) => {
 });
 
 test.afterEach.always((t) => {
+	delete process.env.UI5_PROJECT_USE_FRAMEWORK_SOURCES;
 	esmock.purge(t.context.AbstractResolver);
 	sinon.restore();
 });
@@ -42,12 +43,28 @@ test("AbstractResolver: constructor", (t) => {
 	const resolver = new MyResolver({
 		cwd: "/test-project/",
 		version: "1.75.0",
-		providedLibraryMetadata
+		providedLibraryMetadata,
+		sources: true
 	});
 	t.true(resolver instanceof MyResolver, "Constructor returns instance of sub-class");
 	t.true(resolver instanceof AbstractResolver, "Constructor returns instance of abstract class");
 	t.is(resolver._version, "1.75.0");
-	t.is(resolver._providedLibraryMetadata, providedLibraryMetadata);
+	t.true(resolver._sources, "Correct value for 'sources' flag");
+});
+
+test("AbstractResolver: constructor overwrites sources with env variable", (t) => {
+	const {MyResolver, AbstractResolver} = t.context;
+
+	process.env.UI5_PROJECT_USE_FRAMEWORK_SOURCES = true;
+	const resolver = new MyResolver({
+		cwd: "/test-project/",
+		version: "1.75.0",
+		sources: false // Environment variable overrules parameter
+	});
+	t.true(resolver instanceof MyResolver, "Constructor returns instance of sub-class");
+	t.true(resolver instanceof AbstractResolver, "Constructor returns instance of abstract class");
+	t.is(resolver._version, "1.75.0");
+	t.true(resolver._sources, "Correct value for 'sources' flag");
 });
 
 test("AbstractResolver: constructor without version", (t) => {


### PR DESCRIPTION
By setting environment variable 'UI5_PROJECT_USE_FRAMEWORK_SOURCES' to
any value, resolvers will be forced to always download the sources of
framework dependencies rather than pre-built versions.

Currently this only really affects the Sapui5MavenSnapshotResolver,
being the only resolver capable of downloading pre-built packages as of
today.

JIRA: CPOUI5FOUNDATION-657
