### PR TITLE
[INTERNAL] Sapui5MavenSnapshotResolver: Rename endpoint URL env var

### DIFF
--- a/lib/ui5Framework/Sapui5MavenSnapshotResolver.js
+++ b/lib/ui5Framework/Sapui5MavenSnapshotResolver.js
@@ -24,9 +24,9 @@ const DIST_ARTIFACT_ID = "sapui5-sdk-dist";
 class Sapui5MavenSnapshotResolver extends AbstractResolver {
 	/**
 	 * @param {*} options options
-	 * @param {string} [options.snapshotEndpointUrl] Maven Repository Snapshot URL. If not provided,
-	 *	falls back to an optional <code>UI5_MAVEN_SNAPSHOT_ENDPOINT</code> environment variable,
-	 *	or the standard Maven settings.xml file (if existing).
+	 * @param {string} [options.snapshotEndpointUrl] Maven Repository Snapshot URL. Can by overruled
+	 *	by setting the <code>UI5_MAVEN_SNAPSHOT_ENDPOINT_URL</code> environment variable. If neither is provided,
+	 *	falling back to the standard Maven settings.xml file (if existing).
 	 * @param {string} options.version SAPUI5 version to use
 	 * @param {boolean} [options.sources=false] Whether to install framework libraries as sources or
 	 * pre-built (with build manifest)
@@ -133,7 +133,7 @@ class Sapui5MavenSnapshotResolver extends AbstractResolver {
 	}
 
 	static _createSnapshotEndpointUrlCallback(snapshotEndpointUrl) {
-		snapshotEndpointUrl = snapshotEndpointUrl || process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT;
+		snapshotEndpointUrl = process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT_URL || snapshotEndpointUrl;
 
 		if (!snapshotEndpointUrl) {
 			// If we resolve the settings.xml at this point, we'd need to always ask the end

--- a/test/lib/ui5framework/Sapui5MavenSnapshotResolver.js
+++ b/test/lib/ui5framework/Sapui5MavenSnapshotResolver.js
@@ -17,7 +17,7 @@ test.beforeEach(async (t) => {
 		};
 	});
 
-	process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT = "_SNAPSHOT_URL_";
+	process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT_URL = "_SNAPSHOT_URL_";
 
 	t.context.yesnoStub = sinon.stub();
 	t.context.promisifyStub = sinon.stub();
@@ -51,7 +51,7 @@ test.beforeEach(async (t) => {
 
 test.afterEach.always((t) => {
 	process.stdout.isTTY = t.context.originalIsTty;
-	delete process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT;
+	delete process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT_URL;
 	esmock.purge(t.context.Sapui5MavenSnapshotResolver);
 	sinon.restore();
 });
@@ -261,7 +261,7 @@ test.serial("_createSnapshotEndpointUrlCallback: Environment variable", async (t
 	const {Sapui5MavenSnapshotResolver} = t.context;
 	const createSnapshotEndpointUrlCallback = Sapui5MavenSnapshotResolver._createSnapshotEndpointUrlCallback;
 
-	const endpointCallback = await createSnapshotEndpointUrlCallback();
+	const endpointCallback = await createSnapshotEndpointUrlCallback("my url");
 
 	t.is(await endpointCallback(), "_SNAPSHOT_URL_",
 		"Returned a callback resolving to value of env variable");
@@ -271,6 +271,7 @@ test.serial("_createSnapshotEndpointUrlCallback: Parameter", async (t) => {
 	const {Sapui5MavenSnapshotResolver} = t.context;
 	const createSnapshotEndpointUrlCallback = Sapui5MavenSnapshotResolver._createSnapshotEndpointUrlCallback;
 
+	delete process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT_URL; // Delete env variable for this test
 	const endpointCallback = await createSnapshotEndpointUrlCallback("my url");
 
 	t.is(await endpointCallback(), "my url",
@@ -281,7 +282,7 @@ test.serial("_createSnapshotEndpointUrlCallback: Fallback to configuration files
 	const {Sapui5MavenSnapshotResolver} = t.context;
 	const createSnapshotEndpointUrlCallback = Sapui5MavenSnapshotResolver._createSnapshotEndpointUrlCallback;
 
-	delete process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT; // Delete env variable for this test
+	delete process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT_URL; // Delete env variable for this test
 	const resolveUrlStub = sinon.stub(Sapui5MavenSnapshotResolver, "_resolveSnapshotEndpointUrl").resolves("🐱");
 
 	const endpointCallback = await createSnapshotEndpointUrlCallback();


### PR DESCRIPTION
"UI5_MAVEN_SNAPSHOT_ENDPOINT" => "UI5_MAVEN_SNAPSHOT_ENDPOINT_URL"

Also always prefer it over the API parameter.