### PR TITLE
[FIX] projectGraphBuilder: Add module cache invalidation

### DIFF
--- a/lib/graph/projectGraphBuilder.js
+++ b/lib/graph/projectGraphBuilder.js
@@ -161,6 +161,24 @@ async function projectGraphBuilder(nodeProvider, workspace) {
 		const {nodes, parentProject} = queue.shift(); // Get and remove first entry from queue
 		const res = await Promise.all(nodes.map(async (node) => {
 			let ui5Module = moduleCollection[node.id];
+
+			if (ui5Module) {
+				log.silly(
+					`Re-visiting module ${node.id} as a dependency of ${parentProject.getName()}`);
+
+				const {project, extensions} = await ui5Module.getSpecifications();
+				if (!project && !extensions.length) {
+					// Invalidate cache if the cached module is visited through another parent project and did not
+					// resolve to anything useful (project or extension(s)) before.
+					// The module being visited now might be a different version where it contains UI5 Tooling
+					// configuration, or one of the parent projects could have defined a shim extension meanwhile
+					log.silly(
+						`Cached module ${node.id} did not resolve to any projects or extensions. ` +
+						`Recreating module as a dependency of ${parentProject.getName()}...`);
+					ui5Module = null;
+				}
+			}
+
 			if (!ui5Module) {
 				log.silly(`Visiting Module ${node.id} as a dependency of ${parentProject.getName()}`);
 				log.verbose(`Creating module ${node.id}...`);
@@ -174,8 +192,6 @@ async function projectGraphBuilder(nodeProvider, workspace) {
 					shimCollection
 				});
 			} else {
-				log.silly(
-					`Re-visiting module ${node.id} as a dependency of ${parentProject.getName()}`);
 				if (ui5Module.getPath() !== node.path) {
 					log.verbose(
 						`Warning - Dependency ${node.id} is available at multiple paths:` +

--- a/lib/graph/projectGraphBuilder.js
+++ b/lib/graph/projectGraphBuilder.js
@@ -169,9 +169,10 @@ async function projectGraphBuilder(nodeProvider, workspace) {
 				const {project, extensions} = await ui5Module.getSpecifications();
 				if (!project && !extensions.length) {
 					// Invalidate cache if the cached module is visited through another parent project and did not
-					// resolve to anything useful (project or extension(s)) before.
-					// The module being visited now might be a different version where it contains UI5 Tooling
-					// configuration, or one of the parent projects could have defined a shim extension meanwhile
+					// resolve to a project or extension(s) before.
+					// The module being visited now might be a different version containing for example
+					// UI5 Tooling configuration, or one of the parent projects could have defined a
+					// relevant configuration shim meanwhile
 					log.silly(
 						`Cached module ${node.id} did not resolve to any projects or extensions. ` +
 						`Recreating module as a dependency of ${parentProject.getName()}...`);
@@ -191,13 +192,11 @@ async function projectGraphBuilder(nodeProvider, workspace) {
 					configuration: node.configuration,
 					shimCollection
 				});
-			} else {
-				if (ui5Module.getPath() !== node.path) {
-					log.verbose(
-						`Warning - Dependency ${node.id} is available at multiple paths:` +
-						`\n  Location of the already processed module (this one will be used): ${ui5Module.getPath()}` +
-						`\n  Additional location (this one will be ignored): ${node.path}`);
-				}
+			} else if (ui5Module.getPath() !== node.path) {
+				log.verbose(
+					`Warning - Dependency ${node.id} is available at multiple paths:` +
+					`\n  Location of the already processed module (this one will be used): ${ui5Module.getPath()}` +
+					`\n  Additional location (this one will be ignored): ${node.path}`);
 			}
 
 			const {project, extensions} = await ui5Module.getSpecifications();

--- a/test/lib/graph/projectGraphBuilder.js
+++ b/test/lib/graph/projectGraphBuilder.js
@@ -679,55 +679,55 @@ test("Define external dependency as shims in sub-module", async (t) => {
 		id: "app",
 		version: "1.0.0",
 		path: "/app"
-	  }));
+	}));
 
-	  t.context.getDependencies.onCall(0).resolves([
-			createNode({
-				id: "lib",
-				version: "1.0.0",
-				path: "/lib"
-			}),
-			{
-				id: "external-thirdparty",
-				version: "1.0.0",
-				path: "/app/node_modules/external-thirdparty"
-			},
-			createNode({
-				id: "external-thirdparty-shim",
-				configuration: {
-					kind: "extension",
-					type: "project-shim",
-					shims: {
-						configurations: {
-							"external-thirdparty": {
-								specVersion: "3.0",
-								type: "module",
-								metadata: { name: "external-thirdparty" },
-								resources: {
-									configuration: {
-										paths: { "/resources/": "" },
-									},
+	t.context.getDependencies.onCall(0).resolves([
+		createNode({
+			id: "lib",
+			version: "1.0.0",
+			path: "/lib"
+		}),
+		{
+			id: "external-thirdparty",
+			version: "1.0.0",
+			path: "/app/node_modules/external-thirdparty"
+		},
+		createNode({
+			id: "external-thirdparty-shim",
+			configuration: {
+				kind: "extension",
+				type: "project-shim",
+				shims: {
+					configurations: {
+						"external-thirdparty": {
+							specVersion: "3.0",
+							type: "module",
+							metadata: {name: "external-thirdparty"},
+							resources: {
+								configuration: {
+									paths: {"/resources/": ""},
 								},
 							},
 						},
 					},
-				}
-			})
-		]);
-	  
-	  t.context.getDependencies.onCall(1).resolves([
+				},
+			}
+		})
+	]);
+
+	t.context.getDependencies.onCall(1).resolves([
 		createNode({
 			id: "external-thirdparty",
 			version: "1.0.0",
 			path: "/app/node_modules/external-thirdparty",
 			optional: false
-		  })
-	  ]);
+		})
+	]);
 
-	  const graph = await projectGraphBuilder(t.context.provider);
-	  
-	  t.deepEqual(graph.getDependencies("app"), ["lib"], "'app' depends on 'lib'");
-	  t.deepEqual(graph.getDependencies("lib"), ["external-thirdparty"], "'lib' depends on 'external-thirdparty'");
+	const graph = await projectGraphBuilder(t.context.provider);
+
+	t.deepEqual(graph.getDependencies("app"), ["lib"], "'app' depends on 'lib'");
+	t.deepEqual(graph.getDependencies("lib"), ["external-thirdparty"], "'lib' depends on 'external-thirdparty'");
 });
 
 test("Extension in dependencies", async (t) => {

--- a/test/lib/graph/projectGraphBuilder.js
+++ b/test/lib/graph/projectGraphBuilder.js
@@ -674,7 +674,7 @@ test("Dependencies defined through shim", async (t) => {
 	t.deepEqual(graph.getDependencies("project-3"), ["project-2"], "Shimmed dependency has been defined");
 });
 
-test.only("Define external dependency as shims in sub-module", async (t) => {
+test("Define external dependency as shims in sub-module", async (t) => {
 	t.context.getRootNode.resolves(createNode({
 		id: "app",
 		version: "1.0.0",

--- a/test/lib/graph/projectGraphBuilder.js
+++ b/test/lib/graph/projectGraphBuilder.js
@@ -674,6 +674,62 @@ test("Dependencies defined through shim", async (t) => {
 	t.deepEqual(graph.getDependencies("project-3"), ["project-2"], "Shimmed dependency has been defined");
 });
 
+test.only("Define external dependency as shims in sub-module", async (t) => {
+	t.context.getRootNode.resolves(createNode({
+		id: "app",
+		version: "1.0.0",
+		path: "/app"
+	  }));
+
+	  t.context.getDependencies.onCall(0).resolves([
+			createNode({
+				id: "lib",
+				version: "1.0.0",
+				path: "/lib"
+			}),
+			{
+				id: "external-thirdparty",
+				version: "1.0.0",
+				path: "/app/node_modules/external-thirdparty"
+			},
+			createNode({
+				id: "external-thirdparty-shim",
+				configuration: {
+					kind: "extension",
+					type: "project-shim",
+					shims: {
+						configurations: {
+							"external-thirdparty": {
+								specVersion: "3.0",
+								type: "module",
+								metadata: { name: "external-thirdparty" },
+								resources: {
+									configuration: {
+										paths: { "/resources/": "" },
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+		]);
+	  
+	  t.context.getDependencies.onCall(1).resolves([
+		createNode({
+			id: "external-thirdparty",
+			version: "1.0.0",
+			path: "/app/node_modules/external-thirdparty",
+			optional: false
+		  })
+	  ]);
+
+	  const graph = await projectGraphBuilder(t.context.provider);
+	  
+	  t.deepEqual(graph.getDependencies("app"), ["lib"], "'app' depends on 'lib'");
+	  t.deepEqual(graph.getDependencies("lib"), ["external-thirdparty"], "'lib' depends on 'external-thirdparty'");
+});
+
 test("Extension in dependencies", async (t) => {
 	t.context.getRootNode.resolves(createNode({
 		id: "id1",


### PR DESCRIPTION
If a visited module did not resolve to any specification (project or
extensions), try recreating the module when visiting it again from a
different parent.

Resolves https://github.com/SAP/ui5-tooling/issues/807

This is an alternative to https://github.com/SAP/ui5-project/pull/611

This change might have a greater impact on performance since er might
recreate modules that are not relevant to UI5 Tooling more than once if
they are listed multiple times in the dependency tree.
Before this change, such modules where only visited once.