### PR TITLE
[FIX] maven/Registry: Prevent socket timeouts when installing framework libraries

### DIFF
--- a/lib/ui5Framework/maven/Registry.js
+++ b/lib/ui5Framework/maven/Registry.js
@@ -40,7 +40,15 @@ class Registry {
 				`${groupId.replaceAll(".", "/")}/${artifactId}/${optionalVersion}maven-metadata.xml`;
 
 			log.verbose(`Fetching: ${url}`);
-			const res = await fetch(url);
+			const res = await fetch(url, {
+				// Disable usage of shared keep-alive agents.
+				// make-fetch-happen uses a hard-coded 15 seconds freeSocketTimeout
+				// that can be easily reached (Error: Socket timeout) and there doesn't
+				// seem to be another way to disable or increase it.
+				// Also see: https://github.com/node-modules/agentkeepalive/issues/106
+				// The same applies in npm/Registry.js
+				agent: false,
+			});
 			if (!res.ok) {
 				throw new Error(`[HTTP Error] ${res.status} ${res.statusText}`);
 			}
@@ -84,7 +92,15 @@ class Registry {
 
 			log.verbose(`Fetching: ${url}`);
 			const res = await fetch(url, {
-				cache: "no-store" // Do not cache these large artifacts. We store them right away anyways
+				cache: "no-store", // Do not cache these large artifacts. We store them right away anyways
+
+				// Disable usage of shared keep-alive agents.
+				// make-fetch-happen uses a hard-coded 15 seconds freeSocketTimeout
+				// that can be easily reached (Error: Socket timeout) and there doesn't
+				// seem to be another way to disable or increase it.
+				// Also see: https://github.com/node-modules/agentkeepalive/issues/106
+				// The same applies in npm/Registry.js
+				agent: false,
 			});
 			if (!res.ok) {
 				throw new Error(`[HTTP Error] ${res.status} ${res.statusText}`);


### PR DESCRIPTION
Applying the fix from https://github.com/SAP/ui5-project/pull/579 in the Maven Registry module