### PR TITLE
[INTERNAL] graph: Fix JSDoc links

### DIFF
--- a/lib/graph/Module.js
+++ b/lib/graph/Module.js
@@ -20,7 +20,7 @@ function clone(obj) {
 /**
  * Raw representation of a UI5 Project. A module can contain zero to one projects and n extensions.
  * This class is intended for private use by the
- * [@ui5/project/graph/ProjectGraphFromTree]{@link @ui5/project/graph/ProjectGraphFromTree} module
+ * [@ui5/project/graph/ProjectGraphBuilder]{@link @ui5/project/graph/ProjectGraphBuilder} module
  *
  * @private
  * @class

--- a/lib/graph/graph.js
+++ b/lib/graph/graph.js
@@ -81,8 +81,11 @@ export async function graphFromPackageDependencies({
 
 /**
  * Generates a [@ui5/project/graph/ProjectGraph]{@link @ui5/project/graph/ProjectGraph} from a
- * YAML file following the structure of the
- * [@ui5/project/graph/ProjectGraphFromTree]{@link @ui5/project/graph/ProjectGraphFromTree} API
+ * YAML file following the structure of
+ * [@ui5/project/graph/providers/DependencyTree~TreeNode]{@link @ui5/project/graph/providers/DependencyTree~TreeNode}.
+ *
+ * Documentation:
+ * [Static Dependency Definition]{@link https://sap.github.io/ui5-tooling/stable/pages/Overview/#static-dependency-definition}
  *
  * @public
  * @static
@@ -133,7 +136,7 @@ export async function graphFromStaticFile({
 
 /**
  * Generates a [@ui5/project/graph/ProjectGraph]{@link @ui5/project/graph/ProjectGraph} from the
- * given <code>dependencyTree</code> following the structure of the
+ * given <code>dependencyTree</code> following the structure of
  * [@ui5/project/graph/providers/DependencyTree~TreeNode]{@link @ui5/project/graph/providers/DependencyTree~TreeNode}
  *
  * @public


### PR DESCRIPTION
Minor fix of outdated JSDoc links. Plus added a new link to the
documentation chapter added in
https://github.com/SAP/ui5-tooling/pull/843