### PR TITLE
[FIX] Properly resolve dependent shimmed modules

### DIFF
--- a/lib/graph/projectGraphBuilder.js
+++ b/lib/graph/projectGraphBuilder.js
@@ -187,7 +187,7 @@ async function projectGraphBuilder(nodeProvider, workspace) {
 			}
 
 			let {project, extensions} = await ui5Module.getSpecifications();
-			
+
 			// Try again this module with an eventual Shim resolution
 			if (
 				fromCache &&
@@ -203,9 +203,9 @@ async function projectGraphBuilder(nodeProvider, workspace) {
 					shimCollection,
 				});
 
-				({ project, extensions } = await ui5Module.getSpecifications());
+				({project, extensions} = await ui5Module.getSpecifications());
 			}
-			
+
 			return {
 				node,
 				project,

--- a/lib/graph/projectGraphBuilder.js
+++ b/lib/graph/projectGraphBuilder.js
@@ -161,10 +161,12 @@ async function projectGraphBuilder(nodeProvider, workspace) {
 		const {nodes, parentProject} = queue.shift(); // Get and remove first entry from queue
 		const res = await Promise.all(nodes.map(async (node) => {
 			let ui5Module = moduleCollection[node.id];
+			let fromCache = true;
 			if (!ui5Module) {
 				log.silly(`Visiting Module ${node.id} as a dependency of ${parentProject.getName()}`);
 				log.verbose(`Creating module ${node.id}...`);
 				validateNode(node);
+				fromCache = false;
 				ui5Module = moduleCollection[node.id] = new Module({
 					id: node.id,
 					version: node.version,
@@ -184,7 +186,26 @@ async function projectGraphBuilder(nodeProvider, workspace) {
 				}
 			}
 
-			const {project, extensions} = await ui5Module.getSpecifications();
+			let {project, extensions} = await ui5Module.getSpecifications();
+			
+			// Try again this module with an eventual Shim resolution
+			if (
+				fromCache &&
+				!project &&
+				!!shimCollection.getProjectConfigurationShims(node.id)
+			) {
+				ui5Module = moduleCollection[node.id] = new Module({
+					id: node.id,
+					version: node.version,
+					modulePath: node.path,
+					configPath: node.configPath,
+					configuration: node.configuration,
+					shimCollection,
+				});
+
+				({ project, extensions } = await ui5Module.getSpecifications());
+			}
+			
 			return {
 				node,
 				project,

--- a/test/lib/graph/projectGraphBuilder.js
+++ b/test/lib/graph/projectGraphBuilder.js
@@ -679,55 +679,55 @@ test("Define external dependency as shims in sub-module", async (t) => {
 		id: "app",
 		version: "1.0.0",
 		path: "/app"
-	  }));
+	}));
 
-	  t.context.getDependencies.onCall(0).resolves([
-			createNode({
-				id: "lib",
-				version: "1.0.0",
-				path: "/lib"
-			}),
-			{
-				id: "external-thirdparty",
-				version: "1.0.0",
-				path: "/app/node_modules/external-thirdparty"
-			},
-			createNode({
-				id: "external-thirdparty-shim",
-				configuration: {
-					kind: "extension",
-					type: "project-shim",
-					shims: {
-						configurations: {
-							"external-thirdparty": {
-								specVersion: "3.0",
-								type: "module",
-								metadata: { name: "external-thirdparty" },
-								resources: {
-									configuration: {
-										paths: { "/resources/": "" },
-									},
+	t.context.getDependencies.onCall(0).resolves([
+		createNode({
+			id: "lib",
+			version: "1.0.0",
+			path: "/lib"
+		}),
+		{
+			id: "external-thirdparty",
+			version: "1.0.0",
+			path: "/app/node_modules/external-thirdparty"
+		},
+		createNode({
+			id: "external-thirdparty-shim",
+			configuration: {
+				kind: "extension",
+				type: "project-shim",
+				shims: {
+					configurations: {
+						"external-thirdparty": {
+							specVersion: "3.0",
+							type: "module",
+							metadata: {name: "external-thirdparty"},
+							resources: {
+								configuration: {
+									paths: {"/resources/": ""},
 								},
 							},
 						},
 					},
-				}
-			})
-		]);
-	  
-	  t.context.getDependencies.onCall(1).resolves([
+				},
+			}
+		})
+	]);
+
+	t.context.getDependencies.onCall(1).resolves([
 		createNode({
 			id: "external-thirdparty",
 			version: "1.0.0",
 			path: "/app/node_modules/external-thirdparty",
 			optional: false
-		  })
-	  ]);
+		})
+	]);
 
-	  const graph = await projectGraphBuilder(t.context.provider);
-	  
-	  t.deepEqual(graph.getDependencies("app"), ["lib"], "'app' depends on 'lib'");
-	  t.deepEqual(graph.getDependencies("lib"), ["external-thirdparty"], "'lib' depends on 'external-thirdparty'");
+	const graph = await projectGraphBuilder(t.context.provider);
+
+	t.deepEqual(graph.getDependencies("app"), ["lib"], "'app' depends on 'lib'");
+	t.deepEqual(graph.getDependencies("lib"), ["external-thirdparty"], "'lib' depends on 'external-thirdparty'");
 });
 
 test("Extension in dependencies", async (t) => {

--- a/test/lib/graph/projectGraphBuilder.js
+++ b/test/lib/graph/projectGraphBuilder.js
@@ -674,7 +674,7 @@ test("Dependencies defined through shim", async (t) => {
 	t.deepEqual(graph.getDependencies("project-3"), ["project-2"], "Shimmed dependency has been defined");
 });
 
-test.only("Define external dependency as shims in sub-module", async (t) => {
+test("Define external dependency as shims in sub-module", async (t) => {
 	t.context.getRootNode.resolves(createNode({
 		id: "app",
 		version: "1.0.0",

--- a/test/lib/graph/projectGraphBuilder.js
+++ b/test/lib/graph/projectGraphBuilder.js
@@ -674,6 +674,62 @@ test("Dependencies defined through shim", async (t) => {
 	t.deepEqual(graph.getDependencies("project-3"), ["project-2"], "Shimmed dependency has been defined");
 });
 
+test.only("Define external dependency as shims in sub-module", async (t) => {
+	t.context.getRootNode.resolves(createNode({
+		id: "app",
+		version: "1.0.0",
+		path: "/app"
+	  }));
+
+	  t.context.getDependencies.onCall(0).resolves([
+			createNode({
+				id: "lib",
+				version: "1.0.0",
+				path: "/lib"
+			}),
+			{
+				id: "external-thirdparty",
+				version: "1.0.0",
+				path: "/app/node_modules/external-thirdparty"
+			},
+			createNode({
+				id: "external-thirdparty-shim",
+				configuration: {
+					kind: "extension",
+					type: "project-shim",
+					shims: {
+						configurations: {
+							"external-thirdparty": {
+								specVersion: "3.0",
+								type: "module",
+								metadata: { name: "external-thirdparty" },
+								resources: {
+									configuration: {
+										paths: { "/resources/": "" },
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+		]);
+	  
+	  t.context.getDependencies.onCall(1).resolves([
+		createNode({
+			id: "external-thirdparty",
+			version: "1.0.0",
+			path: "/app/node_modules/external-thirdparty",
+			optional: false
+		  })
+	  ]);
+
+	  const graph = await projectGraphBuilder(t.context.provider);
+	  
+	  t.deepEqual(graph.getDependencies("app"), ["lib"], "'app' depends on 'lib'");
+	  t.deepEqual(graph.getDependencies("lib"), ["external-thirdparty"], "'lib' depends on 'external-thirdparty'");
+});
+
 test("Extension in dependencies", async (t) => {
 	t.context.getRootNode.resolves(createNode({
 		id: "id1",


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-tooling/issues/807

If an external (non-UI5) module is provided as devDependency in an application, but there's a dependecy to a sub-module that uses the external module as a **main** dependency and is shimmed there, it's been cached without the shim and is not build properly later.

Sample structure:
```bash
app/
  \_ node_modules/
    \_ rxjs/ # devDependency, not shimmed
    \_ library/
      \_ node_modules/
        \_ rxjs/ # dependency, shimmed
```