### PR TITLE
[FIX] ui5Framework: Respect npm proxy configuration to fetch libraries

### DIFF
--- a/lib/ui5Framework/npm/Registry.js
+++ b/lib/ui5Framework/npm/Registry.js
@@ -52,16 +52,27 @@ class Registry {
 			const {default: libnpmconfig} = await import("libnpmconfig");
 			const opts = {
 				cache: this._cacheDir,
-				// Disable usage of shared keep-alive agents.
-				// make-fetch-happen uses a hard-coded 15 seconds freeSocketTimeout
-				// that can be easily reached (Error: Socket timeout) and there doesn't
-				// seem to be another way to disable or increase it.
-				// Also see: https://github.com/node-modules/agentkeepalive/issues/106
-				agent: false,
 			};
 			const config = libnpmconfig.read(opts, {
 				cwd: this._cwd
 			}).toJSON();
+
+			// Rename https-proxy to httpsProxy so that it is picked up by npm-registry-fetch (via pacote)
+			if (config["https-proxy"]) {
+				config.httpsProxy = config["https-proxy"];
+				delete config["https-proxy"];
+			}
+
+			if (!config.proxy && !config.httpsProxy) {
+				// Disable usage of shared keep-alive agents unless a proxy is configured
+				// which only works with agents.
+
+				// make-fetch-happen uses a hard-coded 15 seconds freeSocketTimeout
+				// that can be easily reached (Error: Socket timeout) and there doesn't
+				// seem to be another way to disable or increase it.
+				// Also see: https://github.com/node-modules/agentkeepalive/issues/106
+				config.agent = false;
+			}
 
 			log.verbose(`Using npm configuration (extract):`);
 			// Do not log full configuration as it may contain authentication tokens
@@ -69,6 +80,7 @@ class Registry {
 			logConfig(config, "@sapui5:registry");
 			logConfig(config, "@openui5:registry");
 			logConfig(config, "proxy");
+			logConfig(config, "httpsProxy");
 			logConfig(config, "globalconfig");
 			logConfig(config, "userconfig");
 			logConfig(config, "cache");

--- a/test/lib/ui5framework/npm/Registry.js
+++ b/test/lib/ui5framework/npm/Registry.js
@@ -54,6 +54,11 @@ test.serial("_getPacoteOptions", async (t) => {
 		"fake": "config"
 	};
 
+	const expectedPacoteOptions = {
+		fake: "config",
+		agent: false
+	};
+
 	libnpmconfigReadToJSON.returns(npmConfig);
 
 	const pacoteOptions = await registry._getPacoteOptions();
@@ -62,19 +67,94 @@ test.serial("_getPacoteOptions", async (t) => {
 	t.is(libnpmconfig.read.callCount, 1);
 	t.deepEqual(libnpmconfig.read.getCall(0).args, [{
 		cache: "cacheDir",
-		agent: false
 	}, {
 		cwd: "cwd"
 	}]);
 
-	t.is(pacoteOptions, npmConfig);
+	t.deepEqual(pacoteOptions, expectedPacoteOptions);
 
 	const cachedPacoteOptions = await registry._getPacoteOptions();
 
 	t.is(libnpmconfigReadToJSON.callCount, 1);
 	t.is(libnpmconfig.read.callCount, 1);
 
-	t.is(cachedPacoteOptions, npmConfig);
+	t.deepEqual(cachedPacoteOptions, expectedPacoteOptions);
+});
+
+test.serial("_getPacoteOptions (proxy config set)", async (t) => {
+	const {Registry, libnpmconfig, libnpmconfigReadToJSON} = t.context;
+
+	const registry = new Registry({
+		cwd: "cwd",
+		cacheDir: "cacheDir"
+	});
+
+	const npmConfig = {
+		"proxy": "http://localhost:9999"
+	};
+
+	const expectedPacoteOptions = {
+		proxy: "http://localhost:9999"
+	};
+
+	libnpmconfigReadToJSON.returns(npmConfig);
+
+	const pacoteOptions = await registry._getPacoteOptions();
+
+	t.is(libnpmconfigReadToJSON.callCount, 1);
+	t.is(libnpmconfig.read.callCount, 1);
+	t.deepEqual(libnpmconfig.read.getCall(0).args, [{
+		cache: "cacheDir",
+	}, {
+		cwd: "cwd"
+	}]);
+
+	t.deepEqual(pacoteOptions, expectedPacoteOptions);
+
+	const cachedPacoteOptions = await registry._getPacoteOptions();
+
+	t.is(libnpmconfigReadToJSON.callCount, 1);
+	t.is(libnpmconfig.read.callCount, 1);
+
+	t.deepEqual(cachedPacoteOptions, expectedPacoteOptions);
+});
+
+test.serial("_getPacoteOptions (https-proxy config set)", async (t) => {
+	const {Registry, libnpmconfig, libnpmconfigReadToJSON} = t.context;
+
+	const registry = new Registry({
+		cwd: "cwd",
+		cacheDir: "cacheDir"
+	});
+
+	const npmConfig = {
+		"https-proxy": "http://localhost:9999"
+	};
+
+	const expectedPacoteOptions = {
+		httpsProxy: "http://localhost:9999"
+	};
+
+	libnpmconfigReadToJSON.returns(npmConfig);
+
+	const pacoteOptions = await registry._getPacoteOptions();
+
+	t.is(libnpmconfigReadToJSON.callCount, 1);
+	t.is(libnpmconfig.read.callCount, 1);
+	t.deepEqual(libnpmconfig.read.getCall(0).args, [{
+		cache: "cacheDir",
+	}, {
+		cwd: "cwd"
+	}]);
+
+	t.deepEqual(pacoteOptions, expectedPacoteOptions);
+
+	const cachedPacoteOptions = await registry._getPacoteOptions();
+
+	t.is(libnpmconfigReadToJSON.callCount, 1);
+	t.is(libnpmconfig.read.callCount, 1);
+
+	t.deepEqual(cachedPacoteOptions, expectedPacoteOptions);
 });
 
 test.serial("_getPacote", async (t) => {


### PR DESCRIPTION
This commit fixes a regression caused via https://github.com/SAP/ui5-project/pull/579

The proxy functionality relies on the agent option so it must not be
disabled when using a proxy.

This again enables proxy support but doesn't solve potential
"Socket Timeout" issues that might also appear when using a proxy
(see https://github.com/SAP/ui5-project/pull/579).

The https-proxy option is now also taken into account, which didn't work
before due to missing normalization from https-proxy to httpsProxy.

Fixes: https://github.com/SAP/ui5-tooling/issues/822
