### PR TITLE
[FEATURE] ProjectBuilder: Add `outputStyle` option to request flat build output

### DIFF
--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -27,7 +27,7 @@ class ProjectBuilder {
 	 * @property {boolean} [flatOutput=false]
 	 *   Whether to write the build results into a flat directory structure, omitting the project
 	 *   namespace and the "resources" directory.
-	 *   This is currently only supported for projects of type 'library' and 'theme-library'.
+	 *   This is currently only supported for projects of type 'library'
 	 *   No other dependencies can be included in the build result.
 	 * @property {Array.<string>} [includedTasks=[]] List of tasks to be included
 	 * @property {Array.<string>} [excludedTasks=[]] List of tasks to be excluded.

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -411,9 +411,15 @@ class ProjectBuilder {
 		}));
 
 		if (flatOutput) {
-			const namespacedRegex = new RegExp("/(resources|test-resources)/" + project.getNamespace());
+			const namespace = project.getNamespace();
+			const libraryResourcesPrefix = `/resources/${namespace}/`;
+			const testResourcesPrefix = "/test-resources/";
+			const namespacedRegex = new RegExp(`/(resources|test-resources)/${namespace}`);
 			const processedResourcesSet = resources.reduce((acc, resource) => acc.add(resource.getPath()), new Set());
 
+			// If there's a flatOutput enabled, then the FlatReader would have filtered
+			// some resources. We now need to get all of the available resources and
+			// do an intersection with the processed/bundled ones.
 			const defaultReader = project.getReader();
 			const defaultResources = await defaultReader.byGlob("/**/*");
 			const flatDefaultResources = defaultResources.map((resource) => ({
@@ -426,14 +432,14 @@ class ProjectBuilder {
 			});
 
 			skippedResources.forEach((resource) => {
-				if (resource.originalPath.startsWith("/test-resources")) {
+				if (resource.originalPath.startsWith(testResourcesPrefix)) {
 					this.#log.verbose(
-						`Omitting ${resource.originalPath} from build result. File is part of /test-resources.`
+						`Omitting ${resource.originalPath} from build result. File is part of ${testResourcesPrefix}.`
 					);
-				} else {
+				} else if (!resource.originalPath.startsWith(libraryResourcesPrefix)) {
 					this.#log.warn(
 						`Omitting ${resource.originalPath} from build result. ` +
-							`File is not within project namespace '${project.getNamespace()}'.`
+							`File is not within project namespace '${namespace}'.`
 					);
 				}
 			});

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -372,7 +372,7 @@ class ProjectBuilder {
 		const buildConfig = this._buildContext.getBuildConfig();
 		const {createBuildManifest, outputStyle} = buildConfig;
 		// Output styles are applied only for the root project
-		const isRootProject = this._graph.getRoot().getName() === project.getName();
+		const isRootProject = taskUtil.isRootProject();
 
 		let readerStyle = "dist";
 		if (createBuildManifest ||

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -173,15 +173,10 @@ class ProjectBuilder {
 		});
 
 		if (requestedProjects.length > 1) {
-			const {createBuildManifest, outputStyle} = this._buildContext.getBuildConfig();
+			const {createBuildManifest} = this._buildContext.getBuildConfig();
 			if (createBuildManifest) {
 				throw new Error(
 					`It is currently not supported to request the creation of a build manifest ` +
-					`while including any dependencies into the build result`);
-			}
-			if (outputStyle === OutputStyleEnum.Flat) {
-				throw new Error(
-					`It is currently not supported to request flat build output ` +
 					`while including any dependencies into the build result`);
 			}
 		}
@@ -376,13 +371,15 @@ class ProjectBuilder {
 		const taskUtil = projectBuildContext.getTaskUtil();
 		const buildConfig = this._buildContext.getBuildConfig();
 		const {createBuildManifest, outputStyle} = buildConfig;
+		// Output styles are applied only for the root project
+		const isRootProject = this._graph.getRoot().getName() === project.getName();
 
 		let readerStyle = "dist";
 		if (createBuildManifest ||
-			(outputStyle === OutputStyleEnum.Namespace && project.getType() === "application")) {
+			(isRootProject && outputStyle === OutputStyleEnum.Namespace && project.getType() === "application")) {
 			// Ensure buildtime (=namespaced) style when writing with a build manifest
 			readerStyle = "buildtime";
-		} else if (outputStyle === OutputStyleEnum.Flat) {
+		} else if (isRootProject && outputStyle === OutputStyleEnum.Flat) {
 			readerStyle = "flat";
 		}
 
@@ -412,7 +409,8 @@ class ProjectBuilder {
 			return target.write(resource);
 		}));
 
-		if (outputStyle === OutputStyleEnum.Flat &&
+		if (isRootProject &&
+			outputStyle === OutputStyleEnum.Flat &&
 			project.getType() !== "application" /* application type is with a flat source structure */) {
 			const namespace = project.getNamespace();
 			const libraryResourcesPrefix = `/resources/${namespace}/`;

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -410,7 +410,8 @@ class ProjectBuilder {
 			return target.write(resource);
 		}));
 
-		if (flatOutput) {
+		if (flatOutput &&
+			project.getType() !== "application" /* application type is with a flat source structure */) {
 			const namespace = project.getNamespace();
 			const libraryResourcesPrefix = `/resources/${namespace}/`;
 			const testResourcesPrefix = "/test-resources/";

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -27,10 +27,6 @@ class ProjectBuilder {
 	 *   No other dependencies can be included in the build result.
 	 * @property {module:@ui5/project/build/ProjectBuilderOutputStyle} [outputStyle=Default]
 	 *   Processes build results into a specific directory structure.
-	 *   "Flat" omits the project namespace and the "resources" directory. This
-	 *   is currently only supported for projects of type 'library'.
-	 *   Projects of type 'application' always result in a flat output.
-	 *   No other dependencies can be included in the build result.
 	 * @property {Array.<string>} [includedTasks=[]] List of tasks to be included
 	 * @property {Array.<string>} [excludedTasks=[]] List of tasks to be excluded.
 	 * 			If the wildcard '*' is provided, only the included tasks will be executed.

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -24,11 +24,11 @@ class ProjectBuilder {
 	 *   Whether to create a build manifest file for the root project.
 	 *   This is currently only supported for projects of type 'library' and 'theme-library'
 	 *   No other dependencies can be included in the build result.
-	 * @property {boolean} [flatOutput=false]
-	 *   Whether to write the build results into a flat directory structure, omitting the project
-	 *   namespace and the "resources" directory.
-	 *   This is currently only supported for projects of type 'library' and projects of type
-	 *   'application' always result in flat output.
+	 * @property {("Default"|"Flat"|"Namespace")} [outputStyle="Default"]
+	 *   Processes build results into a specific directory structure.
+	 *   "Flat" omits the project namespace and the \"resources\" directory. This
+	 *   is currently only supported for projects of type 'library'.
+	 *   Projects of type 'application' always result in a flat output.
 	 *   No other dependencies can be included in the build result.
 	 * @property {Array.<string>} [includedTasks=[]] List of tasks to be included
 	 * @property {Array.<string>} [excludedTasks=[]] List of tasks to be excluded.
@@ -172,13 +172,13 @@ class ProjectBuilder {
 		});
 
 		if (requestedProjects.length > 1) {
-			const {createBuildManifest, flatOutput} = this._buildContext.getBuildConfig();
+			const {createBuildManifest, outputStyle} = this._buildContext.getBuildConfig();
 			if (createBuildManifest) {
 				throw new Error(
 					`It is currently not supported to request the creation of a build manifest ` +
 					`while including any dependencies into the build result`);
 			}
-			if (flatOutput) {
+			if (outputStyle === "Flat") {
 				throw new Error(
 					`It is currently not supported to request flat build output ` +
 					`while including any dependencies into the build result`);
@@ -374,13 +374,13 @@ class ProjectBuilder {
 		const project = projectBuildContext.getProject();
 		const taskUtil = projectBuildContext.getTaskUtil();
 		const buildConfig = this._buildContext.getBuildConfig();
-		const {createBuildManifest, flatOutput} = buildConfig;
+		const {createBuildManifest, outputStyle} = buildConfig;
 
 		let readerStyle = "dist";
 		if (createBuildManifest) {
 			// Ensure buildtime (=namespaced) style when writing with a build manifest
 			readerStyle = "buildtime";
-		} else if (flatOutput) {
+		} else if (outputStyle === "Flat") {
 			readerStyle = "flat";
 		}
 
@@ -410,7 +410,7 @@ class ProjectBuilder {
 			return target.write(resource);
 		}));
 
-		if (flatOutput &&
+		if (outputStyle === "Flat" &&
 			project.getType() !== "application" /* application type is with a flat source structure */) {
 			const namespace = project.getNamespace();
 			const libraryResourcesPrefix = `/resources/${namespace}/`;
@@ -418,7 +418,7 @@ class ProjectBuilder {
 			const namespacedRegex = new RegExp(`/(resources|test-resources)/${namespace}`);
 			const processedResourcesSet = resources.reduce((acc, resource) => acc.add(resource.getPath()), new Set());
 
-			// If there's a flatOutput enabled, then the FlatReader would have filtered
+			// If outputStyle === "Flat", then the FlatReader would have filtered
 			// some resources. We now need to get all of the available resources and
 			// do an intersection with the processed/bundled ones.
 			const defaultReader = project.getReader();

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -27,8 +27,9 @@ class ProjectBuilder {
 	 * @property {boolean} [flatOutput=false]
 	 *   Whether to write the build results into a flat directory structure, omitting the project
 	 *   namespace and the "resources" directory.
-	 *   This is currently only supported for projects of type 'library'
+	 *   This is currently only supported for projects of type 'library'.
 	 *   No other dependencies can be included in the build result.
+	 *   Projects of type 'application' always result in flat output.
 	 * @property {Array.<string>} [includedTasks=[]] List of tasks to be included
 	 * @property {Array.<string>} [excludedTasks=[]] List of tasks to be excluded.
 	 * 			If the wildcard '*' is provided, only the included tasks will be executed.

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -27,9 +27,9 @@ class ProjectBuilder {
 	 * @property {boolean} [flatOutput=false]
 	 *   Whether to write the build results into a flat directory structure, omitting the project
 	 *   namespace and the "resources" directory.
-	 *   This is currently only supported for projects of type 'library'.
+	 *   This is currently only supported for projects of type 'library' and projects of type
+	 *   'application' always result in flat output.
 	 *   No other dependencies can be included in the build result.
-	 *   Projects of type 'application' always result in flat output.
 	 * @property {Array.<string>} [includedTasks=[]] List of tasks to be included
 	 * @property {Array.<string>} [excludedTasks=[]] List of tasks to be excluded.
 	 * 			If the wildcard '*' is provided, only the included tasks will be executed.

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -26,7 +26,7 @@ class ProjectBuilder {
 	 *   No other dependencies can be included in the build result.
 	 * @property {("Default"|"Flat"|"Namespace")} [outputStyle="Default"]
 	 *   Processes build results into a specific directory structure.
-	 *   "Flat" omits the project namespace and the \"resources\" directory. This
+	 *   "Flat" omits the project namespace and the "resources" directory. This
 	 *   is currently only supported for projects of type 'library'.
 	 *   Projects of type 'application' always result in a flat output.
 	 *   No other dependencies can be included in the build result.

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -407,7 +407,7 @@ class ProjectBuilder {
 
 		if (isRootProject &&
 			outputStyle === OutputStyleEnum.Flat &&
-			project.getType() !== "application" /* application type is with a flat source structure */) {
+			project.getType() !== "application" /* application type is with a default flat build output structure */) {
 			const namespace = project.getNamespace();
 			const libraryResourcesPrefix = `/resources/${namespace}/`;
 			const testResourcesPrefix = "/test-resources/";

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -4,6 +4,7 @@ import BuildLogger from "@ui5/logger/internal/loggers/Build";
 import composeProjectList from "./helpers/composeProjectList.js";
 import BuildContext from "./helpers/BuildContext.js";
 import prettyHrtime from "pretty-hrtime";
+import OutputStyleEnum from "./helpers/ProjectBuilderOutputStyle.js";
 
 /**
  * @public
@@ -24,7 +25,7 @@ class ProjectBuilder {
 	 *   Whether to create a build manifest file for the root project.
 	 *   This is currently only supported for projects of type 'library' and 'theme-library'
 	 *   No other dependencies can be included in the build result.
-	 * @property {("Default"|"Flat"|"Namespace")} [outputStyle="Default"]
+	 * @property {module:@ui5/project/build/ProjectBuilderOutputStyle} [outputStyle=Default]
 	 *   Processes build results into a specific directory structure.
 	 *   "Flat" omits the project namespace and the "resources" directory. This
 	 *   is currently only supported for projects of type 'library'.
@@ -178,7 +179,7 @@ class ProjectBuilder {
 					`It is currently not supported to request the creation of a build manifest ` +
 					`while including any dependencies into the build result`);
 			}
-			if (outputStyle === "Flat") {
+			if (outputStyle === OutputStyleEnum.Flat) {
 				throw new Error(
 					`It is currently not supported to request flat build output ` +
 					`while including any dependencies into the build result`);
@@ -380,7 +381,7 @@ class ProjectBuilder {
 		if (createBuildManifest) {
 			// Ensure buildtime (=namespaced) style when writing with a build manifest
 			readerStyle = "buildtime";
-		} else if (outputStyle === "Flat") {
+		} else if (outputStyle === OutputStyleEnum.Flat) {
 			readerStyle = "flat";
 		}
 
@@ -410,7 +411,7 @@ class ProjectBuilder {
 			return target.write(resource);
 		}));
 
-		if (outputStyle === "Flat" &&
+		if (outputStyle === OutputStyleEnum.Flat &&
 			project.getType() !== "application" /* application type is with a flat source structure */) {
 			const namespace = project.getNamespace();
 			const libraryResourcesPrefix = `/resources/${namespace}/`;

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -377,7 +377,7 @@ class ProjectBuilder {
 		let readerStyle = "dist";
 		if (createBuildManifest ||
 			(isRootProject && outputStyle === OutputStyleEnum.Namespace && project.getType() === "application")) {
-			// Ensure buildtime (=namespaced) style when writing with a build manifest
+			// Ensure buildtime (=namespaced) style when writing with a build manifest or when explicitly requested
 			readerStyle = "buildtime";
 		} else if (isRootProject && outputStyle === OutputStyleEnum.Flat) {
 			readerStyle = "flat";

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -409,6 +409,35 @@ class ProjectBuilder {
 			}
 			return target.write(resource);
 		}));
+
+		if (flatOutput) {
+			const namespacedRegex = new RegExp("/(resources|test-resources)/" + project.getNamespace());
+			const processedResourcesSet = resources.reduce((acc, resource) => acc.add(resource.getPath()), new Set());
+
+			const defaultReader = project.getReader();
+			const defaultResources = await defaultReader.byGlob("/**/*");
+			const flatDefaultResources = defaultResources.map((resource) => ({
+				flatResource: resource.getPath().replace(namespacedRegex, ""),
+				originalPath: resource.getPath(),
+			}));
+
+			const skippedResources = flatDefaultResources.filter((resource) => {
+				return processedResourcesSet.has(resource.flatResource) === false;
+			});
+
+			skippedResources.forEach((resource) => {
+				if (resource.originalPath.startsWith("/test-resources")) {
+					this.#log.verbose(
+						`Omitting ${resource.originalPath} from build result. File is part of /test-resources.`
+					);
+				} else {
+					this.#log.warn(
+						`Omitting ${resource.originalPath} from build result. ` +
+							`File is not within project namespace '${project.getNamespace()}'.`
+					);
+				}
+			});
+		}
 	}
 
 	async _executeCleanupTasks(force) {

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -24,6 +24,11 @@ class ProjectBuilder {
 	 *   Whether to create a build manifest file for the root project.
 	 *   This is currently only supported for projects of type 'library' and 'theme-library'
 	 *   No other dependencies can be included in the build result.
+	 * @property {boolean} [flatOutput=false]
+	 *   Whether to write the build results into a flat directory structure, omitting the project
+	 *   namespace and the "resources" directory.
+	 *   This is currently only supported for projects of type 'library' and 'theme-library'.
+	 *   No other dependencies can be included in the build result.
 	 * @property {Array.<string>} [includedTasks=[]] List of tasks to be included
 	 * @property {Array.<string>} [excludedTasks=[]] List of tasks to be excluded.
 	 * 			If the wildcard '*' is provided, only the included tasks will be executed.
@@ -165,10 +170,18 @@ class ProjectBuilder {
 			return filterProject(projectName);
 		});
 
-		if (this._buildContext.getBuildConfig().createBuildManifest && requestedProjects.length > 1) {
-			throw new Error(
-				`It is currently not supported to request the creation of a build manifest ` +
-				`while including any dependencies into the build result`);
+		if (requestedProjects.length > 1) {
+			const {createBuildManifest, flatOutput} = this._buildContext.getBuildConfig();
+			if (createBuildManifest) {
+				throw new Error(
+					`It is currently not supported to request the creation of a build manifest ` +
+					`while including any dependencies into the build result`);
+			}
+			if (flatOutput) {
+				throw new Error(
+					`It is currently not supported to request flat build output ` +
+					`while including any dependencies into the build result`);
+			}
 		}
 
 		const projectBuildContexts = await this._createRequiredBuildContexts(requestedProjects);
@@ -360,13 +373,22 @@ class ProjectBuilder {
 		const project = projectBuildContext.getProject();
 		const taskUtil = projectBuildContext.getTaskUtil();
 		const buildConfig = this._buildContext.getBuildConfig();
+		const {createBuildManifest, flatOutput} = buildConfig;
+
+		let readerStyle = "dist";
+		if (createBuildManifest) {
+			// Ensure buildtime (=namespaced) style when writing with a build manifest
+			readerStyle = "buildtime";
+		} else if (flatOutput) {
+			readerStyle = "flat";
+		}
+
 		const reader = project.getReader({
-			// Force buildtime (=namespaced) style when writing with a build manifest
-			style: taskUtil.isRootProject() && buildConfig.createBuildManifest ? "buildtime" : "dist"
+			style: readerStyle
 		});
 		const resources = await reader.byGlob("/**/*");
 
-		if (taskUtil.isRootProject() && buildConfig.createBuildManifest) {
+		if (createBuildManifest) {
 			// Create and write a build manifest metadata file
 			const {
 				default: createBuildManifest

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -378,7 +378,8 @@ class ProjectBuilder {
 		const {createBuildManifest, outputStyle} = buildConfig;
 
 		let readerStyle = "dist";
-		if (createBuildManifest) {
+		if (createBuildManifest ||
+			(outputStyle === OutputStyleEnum.Namespace && project.getType() === "application")) {
 			// Ensure buildtime (=namespaced) style when writing with a build manifest
 			readerStyle = "buildtime";
 		} else if (outputStyle === OutputStyleEnum.Flat) {

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -40,11 +40,6 @@ class BuildContext {
 				`Flat build output is currently not supported for projects of type ` +
 				graph.getRoot().getType());
 		}
-		if (![OutputStyleEnum.Default, OutputStyleEnum.Flat].includes(outputStyle) &&
-			["application"].includes(graph.getRoot().getType())) {
-			throw new Error(
-				`Projects of type ${graph.getRoot().getType()} support only flat output`);
-		}
 		if (createBuildManifest && outputStyle === OutputStyleEnum.Flat) {
 			throw new Error(
 				`Build manifest creation is not supported in conjunction with flat build output`);

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -12,7 +12,7 @@ class BuildContext {
 		cssVariables = false,
 		jsdoc = false,
 		createBuildManifest = false,
-		flatOutput,
+		outputStyle = "Default",
 		includedTasks = [], excludedTasks = [],
 	} = {}) {
 		if (!graph) {
@@ -34,16 +34,17 @@ class BuildContext {
 				`self-contained builds`);
 		}
 
-		if (flatOutput && !["library", "application"].includes(graph.getRoot().getType())) {
+		if (outputStyle === "Flat" && !["library", "application"].includes(graph.getRoot().getType())) {
 			throw new Error(
 				`Flat build output is currently not supported for projects of type ` +
 				graph.getRoot().getType());
 		}
-		if (flatOutput === false && ["application"].includes(graph.getRoot().getType())) {
+		if (!["Default", "Flat"].includes(outputStyle) &&
+			["application"].includes(graph.getRoot().getType())) {
 			throw new Error(
 				`Projects of type ${graph.getRoot().getType()} support only flat output`);
 		}
-		if (createBuildManifest && flatOutput) {
+		if (createBuildManifest && outputStyle === "Flat") {
 			throw new Error(
 				`Build manifest creation is not supported in conjunction with flat build output`);
 		}
@@ -51,14 +52,13 @@ class BuildContext {
 
 		// Enforce boolean and default value, but do it here as we're also interested
 		// in the initial value above
-		flatOutput = !!flatOutput || false;
 		this._graph = graph;
 		this._buildConfig = {
 			selfContained,
 			cssVariables,
 			jsdoc,
 			createBuildManifest,
-			flatOutput,
+			outputStyle,
 			includedTasks,
 			excludedTasks,
 		};

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -23,10 +23,12 @@ class BuildContext {
 			throw new Error(`Missing parameter 'taskRepository'`);
 		}
 
-		if (createBuildManifest && !["library", "theme-library"].includes(graph.getRoot().getType())) {
+		const rootProjectType = graph.getRoot().getType();
+
+		if (createBuildManifest && !["library", "theme-library"].includes(rootProjectType)) {
 			throw new Error(
 				`Build manifest creation is currently not supported for projects of type ` +
-				graph.getRoot().getType());
+				rootProjectType);
 		}
 
 		if (createBuildManifest && selfContained) {
@@ -35,14 +37,25 @@ class BuildContext {
 				`self-contained builds`);
 		}
 
-		if (outputStyle === OutputStyleEnum.Flat && !["library", "application"].includes(graph.getRoot().getType())) {
-			throw new Error(
-				`Flat build output is currently not supported for projects of type ` +
-				graph.getRoot().getType());
-		}
 		if (createBuildManifest && outputStyle === OutputStyleEnum.Flat) {
 			throw new Error(
 				`Build manifest creation is not supported in conjunction with flat build output`);
+		}
+		if (outputStyle !== OutputStyleEnum.Default) {
+			if (rootProjectType === "theme-library") {
+				throw new Error(
+					`${outputStyle} build output is currently not supported` +
+						` since a theme-library almost always has more than one namespace.` +
+						`You can use only the Default build output for this project type.`
+				);
+			}
+			if (rootProjectType === "module") {
+				throw new Error(
+					`${outputStyle} build output is currently not supported` +
+						` since modules have explicit path mappings configured and no namespace concept.` +
+						`You can use only the Default build output for this project type.`
+				);
+			}
 		}
 
 

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -51,9 +51,9 @@ class BuildContext {
 			}
 			if (rootProjectType === "module") {
 				throw new Error(
-					`${outputStyle} build output is currently not supported` +
-						` since modules have explicit path mappings configured and no namespace concept.` +
-						`You can use only the Default build output for this project type.`
+					`${outputStyle} build output style is currently not supported for projects of type` +
+						`module. Their path mappings configuration can't be mapped to any namespace.` +
+						`Currently only the Default output style is supported for this project type.`
 				);
 			}
 		}

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -1,4 +1,5 @@
 import ProjectBuildContext from "./ProjectBuildContext.js";
+import OutputStyleEnum from "./ProjectBuilderOutputStyle.js";
 
 /**
  * Context of a build process
@@ -12,7 +13,7 @@ class BuildContext {
 		cssVariables = false,
 		jsdoc = false,
 		createBuildManifest = false,
-		outputStyle = "Default",
+		outputStyle = OutputStyleEnum.Default,
 		includedTasks = [], excludedTasks = [],
 	} = {}) {
 		if (!graph) {
@@ -34,17 +35,17 @@ class BuildContext {
 				`self-contained builds`);
 		}
 
-		if (outputStyle === "Flat" && !["library", "application"].includes(graph.getRoot().getType())) {
+		if (outputStyle === OutputStyleEnum.Flat && !["library", "application"].includes(graph.getRoot().getType())) {
 			throw new Error(
 				`Flat build output is currently not supported for projects of type ` +
 				graph.getRoot().getType());
 		}
-		if (!["Default", "Flat"].includes(outputStyle) &&
+		if (![OutputStyleEnum.Default, OutputStyleEnum.Flat].includes(outputStyle) &&
 			["application"].includes(graph.getRoot().getType())) {
 			throw new Error(
 				`Projects of type ${graph.getRoot().getType()} support only flat output`);
 		}
-		if (createBuildManifest && outputStyle === "Flat") {
+		if (createBuildManifest && outputStyle === OutputStyleEnum.Flat) {
 			throw new Error(
 				`Build manifest creation is not supported in conjunction with flat build output`);
 		}

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -12,6 +12,7 @@ class BuildContext {
 		cssVariables = false,
 		jsdoc = false,
 		createBuildManifest = false,
+		flatOutput = false,
 		includedTasks = [], excludedTasks = [],
 	} = {}) {
 		if (!graph) {
@@ -33,12 +34,23 @@ class BuildContext {
 				`self-contained builds`);
 		}
 
+		if (flatOutput && !["library", "theme-library"].includes(graph.getRoot().getType())) {
+			throw new Error(
+				`Flat build output is currently not supported for projects of type ` +
+				graph.getRoot().getType());
+		}
+		if (createBuildManifest && flatOutput) {
+			throw new Error(
+				`Build manifest creation is not supported in conjunction with flat build output`);
+		}
+
 		this._graph = graph;
 		this._buildConfig = {
 			selfContained,
 			cssVariables,
 			jsdoc,
 			createBuildManifest,
+			flatOutput,
 			includedTasks,
 			excludedTasks,
 		};

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -34,7 +34,7 @@ class BuildContext {
 				`self-contained builds`);
 		}
 
-		if (flatOutput && !["library", "theme-library"].includes(graph.getRoot().getType())) {
+		if (flatOutput && !["library"].includes(graph.getRoot().getType())) {
 			throw new Error(
 				`Flat build output is currently not supported for projects of type ` +
 				graph.getRoot().getType());

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -12,7 +12,7 @@ class BuildContext {
 		cssVariables = false,
 		jsdoc = false,
 		createBuildManifest = false,
-		flatOutput = false,
+		flatOutput,
 		includedTasks = [], excludedTasks = [],
 	} = {}) {
 		if (!graph) {
@@ -34,16 +34,24 @@ class BuildContext {
 				`self-contained builds`);
 		}
 
-		if (flatOutput && !["library"].includes(graph.getRoot().getType())) {
+		if (flatOutput && !["library", "application"].includes(graph.getRoot().getType())) {
 			throw new Error(
 				`Flat build output is currently not supported for projects of type ` +
 				graph.getRoot().getType());
+		}
+		if (flatOutput === false && ["application"].includes(graph.getRoot().getType())) {
+			throw new Error(
+				`Projects of type ${graph.getRoot().getType()} support only flat output`);
 		}
 		if (createBuildManifest && flatOutput) {
 			throw new Error(
 				`Build manifest creation is not supported in conjunction with flat build output`);
 		}
 
+
+		// Enforce boolean and default value, but do it here as we're also interested
+		// in the initial value above
+		flatOutput = !!flatOutput || false;
 		this._graph = graph;
 		this._buildConfig = {
 			selfContained,

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -44,9 +44,9 @@ class BuildContext {
 		if (outputStyle !== OutputStyleEnum.Default) {
 			if (rootProjectType === "theme-library") {
 				throw new Error(
-					`${outputStyle} build output is currently not supported` +
-						` since a theme-library almost always has more than one namespace.` +
-						`You can use only the Default build output for this project type.`
+					`${outputStyle} build output style is currently not supported for projects of type` +
+						`theme-library since they commonly have more than one namespace. ` +
+						`Currently only the Default output style is supported for this project type.`
 				);
 			}
 			if (rootProjectType === "module") {

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -58,9 +58,6 @@ class BuildContext {
 			}
 		}
 
-
-		// Enforce boolean and default value, but do it here as we're also interested
-		// in the initial value above
 		this._graph = graph;
 		this._buildConfig = {
 			selfContained,

--- a/lib/build/helpers/ProjectBuilderOutputStyle.js
+++ b/lib/build/helpers/ProjectBuilderOutputStyle.js
@@ -1,0 +1,18 @@
+/**
+ * Processes build results into a specific directory structure.
+ *
+ * @public
+ * @readonly
+ * @enum {string}
+ * @property {string} Default Default directory structure for every project type.
+ *     For applications: "Flat", for libraries: "Namespace", for theme-libraries: "Namespace", etc.
+ * @property {string} Flat Omits the project namespace and the "resources" directory.
+ * @property {string} Namespace Respects project namespace and the "resources" directory.
+ *     Not applicable for projects of type 'application'.
+ * @module @ui5/project/build/ProjectBuilderOutputStyle
+ */
+export default {
+	Default: "Default",
+	Flat: "Flat",
+	Namespace: "Namespace"
+};

--- a/lib/build/helpers/ProjectBuilderOutputStyle.js
+++ b/lib/build/helpers/ProjectBuilderOutputStyle.js
@@ -5,7 +5,8 @@
  * @readonly
  * @enum {string}
  * @property {string} Default Default directory structure for every project type.
- *     For applications this is identical to "Flat" and for libraries to "Namespace". Other types have a more distinct default output style.
+ *     For applications this is identical to "Flat" and for libraries to "Namespace".
+ *     Other types have a more distinct default output style.
  * @property {string} Flat Omits the project namespace and the "resources" directory.
  * @property {string} Namespace Respects project namespace and the "resources" directory.
  * @module @ui5/project/build/ProjectBuilderOutputStyle

--- a/lib/build/helpers/ProjectBuilderOutputStyle.js
+++ b/lib/build/helpers/ProjectBuilderOutputStyle.js
@@ -4,7 +4,7 @@
  * @public
  * @readonly
  * @enum {string}
- * @property {string} Default Default directory structure for every project type.
+ * @property {string} Default The default directory structure for every project type.
  *     For applications this is identical to "Flat" and for libraries to "Namespace".
  *     Other types have a more distinct default output style.
  * @property {string} Flat Omits the project namespace and the "resources" directory.

--- a/lib/build/helpers/ProjectBuilderOutputStyle.js
+++ b/lib/build/helpers/ProjectBuilderOutputStyle.js
@@ -8,7 +8,6 @@
  *     For applications this is identical to "Flat" and for libraries to "Namespace". Other types have a more distinct default output style.
  * @property {string} Flat Omits the project namespace and the "resources" directory.
  * @property {string} Namespace Respects project namespace and the "resources" directory.
- *     Not applicable for projects of type 'application'.
  * @module @ui5/project/build/ProjectBuilderOutputStyle
  */
 export default {

--- a/lib/build/helpers/ProjectBuilderOutputStyle.js
+++ b/lib/build/helpers/ProjectBuilderOutputStyle.js
@@ -5,7 +5,7 @@
  * @readonly
  * @enum {string}
  * @property {string} Default Default directory structure for every project type.
- *     For applications: "Flat", for libraries: "Namespace", for theme-libraries: "Namespace", etc.
+ *     For applications this is identical to "Flat" and for libraries to "Namespace". Other types have a more distinct default output style.
  * @property {string} Flat Omits the project namespace and the "resources" directory.
  * @property {string} Namespace Respects project namespace and the "resources" directory.
  *     Not applicable for projects of type 'application'.

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -540,11 +540,11 @@ class ProjectGraph {
 	 *			This is currently only supported for projects of type 'library' and 'theme-library'
 	 * @param {Array.<string>} [parameters.includedTasks=[]] List of tasks to be included
 	 * @param {Array.<string>} [parameters.excludedTasks=[]] List of tasks to be excluded.
-	 * @param {boolean} [parameters.flatOutput=false]
-	 *   Whether to write the build results into a flat directory structure, omitting the project
-	 *   namespace and the "resources" directory.
-	 *   This is currently only supported for projects of type 'library' and projects of type
-	 *   'application' always result in flat output.
+	 * @property {("Default"|"Flat"|"Namespace")} [outputStyle="Default"]
+	 *   Processes build results into a specific directory structure.
+	 *   "Flat" omits the project namespace and the \"resources\" directory. This
+	 *   is currently only supported for projects of type 'library'.
+	 *   Projects of type 'application' always result in a flat output.
 	 *   No other dependencies can be included in the build result.
 	 * @returns {Promise} Promise resolving to <code>undefined</code> once build has finished
 	 */
@@ -554,7 +554,7 @@ class ProjectGraph {
 		dependencyIncludes,
 		selfContained = false, cssVariables = false, jsdoc = false, createBuildManifest = false,
 		includedTasks = [], excludedTasks = [],
-		flatOutput /* default value (false) is defined in BuildContext if not set explicitly as an argument */
+		outputStyle /* default value (false) is defined in BuildContext if not set explicitly as an argument */
 	}) {
 		this.seal(); // Do not allow further changes to the graph
 		if (this._built) {
@@ -572,7 +572,7 @@ class ProjectGraph {
 			buildConfig: {
 				selfContained, cssVariables, jsdoc,
 				createBuildManifest,
-				includedTasks, excludedTasks, flatOutput,
+				includedTasks, excludedTasks, outputStyle,
 			}
 		});
 		await builder.build({

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -543,7 +543,8 @@ class ProjectGraph {
 	 * @param {boolean} [parameters.flatOutput=false]
 	 *   Whether to write the build results into a flat directory structure, omitting the project
 	 *   namespace and the "resources" directory.
-	 *   This is currently only supported for projects of type 'library'
+	 *   This is currently only supported for projects of type 'library' and projects of type
+	 *   'application' always result in flat output.
 	 *   No other dependencies can be included in the build result.
 	 * @returns {Promise} Promise resolving to <code>undefined</code> once build has finished
 	 */

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -540,7 +540,11 @@ class ProjectGraph {
 	 *			This is currently only supported for projects of type 'library' and 'theme-library'
 	 * @param {Array.<string>} [parameters.includedTasks=[]] List of tasks to be included
 	 * @param {Array.<string>} [parameters.excludedTasks=[]] List of tasks to be excluded.
-	 * 			If the wildcard '*' is provided, only the included tasks will be executed.
+	 * @param {boolean} [parameters.flatOutput=false]
+	 *   Whether to write the build results into a flat directory structure, omitting the project
+	 *   namespace and the "resources" directory.
+	 *   This is currently only supported for projects of type 'library'
+	 *   No other dependencies can be included in the build result.
 	 * @returns {Promise} Promise resolving to <code>undefined</code> once build has finished
 	 */
 	async build({
@@ -548,7 +552,7 @@ class ProjectGraph {
 		includedDependencies = [], excludedDependencies = [],
 		dependencyIncludes,
 		selfContained = false, cssVariables = false, jsdoc = false, createBuildManifest = false,
-		includedTasks = [], excludedTasks = []
+		includedTasks = [], excludedTasks = [], flatOutput = false
 	}) {
 		this.seal(); // Do not allow further changes to the graph
 		if (this._built) {
@@ -566,7 +570,7 @@ class ProjectGraph {
 			buildConfig: {
 				selfContained, cssVariables, jsdoc,
 				createBuildManifest,
-				includedTasks, excludedTasks,
+				includedTasks, excludedTasks, flatOutput,
 			}
 		});
 		await builder.build({

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -540,7 +540,7 @@ class ProjectGraph {
 	 *			This is currently only supported for projects of type 'library' and 'theme-library'
 	 * @param {Array.<string>} [parameters.includedTasks=[]] List of tasks to be included
 	 * @param {Array.<string>} [parameters.excludedTasks=[]] List of tasks to be excluded.
-	 * @property {("Default"|"Flat"|"Namespace")} [outputStyle="Default"]
+	 * @param {("Default"|"Flat"|"Namespace")} [parameters.outputStyle="Default"]
 	 *   Processes build results into a specific directory structure.
 	 *   "Flat" omits the project namespace and the \"resources\" directory. This
 	 *   is currently only supported for projects of type 'library'.

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -544,10 +544,6 @@ class ProjectGraph {
 	 * @param {Array.<string>} [parameters.excludedTasks=[]] List of tasks to be excluded.
 	 * @param {module:@ui5/project/build/ProjectBuilderOutputStyle} [parameters.outputStyle=Default]
 	 *   Processes build results into a specific directory structure.
-	 *   "Flat" omits the project namespace and the "resources" directory. This
-	 *   is currently only supported for projects of type 'library'.
-	 *   Projects of type 'application' always result in a flat output.
-	 *   No other dependencies can be included in the build result.
 	 * @returns {Promise} Promise resolving to <code>undefined</code> once build has finished
 	 */
 	async build({

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -1,5 +1,7 @@
+import OutputStyleEnum from "../build/helpers/ProjectBuilderOutputStyle.js";
 import {getLogger} from "@ui5/logger";
 const log = getLogger("graph:ProjectGraph");
+
 
 /**
  * A rooted, directed graph representing a UI5 project, its dependencies and available extensions.
@@ -540,7 +542,7 @@ class ProjectGraph {
 	 *			This is currently only supported for projects of type 'library' and 'theme-library'
 	 * @param {Array.<string>} [parameters.includedTasks=[]] List of tasks to be included
 	 * @param {Array.<string>} [parameters.excludedTasks=[]] List of tasks to be excluded.
-	 * @param {("Default"|"Flat"|"Namespace")} [parameters.outputStyle="Default"]
+	 * @param {module:@ui5/project/build/ProjectBuilderOutputStyle} [parameters.outputStyle=Default]
 	 *   Processes build results into a specific directory structure.
 	 *   "Flat" omits the project namespace and the "resources" directory. This
 	 *   is currently only supported for projects of type 'library'.
@@ -554,7 +556,7 @@ class ProjectGraph {
 		dependencyIncludes,
 		selfContained = false, cssVariables = false, jsdoc = false, createBuildManifest = false,
 		includedTasks = [], excludedTasks = [],
-		outputStyle = "Default"
+		outputStyle = OutputStyleEnum.Default
 	}) {
 		this.seal(); // Do not allow further changes to the graph
 		if (this._built) {

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -542,7 +542,7 @@ class ProjectGraph {
 	 * @param {Array.<string>} [parameters.excludedTasks=[]] List of tasks to be excluded.
 	 * @param {("Default"|"Flat"|"Namespace")} [parameters.outputStyle="Default"]
 	 *   Processes build results into a specific directory structure.
-	 *   "Flat" omits the project namespace and the \"resources\" directory. This
+	 *   "Flat" omits the project namespace and the "resources" directory. This
 	 *   is currently only supported for projects of type 'library'.
 	 *   Projects of type 'application' always result in a flat output.
 	 *   No other dependencies can be included in the build result.
@@ -554,7 +554,7 @@ class ProjectGraph {
 		dependencyIncludes,
 		selfContained = false, cssVariables = false, jsdoc = false, createBuildManifest = false,
 		includedTasks = [], excludedTasks = [],
-		outputStyle /* default value (false) is defined in BuildContext if not set explicitly as an argument */
+		outputStyle = "Default"
 	}) {
 		this.seal(); // Do not allow further changes to the graph
 		if (this._built) {

--- a/lib/graph/ProjectGraph.js
+++ b/lib/graph/ProjectGraph.js
@@ -552,7 +552,8 @@ class ProjectGraph {
 		includedDependencies = [], excludedDependencies = [],
 		dependencyIncludes,
 		selfContained = false, cssVariables = false, jsdoc = false, createBuildManifest = false,
-		includedTasks = [], excludedTasks = [], flatOutput = false
+		includedTasks = [], excludedTasks = [],
+		flatOutput /* default value (false) is defined in BuildContext if not set explicitly as an argument */
 	}) {
 		this.seal(); // Do not allow further changes to the graph
 		if (this._built) {

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -508,7 +508,7 @@ test("_writeResults", async (t) => {
 		}
 	});
 
-	const dummyResources = [{
+	const mockResources = [{
 		_resourceName: "resource.a",
 		getPath: () => "resource.a"
 	}, {
@@ -518,7 +518,7 @@ test("_writeResults", async (t) => {
 		_resourceName: "resource.c",
 		getPath: () => "resource.c"
 	}];
-	const byGlobStub = sinon.stub().resolves(dummyResources);
+	const byGlobStub = sinon.stub().resolves(mockResources);
 	const getReaderStub = sinon.stub().returns({
 		byGlob: byGlobStub
 	});
@@ -553,16 +553,16 @@ test("_writeResults", async (t) => {
 	t.is(byGlobStub.getCall(0).args[0], "/**/*", "byGlob called with expected pattern");
 
 	t.is(getTagStub.callCount, 3, "TaskUtil#getTag got called three times");
-	t.is(getTagStub.getCall(0).args[0], dummyResources[0], "TaskUtil#getTag called with first resource");
+	t.is(getTagStub.getCall(0).args[0], mockResources[0], "TaskUtil#getTag called with first resource");
 	t.is(getTagStub.getCall(0).args[1], "OmitFromBuildResultTag", "TaskUtil#getTag called with correct tag value");
-	t.is(getTagStub.getCall(1).args[0], dummyResources[1], "TaskUtil#getTag called with second resource");
+	t.is(getTagStub.getCall(1).args[0], mockResources[1], "TaskUtil#getTag called with second resource");
 	t.is(getTagStub.getCall(1).args[1], "OmitFromBuildResultTag", "TaskUtil#getTag called with correct tag value");
-	t.is(getTagStub.getCall(2).args[0], dummyResources[2], "TaskUtil#getTag called with third resource");
+	t.is(getTagStub.getCall(2).args[0], mockResources[2], "TaskUtil#getTag called with third resource");
 	t.is(getTagStub.getCall(2).args[1], "OmitFromBuildResultTag", "TaskUtil#getTag called with correct tag value");
 
 	t.is(writerMock.write.callCount, 2, "Write got called twice");
-	t.is(writerMock.write.getCall(0).args[0], dummyResources[1], "Write got called with second resource");
-	t.is(writerMock.write.getCall(1).args[0], dummyResources[2], "Write got called with third resource");
+	t.is(writerMock.write.getCall(0).args[0], mockResources[1], "Write got called with second resource");
+	t.is(writerMock.write.getCall(1).args[0], mockResources[2], "Write got called with third resource");
 });
 
 test.serial("_writeResults: Create build manifest", async (t) => {
@@ -587,7 +587,7 @@ test.serial("_writeResults: Create build manifest", async (t) => {
 		}
 	});
 
-	const dummyResources = [{
+	const mockResources = [{
 		_resourceName: "resource.a",
 		getPath: () => "resource.a"
 	}, {
@@ -597,7 +597,7 @@ test.serial("_writeResults: Create build manifest", async (t) => {
 		_resourceName: "resource.c",
 		getPath: () => "resource.c"
 	}];
-	const byGlobStub = sinon.stub().resolves(dummyResources);
+	const byGlobStub = sinon.stub().resolves(mockResources);
 	const getReaderStub = sinon.stub().returns({
 		byGlob: byGlobStub
 	});
@@ -636,6 +636,7 @@ test.serial("_writeResults: Create build manifest", async (t) => {
 		"createBuildManifest got called with correct project");
 	t.deepEqual(createBuildManifestStub.getCall(0).args[1], {
 		createBuildManifest: true,
+		flatOutput: false,
 		cssVariables: false,
 		excludedTasks: [],
 		includedTasks: [],
@@ -652,50 +653,57 @@ test.serial("_writeResults: Create build manifest", async (t) => {
 	}, "Build manifest resource has been created with correct arguments");
 
 	t.is(getTagStub.callCount, 3, "TaskUtil#getTag got called three times");
-	t.is(getTagStub.getCall(0).args[0], dummyResources[0], "TaskUtil#getTag called with first resource");
+	t.is(getTagStub.getCall(0).args[0], mockResources[0], "TaskUtil#getTag called with first resource");
 	t.is(getTagStub.getCall(0).args[1], "OmitFromBuildResultTag", "TaskUtil#getTag called with correct tag value");
-	t.is(getTagStub.getCall(1).args[0], dummyResources[1], "TaskUtil#getTag called with second resource");
+	t.is(getTagStub.getCall(1).args[0], mockResources[1], "TaskUtil#getTag called with second resource");
 	t.is(getTagStub.getCall(1).args[1], "OmitFromBuildResultTag", "TaskUtil#getTag called with correct tag value");
-	t.is(getTagStub.getCall(2).args[0], dummyResources[2], "TaskUtil#getTag called with third resource");
+	t.is(getTagStub.getCall(2).args[0], mockResources[2], "TaskUtil#getTag called with third resource");
 	t.is(getTagStub.getCall(2).args[1], "OmitFromBuildResultTag", "TaskUtil#getTag called with correct tag value");
 
 	t.is(writerMock.write.callCount, 3, "Write got called three times");
 	t.is(writerMock.write.getCall(0).args[0], "build manifest resource", "Write got called with build manifest");
-	t.is(writerMock.write.getCall(1).args[0], dummyResources[1], "Write got called with second resource");
-	t.is(writerMock.write.getCall(2).args[0], dummyResources[2], "Write got called with third resource");
+	t.is(writerMock.write.getCall(1).args[0], mockResources[1], "Write got called with second resource");
+	t.is(writerMock.write.getCall(2).args[0], mockResources[2], "Write got called with third resource");
 
 	esmock.purge(ProjectBuilder);
 });
 
-test("_writeResults: Do not create build manifest for non-root project", async (t) => {
-	const {ProjectBuilder, sinon} = t.context;
+test.serial("_writeResults: Flat build output", async (t) => {
+	const {sinon, ProjectBuilder} = t.context;
 	t.context.getRootTypeStub = sinon.stub().returns("library");
 	const {graph, taskRepository} = t.context;
 
 	const builder = new ProjectBuilder({
 		graph, taskRepository,
 		buildConfig: {
-			createBuildManifest: true
+			flatOutput: true,
+			otherBuildConfig: "yes"
 		}
 	});
 
-	const dummyResources = [{
+	const mockResources = [{
 		_resourceName: "resource.a",
 		getPath: () => "resource.a"
+	}, {
+		_resourceName: "resource.b",
+		getPath: () => "resource.b"
+	}, {
+		_resourceName: "resource.c",
+		getPath: () => "resource.c"
 	}];
-	const byGlobStub = sinon.stub().resolves(dummyResources);
+	const byGlobStub = sinon.stub().resolves(mockResources);
 	const getReaderStub = sinon.stub().returns({
 		byGlob: byGlobStub
 	});
 	const mockProject = getMockProject("library", "c");
 	mockProject.getReader = getReaderStub;
 
-	const getTagStub = sinon.stub().returns(false);
+	const getTagStub = sinon.stub().returns(false).onFirstCall().returns(true);
 	const projectBuildContextMock = {
 		getProject: () => mockProject,
 		getTaskUtil: () => {
 			return {
-				isRootProject: () => false,
+				isRootProject: () => true,
 				getTag: getTagStub,
 				STANDARD_TAGS: {
 					OmitFromBuildResult: "OmitFromBuildResultTag"
@@ -711,14 +719,25 @@ test("_writeResults: Do not create build manifest for non-root project", async (
 
 	t.is(getReaderStub.callCount, 1, "One reader requested");
 	t.deepEqual(getReaderStub.getCall(0).args[0], {
-		style: "dist"
+		style: "flat"
 	}, "Reader requested expected style");
 
-	t.is(getTagStub.callCount, 1, "TaskUtil#getTag got called once");
+	t.is(byGlobStub.callCount, 1, "One byGlob call");
+	t.is(byGlobStub.getCall(0).args[0], "/**/*", "byGlob called with expected pattern");
 
-	t.is(writerMock.write.callCount, 1, "Write got called once");
-	t.is(writerMock.write.getCall(0).args[0], dummyResources[0], "Write got called with only resource");
+	t.is(getTagStub.callCount, 3, "TaskUtil#getTag got called three times");
+	t.is(getTagStub.getCall(0).args[0], mockResources[0], "TaskUtil#getTag called with first resource");
+	t.is(getTagStub.getCall(0).args[1], "OmitFromBuildResultTag", "TaskUtil#getTag called with correct tag value");
+	t.is(getTagStub.getCall(1).args[0], mockResources[1], "TaskUtil#getTag called with second resource");
+	t.is(getTagStub.getCall(1).args[1], "OmitFromBuildResultTag", "TaskUtil#getTag called with correct tag value");
+	t.is(getTagStub.getCall(2).args[0], mockResources[2], "TaskUtil#getTag called with third resource");
+	t.is(getTagStub.getCall(2).args[1], "OmitFromBuildResultTag", "TaskUtil#getTag called with correct tag value");
+
+	t.is(writerMock.write.callCount, 2, "Write got called twice");
+	t.is(writerMock.write.getCall(0).args[0], mockResources[1], "Write got called with second resource");
+	t.is(writerMock.write.getCall(1).args[0], mockResources[2], "Write got called with third resource");
 });
+
 
 test("_executeCleanupTasks", async (t) => {
 	const {graph, taskRepository, ProjectBuilder, sinon} = t.context;

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -3,6 +3,7 @@ import sinonGlobal from "sinon";
 import path from "node:path";
 import esmock from "esmock";
 import {setLogLevel} from "@ui5/logger";
+import OutputStyleEnum from "../../../lib/build/helpers/ProjectBuilderOutputStyle.js";
 
 function noop() {}
 
@@ -636,7 +637,7 @@ test.serial("_writeResults: Create build manifest", async (t) => {
 		"createBuildManifest got called with correct project");
 	t.deepEqual(createBuildManifestStub.getCall(0).args[1], {
 		createBuildManifest: true,
-		outputStyle: "Default",
+		outputStyle: OutputStyleEnum.Default,
 		cssVariables: false,
 		excludedTasks: [],
 		includedTasks: [],
@@ -676,7 +677,7 @@ test.serial("_writeResults: Flat build output", async (t) => {
 	const builder = new ProjectBuilder({
 		graph, taskRepository,
 		buildConfig: {
-			outputStyle: "Flat",
+			outputStyle: OutputStyleEnum.Flat,
 			otherBuildConfig: "yes"
 		}
 	});

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -696,7 +696,7 @@ test.serial("_writeResults: Flat build output", async (t) => {
 	const getReaderStub = sinon.stub().returns({
 		byGlob: byGlobStub
 	});
-	const mockProject = getMockProject("library", "c");
+	const mockProject = getMockProject("library", "a");
 	mockProject.getReader = getReaderStub;
 
 	const getTagStub = sinon.stub().returns(false).onFirstCall().returns(true);

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -636,7 +636,7 @@ test.serial("_writeResults: Create build manifest", async (t) => {
 		"createBuildManifest got called with correct project");
 	t.deepEqual(createBuildManifestStub.getCall(0).args[1], {
 		createBuildManifest: true,
-		flatOutput: false,
+		outputStyle: "Default",
 		cssVariables: false,
 		excludedTasks: [],
 		includedTasks: [],
@@ -676,7 +676,7 @@ test.serial("_writeResults: Flat build output", async (t) => {
 	const builder = new ProjectBuilder({
 		graph, taskRepository,
 		buildConfig: {
-			flatOutput: true,
+			outputStyle: "Flat",
 			otherBuildConfig: "yes"
 		}
 	});

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -717,12 +717,12 @@ test.serial("_writeResults: Flat build output", async (t) => {
 
 	await builder._writeResults(projectBuildContextMock, writerMock);
 
-	t.is(getReaderStub.callCount, 1, "One reader requested");
+	t.is(getReaderStub.callCount, 2, "One reader requested");
 	t.deepEqual(getReaderStub.getCall(0).args[0], {
 		style: "flat"
 	}, "Reader requested expected style");
 
-	t.is(byGlobStub.callCount, 1, "One byGlob call");
+	t.is(byGlobStub.callCount, 2, "One byGlob call");
 	t.is(byGlobStub.getCall(0).args[0], "/**/*", "byGlob called with expected pattern");
 
 	t.is(getTagStub.callCount, 3, "TaskUtil#getTag got called three times");

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -23,27 +23,38 @@ test("Missing parameters", (t) => {
 });
 
 test("getRootProject", (t) => {
-	const buildContext = new BuildContext({
-		getRoot: () => "pony"
-	}, "taskRepository");
+	const rootProjectStub = sinon.stub()
+		.onFirstCall().returns({getType: () => "library"})
+		.returns("pony");
+	const graph = {getRoot: rootProjectStub};
+	const buildContext = new BuildContext(graph, "taskRepository");
 
 	t.is(buildContext.getRootProject(), "pony", "Returned correct value");
 });
 
 test("getGraph", (t) => {
-	const buildContext = new BuildContext("graph", "taskRepository");
+	const graph = {
+		getRoot: () => ({getType: () => "library"}),
+	};
+	const buildContext = new BuildContext(graph, "taskRepository");
 
-	t.is(buildContext.getGraph(), "graph", "Returned correct value");
+	t.deepEqual(buildContext.getGraph(), graph, "Returned correct value");
 });
 
 test("getTaskRepository", (t) => {
-	const buildContext = new BuildContext("graph", "taskRepository");
+	const graph = {
+		getRoot: () => ({getType: () => "library"}),
+	};
+	const buildContext = new BuildContext(graph, "taskRepository");
 
 	t.is(buildContext.getTaskRepository(), "taskRepository", "Returned correct value");
 });
 
 test("getBuildConfig: Default values", (t) => {
-	const buildContext = new BuildContext("graph", "taskRepository");
+	const graph = {
+		getRoot: () => ({getType: () => "library"}),
+	};
+	const buildContext = new BuildContext(graph, "taskRepository");
 
 	t.deepEqual(buildContext.getBuildConfig(), {
 		selfContained: false,
@@ -193,8 +204,8 @@ test("outputStyle='Flat' not supported for type theme-library", (t) => {
 		});
 	});
 	t.is(err.message,
-		"Flat build output is currently not supported for projects of type theme-library",
-		"Threw with expected error message");
+		"Flat build output is currently not supported since a theme-library " +
+		"almost always has more than one namespace.You can use only the Default build output for this project type.");
 });
 
 test("outputStyle='Flat' not supported for type module", (t) => {
@@ -210,8 +221,9 @@ test("outputStyle='Flat' not supported for type module", (t) => {
 		});
 	});
 	t.is(err.message,
-		"Flat build output is currently not supported for projects of type module",
-		"Threw with expected error message");
+		"Flat build output is currently not supported since modules have"+
+		" explicit path mappings configured and no namespace concept.You can use only "+
+		"the Default build output for this project type.");
 });
 
 test("outputStyle='Flat' not supported for createBuildManifest build", (t) => {
@@ -233,7 +245,10 @@ test("outputStyle='Flat' not supported for createBuildManifest build", (t) => {
 });
 
 test("getOption", (t) => {
-	const buildContext = new BuildContext("graph", "taskRepository", {
+	const graph = {
+		getRoot: () => ({getType: () => "library"}),
+	};
+	const buildContext = new BuildContext(graph, "taskRepository", {
 		cssVariables: "value",
 	});
 
@@ -245,7 +260,10 @@ test("getOption", (t) => {
 });
 
 test("createProjectContext", async (t) => {
-	const buildContext = new BuildContext("graph", "taskRepository");
+	const graph = {
+		getRoot: () => ({getType: () => "library"}),
+	};
+	const buildContext = new BuildContext(graph, "taskRepository");
 	const projectBuildContext = await buildContext.createProjectContext({
 		project: {
 			getName: () => "project",
@@ -258,7 +276,10 @@ test("createProjectContext", async (t) => {
 });
 
 test("executeCleanupTasks", async (t) => {
-	const buildContext = new BuildContext("graph", "taskRepository");
+	const graph = {
+		getRoot: () => ({getType: () => "library"}),
+	};
+	const buildContext = new BuildContext(graph, "taskRepository");
 
 	const executeCleanupTasks = sinon.stub().resolves();
 

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -46,7 +46,7 @@ test("getBuildConfig: Default values", (t) => {
 
 	t.deepEqual(buildContext.getBuildConfig(), {
 		selfContained: false,
-		flatOutput: false,
+		outputStyle: "Default",
 		cssVariables: false,
 		jsdoc: false,
 		createBuildManifest: false,
@@ -64,7 +64,7 @@ test("getBuildConfig: Custom values", (t) => {
 		}
 	}, "taskRepository", {
 		selfContained: true,
-		flatOutput: false,
+		outputStyle: "Namespace",
 		cssVariables: true,
 		jsdoc: true,
 		createBuildManifest: false,
@@ -74,7 +74,7 @@ test("getBuildConfig: Custom values", (t) => {
 
 	t.deepEqual(buildContext.getBuildConfig(), {
 		selfContained: true,
-		flatOutput: false,
+		outputStyle: "Namespace",
 		cssVariables: true,
 		jsdoc: true,
 		createBuildManifest: false,
@@ -165,7 +165,7 @@ test("createBuildManifest supported for jsdoc build", (t) => {
 	});
 });
 
-test("flatOutput=false not supported for type application", (t) => {
+test("outputStyle='Namespace' not supported for type application", (t) => {
 	const err = t.throws(() => {
 		new BuildContext({
 			getRoot: () => {
@@ -174,14 +174,14 @@ test("flatOutput=false not supported for type application", (t) => {
 				};
 			}
 		}, "taskRepository", {
-			flatOutput: false
+			outputStyle: "Namespace"
 		});
 	});
 	t.is(err.message,
 		"Projects of type application support only flat output");
 });
 
-test("flatOutput not supported for type theme-library", (t) => {
+test("outputStyle='Flat' not supported for type theme-library", (t) => {
 	const err = t.throws(() => {
 		new BuildContext({
 			getRoot: () => {
@@ -190,7 +190,7 @@ test("flatOutput not supported for type theme-library", (t) => {
 				};
 			}
 		}, "taskRepository", {
-			flatOutput: true
+			outputStyle: "Flat"
 		});
 	});
 	t.is(err.message,
@@ -198,7 +198,7 @@ test("flatOutput not supported for type theme-library", (t) => {
 		"Threw with expected error message");
 });
 
-test("flatOutput not supported for type module", (t) => {
+test("outputStyle='Flat' not supported for type module", (t) => {
 	const err = t.throws(() => {
 		new BuildContext({
 			getRoot: () => {
@@ -207,7 +207,7 @@ test("flatOutput not supported for type module", (t) => {
 				};
 			}
 		}, "taskRepository", {
-			flatOutput: true
+			outputStyle: "Flat"
 		});
 	});
 	t.is(err.message,
@@ -215,7 +215,7 @@ test("flatOutput not supported for type module", (t) => {
 		"Threw with expected error message");
 });
 
-test("flatOutput not supported for createBuildManifest build", (t) => {
+test("outputStyle='Flat' not supported for createBuildManifest build", (t) => {
 	const err = t.throws(() => {
 		new BuildContext({
 			getRoot: () => {
@@ -225,7 +225,7 @@ test("flatOutput not supported for createBuildManifest build", (t) => {
 			}
 		}, "taskRepository", {
 			createBuildManifest: true,
-			flatOutput: true
+			outputStyle: "Flat"
 		});
 	});
 	t.is(err.message,

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -165,7 +165,7 @@ test("createBuildManifest supported for jsdoc build", (t) => {
 	});
 });
 
-test("flatOutput not supported for type application", (t) => {
+test("flatOutput=false not supported for type application", (t) => {
 	const err = t.throws(() => {
 		new BuildContext({
 			getRoot: () => {
@@ -174,12 +174,11 @@ test("flatOutput not supported for type application", (t) => {
 				};
 			}
 		}, "taskRepository", {
-			flatOutput: true
+			flatOutput: false
 		});
 	});
 	t.is(err.message,
-		"Flat build output is currently not supported for projects of type application",
-		"Threw with expected error message");
+		"Projects of type application support only flat output");
 });
 
 test("flatOutput not supported for type theme-library", (t) => {

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -182,6 +182,23 @@ test("flatOutput not supported for type application", (t) => {
 		"Threw with expected error message");
 });
 
+test("flatOutput not supported for type theme-library", (t) => {
+	const err = t.throws(() => {
+		new BuildContext({
+			getRoot: () => {
+				return {
+					getType: () => "theme-library"
+				};
+			}
+		}, "taskRepository", {
+			flatOutput: true
+		});
+	});
+	t.is(err.message,
+		"Flat build output is currently not supported for projects of type theme-library",
+		"Threw with expected error message");
+});
+
 test("flatOutput not supported for type module", (t) => {
 	const err = t.throws(() => {
 		new BuildContext({

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -1,5 +1,6 @@
 import test from "ava";
 import sinon from "sinon";
+import OutputStyleEnum from "../../../../lib/build/helpers/ProjectBuilderOutputStyle.js";
 
 test.afterEach.always((t) => {
 	sinon.restore();
@@ -46,7 +47,7 @@ test("getBuildConfig: Default values", (t) => {
 
 	t.deepEqual(buildContext.getBuildConfig(), {
 		selfContained: false,
-		outputStyle: "Default",
+		outputStyle: OutputStyleEnum.Default,
 		cssVariables: false,
 		jsdoc: false,
 		createBuildManifest: false,
@@ -64,7 +65,7 @@ test("getBuildConfig: Custom values", (t) => {
 		}
 	}, "taskRepository", {
 		selfContained: true,
-		outputStyle: "Namespace",
+		outputStyle: OutputStyleEnum.Namespace,
 		cssVariables: true,
 		jsdoc: true,
 		createBuildManifest: false,
@@ -74,7 +75,7 @@ test("getBuildConfig: Custom values", (t) => {
 
 	t.deepEqual(buildContext.getBuildConfig(), {
 		selfContained: true,
-		outputStyle: "Namespace",
+		outputStyle: OutputStyleEnum.Namespace,
 		cssVariables: true,
 		jsdoc: true,
 		createBuildManifest: false,
@@ -174,7 +175,7 @@ test("outputStyle='Namespace' not supported for type application", (t) => {
 				};
 			}
 		}, "taskRepository", {
-			outputStyle: "Namespace"
+			outputStyle: OutputStyleEnum.Namespace
 		});
 	});
 	t.is(err.message,
@@ -190,7 +191,7 @@ test("outputStyle='Flat' not supported for type theme-library", (t) => {
 				};
 			}
 		}, "taskRepository", {
-			outputStyle: "Flat"
+			outputStyle: OutputStyleEnum.Flat
 		});
 	});
 	t.is(err.message,
@@ -207,7 +208,7 @@ test("outputStyle='Flat' not supported for type module", (t) => {
 				};
 			}
 		}, "taskRepository", {
-			outputStyle: "Flat"
+			outputStyle: OutputStyleEnum.Flat
 		});
 	});
 	t.is(err.message,
@@ -225,7 +226,7 @@ test("outputStyle='Flat' not supported for createBuildManifest build", (t) => {
 			}
 		}, "taskRepository", {
 			createBuildManifest: true,
-			outputStyle: "Flat"
+			outputStyle: OutputStyleEnum.Flat
 		});
 	});
 	t.is(err.message,

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -46,6 +46,7 @@ test("getBuildConfig: Default values", (t) => {
 
 	t.deepEqual(buildContext.getBuildConfig(), {
 		selfContained: false,
+		flatOutput: false,
 		cssVariables: false,
 		jsdoc: false,
 		createBuildManifest: false,
@@ -63,6 +64,7 @@ test("getBuildConfig: Custom values", (t) => {
 		}
 	}, "taskRepository", {
 		selfContained: true,
+		flatOutput: false,
 		cssVariables: true,
 		jsdoc: true,
 		createBuildManifest: false,
@@ -72,6 +74,7 @@ test("getBuildConfig: Custom values", (t) => {
 
 	t.deepEqual(buildContext.getBuildConfig(), {
 		selfContained: true,
+		flatOutput: false,
 		cssVariables: true,
 		jsdoc: true,
 		createBuildManifest: false,
@@ -162,7 +165,59 @@ test("createBuildManifest supported for jsdoc build", (t) => {
 	});
 });
 
-test("getBuildOption", (t) => {
+test("flatOutput not supported for type application", (t) => {
+	const err = t.throws(() => {
+		new BuildContext({
+			getRoot: () => {
+				return {
+					getType: () => "application"
+				};
+			}
+		}, "taskRepository", {
+			flatOutput: true
+		});
+	});
+	t.is(err.message,
+		"Flat build output is currently not supported for projects of type application",
+		"Threw with expected error message");
+});
+
+test("flatOutput not supported for type module", (t) => {
+	const err = t.throws(() => {
+		new BuildContext({
+			getRoot: () => {
+				return {
+					getType: () => "module"
+				};
+			}
+		}, "taskRepository", {
+			flatOutput: true
+		});
+	});
+	t.is(err.message,
+		"Flat build output is currently not supported for projects of type module",
+		"Threw with expected error message");
+});
+
+test("flatOutput not supported for createBuildManifest build", (t) => {
+	const err = t.throws(() => {
+		new BuildContext({
+			getRoot: () => {
+				return {
+					getType: () => "library"
+				};
+			}
+		}, "taskRepository", {
+			createBuildManifest: true,
+			flatOutput: true
+		});
+	});
+	t.is(err.message,
+		"Build manifest creation is not supported in conjunction with flat build output",
+		"Threw with expected error message");
+});
+
+test("getOption", (t) => {
 	const buildContext = new BuildContext("graph", "taskRepository", {
 		cssVariables: "value",
 	});
@@ -171,7 +226,7 @@ test("getBuildOption", (t) => {
 		"Returned correct value for build configuration 'cssVariables'");
 	t.is(buildContext.getOption("selfContained"), undefined,
 		"Returned undefined for build configuration 'selfContained' " +
-		"(not exposed as buold option)");
+		"(not exposed as build option)");
 });
 
 test("createProjectContext", async (t) => {

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -166,8 +166,8 @@ test("createBuildManifest supported for jsdoc build", (t) => {
 	});
 });
 
-test("outputStyle='Namespace' not supported for type application", (t) => {
-	const err = t.throws(() => {
+test("outputStyle='Namespace' supported for type application", (t) => {
+	t.notThrows(() => {
 		new BuildContext({
 			getRoot: () => {
 				return {
@@ -178,8 +178,6 @@ test("outputStyle='Namespace' not supported for type application", (t) => {
 			outputStyle: OutputStyleEnum.Namespace
 		});
 	});
-	t.is(err.message,
-		"Projects of type application support only flat output");
 });
 
 test("outputStyle='Flat' not supported for type theme-library", (t) => {

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -204,8 +204,9 @@ test("outputStyle='Flat' not supported for type theme-library", (t) => {
 		});
 	});
 	t.is(err.message,
-		"Flat build output is currently not supported since a theme-library " +
-		"almost always has more than one namespace.You can use only the Default build output for this project type.");
+		"Flat build output style is currently not supported for projects of typetheme-library since they" +
+		" commonly have more than one namespace. Currently only the Default output style is supported" +
+		" for this project type.");
 });
 
 test("outputStyle='Flat' not supported for type module", (t) => {
@@ -221,9 +222,9 @@ test("outputStyle='Flat' not supported for type module", (t) => {
 		});
 	});
 	t.is(err.message,
-		"Flat build output is currently not supported since modules have"+
-		" explicit path mappings configured and no namespace concept.You can use only "+
-		"the Default build output for this project type.");
+		"Flat build output style is currently not supported for projects of typemodule. " +
+		"Their path mappings configuration can't be mapped to any namespace.Currently only the " +
+		"Default output style is supported for this project type.");
 });
 
 test("outputStyle='Flat' not supported for createBuildManifest build", (t) => {

--- a/test/lib/build/helpers/ProjectBuildContext.js
+++ b/test/lib/build/helpers/ProjectBuildContext.js
@@ -381,7 +381,10 @@ test.serial("createProjectContext", async (t) => {
 			create: sinon.stub().resolves(taskRunner)
 		}
 	});
-	const testBuildContext = new BuildContext("graph", "taskRepository");
+	const graph = {
+		getRoot: () => ({getType: () => "library"}),
+	};
+	const testBuildContext = new BuildContext(graph, "taskRepository");
 
 	const projectContext = await testBuildContext.createProjectContext({
 		project


### PR DESCRIPTION
New option `outputStyle`. Whether to omit the `/resources/<namespace>` directory structure in the build output.

Resolves https://github.com/SAP/ui5-tooling/issues/507