### PR TITLE
[FIX] Workspace: Ignore empty npm workspace modules

### DIFF
--- a/lib/graph/Workspace.js
+++ b/lib/graph/Workspace.js
@@ -190,6 +190,8 @@ class Workspace {
 			}
 		} catch (err) {
 			if (!failOnMissingFiles && err.code === "ENOENT") {
+				// When resolving a dynamic workspace pattern (not a static path), ignore modules that
+				// are missing a package.json (this might simply indicate an empty directory)
 				log.verbose(`Ignoring module at path ${nodePath}: Directory does not contain a package.json`);
 				return [];
 			}

--- a/lib/graph/Workspace.js
+++ b/lib/graph/Workspace.js
@@ -174,7 +174,7 @@ class Workspace {
 		};
 	}
 
-	async _getModulesFromPath(cwd, relPath) {
+	async _getModulesFromPath(cwd, relPath, failOnMissingFiles = true) {
 		const nodePath = path.join(cwd, relPath);
 		if (this.#visitedNodePaths.has(nodePath)) {
 			log.verbose(`Module located at ${nodePath} has already been visited`);
@@ -189,6 +189,10 @@ class Workspace {
 					`package.json must contain fields 'name' and 'version'`);
 			}
 		} catch (err) {
+			if (!failOnMissingFiles && err.code === "ENOENT") {
+				log.verbose(`Ignoring module at path ${nodePath}: Directory does not contain a package.json`);
+				return [];
+			}
 			throw new Error(
 				`Failed to resolve workspace dependency resolution path ${relPath} to ${nodePath}: ${err.message}`);
 		}
@@ -228,7 +232,7 @@ class Workspace {
 
 			const resolvedModules = new Map();
 			await Promise.all(searchPaths.map(async (pkgPath) => {
-				const modules = await this._getModulesFromPath(nodePath, pkgPath);
+				const modules = await this._getModulesFromPath(nodePath, pkgPath, staticPatterns.includes(pkgPath));
 				modules.forEach((module) => {
 					const id = module.getId();
 					if (!resolvedModules.get(id)) {

--- a/test/fixtures/collection.b/sub-empty/.keep
+++ b/test/fixtures/collection.b/sub-empty/.keep
@@ -1,0 +1,2 @@
+This file is a stand-in for an empty project directory.
+This directory, even though matching the npm workspace configuration pattern, should be ignored by UI5 Tooling.


### PR DESCRIPTION
If a dynamic npm workspaces[1] configuration resolves to a directory
lacking a package.json file, ignore that module silently.

This can happen when using a pattern like "packages/*" in the workspaces
configuration, and then deleting a package. In case files on .gitignore
remain in the directory for some users, the physical directory is not
removed by git. This lead to issues for UI5 Tooling, trying to use the
empty directory and throwing because of the lacking package.json.

With this change, an error is only thrown if the module path is
explicitly configured (no pattern).

[1] https://docs.npmjs.com/cli/v9/using-npm/workspaces?v=true