### PR TITLE
[FIX] Allow usage of after/before task assignment for all standard tasks

### DIFF
--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -111,7 +111,9 @@ class TaskRunner {
 			// This would require a more robust contract to identify task executions
 			// (e.g. via an 'id' that can be assigned to a specific execution in the configuration).
 			const taskWithoutSuffixCounter = taskName.replace(/--\d+$/, "");
-			return tasksToRun.includes(taskWithoutSuffixCounter);
+			return tasksToRun.includes(taskWithoutSuffixCounter) &&
+				// Task can be explicitly excluded by making its taskFunction = null
+				this._tasks[taskName].task !== null;
 		});
 
 		this._log.setTasks(allTasks);
@@ -178,7 +180,7 @@ class TaskRunner {
 
 		let task;
 		if (taskFunction === null) {
-			this._log.verbose(`Task ${taskName} is explicitly skipped!`);
+			this._log.verbose(`Task ${taskName} is set to be explicitly skipped in definitions.`);
 			task = null;
 		} else {
 			task = async (log) => {

--- a/lib/build/TaskRunner.js
+++ b/lib/build/TaskRunner.js
@@ -176,25 +176,31 @@ class TaskRunner {
 				`It has already been scheduled for execution`);
 		}
 
-		const task = async (log) => {
-			options.projectName = this._project.getName();
-			options.projectNamespace = this._project.getNamespace();
+		let task;
+		if (taskFunction === null) {
+			this._log.verbose(`Task ${taskName} is explicitly skipped!`);
+			task = null;
+		} else {
+			task = async (log) => {
+				options.projectName = this._project.getName();
+				options.projectNamespace = this._project.getNamespace();
 
-			const params = {
-				workspace: this._project.getWorkspace(),
-				taskUtil: this._taskUtil,
-				options
+				const params = {
+					workspace: this._project.getWorkspace(),
+					taskUtil: this._taskUtil,
+					options
+				};
+
+				if (requiresDependencies) {
+					params.dependencies = this._allDependenciesReader;
+				}
+
+				if (!taskFunction) {
+					taskFunction = (await this._taskRepository.getTask(taskName)).task;
+				}
+				return taskFunction(params);
 			};
-
-			if (requiresDependencies) {
-				params.dependencies = this._allDependenciesReader;
-			}
-
-			if (!taskFunction) {
-				taskFunction = (await this._taskRepository.getTask(taskName)).task;
-			}
-			return taskFunction(params);
-		};
+		}
 		this._tasks[taskName] = {
 			task,
 			requiredDependencies: requiresDependencies ? this._directDependencies : new Set()

--- a/lib/build/definitions/application.js
+++ b/lib/build/definitions/application.js
@@ -103,7 +103,7 @@ export default function({project, taskUtil, getTask}) {
 	} else {
 		// No bundles defined. Just set task so that it can be referenced by custom tasks
 		tasks.set("generateBundle", {
-			taskFunction: async () => {}
+			taskFunction: null
 		});
 	}
 

--- a/lib/build/definitions/application.js
+++ b/lib/build/definitions/application.js
@@ -100,6 +100,11 @@ export default function({project, taskUtil, getTask}) {
 				}, Promise.resolve());
 			}
 		});
+	} else {
+		// No bundles defined. Just set task so that it can be referenced by custom tasks
+		tasks.set("generateBundle", {
+			taskFunction: async () => {}
+		});
 	}
 
 	tasks.set("generateVersionInfo", {

--- a/lib/build/definitions/library.js
+++ b/lib/build/definitions/library.js
@@ -104,7 +104,7 @@ export default function({project, taskUtil, getTask}) {
 			}
 		});
 	} else {
-		tasks.set("generateComponentPreload", {taskFunction: async () => {}});
+		tasks.set("generateComponentPreload", {taskFunction: null});
 	}
 
 	tasks.set("generateLibraryPreload", {
@@ -136,7 +136,7 @@ export default function({project, taskUtil, getTask}) {
 			}
 		});
 	} else {
-		tasks.set("generateBundle", {taskFunction: async () => {}});
+		tasks.set("generateBundle", {taskFunction: null});
 	}
 
 	tasks.set("buildThemes", {
@@ -158,7 +158,7 @@ export default function({project, taskUtil, getTask}) {
 			}
 		});
 	} else {
-		tasks.set("generateThemeDesignerResources", {taskFunction: async () => {}});
+		tasks.set("generateThemeDesignerResources", {taskFunction: null});
 	}
 
 	tasks.set("generateResourcesJson", {

--- a/lib/build/definitions/library.js
+++ b/lib/build/definitions/library.js
@@ -103,6 +103,8 @@ export default function({project, taskUtil, getTask}) {
 				skipBundles: existingBundleDefinitionNames
 			}
 		});
+	} else {
+		tasks.set("generateComponentPreload", {taskFunction: async () => {}});
 	}
 
 	tasks.set("generateLibraryPreload", {
@@ -133,6 +135,8 @@ export default function({project, taskUtil, getTask}) {
 				}, Promise.resolve());
 			}
 		});
+	} else {
+		tasks.set("generateBundle", {taskFunction: async () => {}});
 	}
 
 	tasks.set("buildThemes", {
@@ -153,6 +157,8 @@ export default function({project, taskUtil, getTask}) {
 				version: project.getVersion()
 			}
 		});
+	} else {
+		tasks.set("generateThemeDesignerResources", {taskFunction: async () => {}});
 	}
 
 	tasks.set("generateResourcesJson", {

--- a/lib/build/definitions/themeLibrary.js
+++ b/lib/build/definitions/themeLibrary.js
@@ -43,7 +43,7 @@ export default function({project, taskUtil, getTask}) {
 			}
 		});
 	} else {
-		tasks.set("generateThemeDesignerResources", {taskFunction: async () => {}});
+		tasks.set("generateThemeDesignerResources", {taskFunction: null});
 	}
 
 	tasks.set("generateResourcesJson", {requiresDependencies: true});

--- a/lib/build/definitions/themeLibrary.js
+++ b/lib/build/definitions/themeLibrary.js
@@ -42,6 +42,8 @@ export default function({project, taskUtil, getTask}) {
 				version: project.getVersion()
 			}
 		});
+	} else {
+		tasks.set("generateThemeDesignerResources", {taskFunction: async () => {}});
 	}
 
 	tasks.set("generateResourcesJson", {requiresDependencies: true});

--- a/test/lib/build/TaskRunner.js
+++ b/test/lib/build/TaskRunner.js
@@ -246,6 +246,7 @@ test("_initTasks: Project of type 'library'", async (t) => {
 		"generateLibraryPreload",
 		"generateBundle",
 		"buildThemes",
+		"generateThemeDesignerResources",
 		"generateResourcesJson"
 	], "Correct standard tasks");
 });
@@ -290,6 +291,7 @@ test("_initTasks: Project of type 'theme-library'", async (t) => {
 		"replaceCopyright",
 		"replaceVersion",
 		"buildThemes",
+		"generateThemeDesignerResources",
 		"generateResourcesJson"
 	], "Correct standard tasks");
 });

--- a/test/lib/build/definitions/application.js
+++ b/test/lib/build/definitions/application.js
@@ -83,6 +83,9 @@ test("Standard build", (t) => {
 			requiresDependencies: true
 		},
 		transformBootstrapHtml: {},
+		generateBundle: {
+			taskFunction: async function() {}
+		},
 		generateVersionInfo: {
 			requiresDependencies: true,
 			options: {
@@ -159,6 +162,9 @@ test("Standard build with legacy spec version", (t) => {
 			requiresDependencies: true
 		},
 		transformBootstrapHtml: {},
+		generateBundle: {
+			taskFunction: async function() {}
+		},
 		generateVersionInfo: {
 			requiresDependencies: true,
 			options: {

--- a/test/lib/build/definitions/application.js
+++ b/test/lib/build/definitions/application.js
@@ -84,7 +84,7 @@ test("Standard build", (t) => {
 		},
 		transformBootstrapHtml: {},
 		generateBundle: {
-			taskFunction: async function() {}
+			taskFunction: null
 		},
 		generateVersionInfo: {
 			requiresDependencies: true,
@@ -163,7 +163,7 @@ test("Standard build with legacy spec version", (t) => {
 		},
 		transformBootstrapHtml: {},
 		generateBundle: {
-			taskFunction: async function() {}
+			taskFunction: null
 		},
 		generateVersionInfo: {
 			requiresDependencies: true,

--- a/test/lib/build/definitions/library.js
+++ b/test/lib/build/definitions/library.js
@@ -631,7 +631,7 @@ test("buildThemes: CSS Variables enabled", (t) => {
 		"taskUtil#getBuildOption got called with correct argument");
 });
 
-test("Standard build: mocked functions for skipped tasks", async (t) => {
+test("Standard build: nulled taskFunction to skip tasks", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 	project.getJsdocExcludes = () => ["**.html"];
 

--- a/test/lib/build/definitions/library.js
+++ b/test/lib/build/definitions/library.js
@@ -115,13 +115,13 @@ test("Standard build", async (t) => {
 			}
 		},
 		generateBundle: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateComponentPreload: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateThemeDesignerResources: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateResourcesJson: {
 			requiresDependencies: true
@@ -251,13 +251,13 @@ test("Standard build with legacy spec version", (t) => {
 			}
 		},
 		generateBundle: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateComponentPreload: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateThemeDesignerResources: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateResourcesJson: {
 			requiresDependencies: true
@@ -380,10 +380,10 @@ test("Custom bundles", async (t) => {
 			}
 		},
 		generateComponentPreload: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateThemeDesignerResources: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateResourcesJson: {
 			requiresDependencies: true
@@ -699,24 +699,20 @@ test("Standard build: mocked functions for skipped tasks", async (t) => {
 			}
 		},
 		generateBundle: {
-			taskFunction: async () => {}
+			taskFunction: null
 		},
 		generateComponentPreload: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateThemeDesignerResources: {
-			taskFunction: async () => {},
+			taskFunction: null
 		},
 		generateResourcesJson: {
 			requiresDependencies: true
 		}
 	}, "Correct task definitions");
 
-	const compPreloadResult = await generateComponentPreloadTaskDefinition.taskFunction();
-	const bundleResult = await generateBundleTaskDefinition.taskFunction();
-	const genThemeResult = await generateThemeDesignerResourcesTaskDefinition.taskFunction();
-
-	t.is(compPreloadResult, undefined, "Empty function used");
-	t.is(bundleResult, undefined, "Empty function used");
-	t.is(genThemeResult, undefined, "Empty function used");
+	t.is(generateComponentPreloadTaskDefinition.taskFunction, null, "taskFunction is explicitly set to null");
+	t.is(generateBundleTaskDefinition.taskFunction, null, "taskFunction is explicitly set to null");
+	t.is(generateThemeDesignerResourcesTaskDefinition.taskFunction, null, "taskFunction is explicitly set to null");
 });

--- a/test/lib/build/definitions/library.js
+++ b/test/lib/build/definitions/library.js
@@ -114,6 +114,15 @@ test("Standard build", async (t) => {
 				cssVariables: undefined
 			}
 		},
+		generateBundle: {
+			taskFunction: async () => {},
+		},
+		generateComponentPreload: {
+			taskFunction: async () => {},
+		},
+		generateThemeDesignerResources: {
+			taskFunction: async () => {},
+		},
 		generateResourcesJson: {
 			requiresDependencies: true
 		}
@@ -241,6 +250,15 @@ test("Standard build with legacy spec version", (t) => {
 				cssVariables: undefined
 			}
 		},
+		generateBundle: {
+			taskFunction: async () => {},
+		},
+		generateComponentPreload: {
+			taskFunction: async () => {},
+		},
+		generateThemeDesignerResources: {
+			taskFunction: async () => {},
+		},
 		generateResourcesJson: {
 			requiresDependencies: true
 		}
@@ -360,6 +378,12 @@ test("Custom bundles", async (t) => {
 				inputPattern: "/resources/project/b/themes/*/library.source.less",
 				cssVariables: undefined
 			}
+		},
+		generateComponentPreload: {
+			taskFunction: async () => {},
+		},
+		generateThemeDesignerResources: {
+			taskFunction: async () => {},
 		},
 		generateResourcesJson: {
 			requiresDependencies: true

--- a/test/lib/build/definitions/themeLibrary.js
+++ b/test/lib/build/definitions/themeLibrary.js
@@ -41,7 +41,7 @@ test.beforeEach((t) => {
 	t.context.getTask = sinon.stub();
 });
 
-test("Standard build", async (t) => {
+test("Standard build", (t) => {
 	const {project, taskUtil, getTask} = t.context;
 
 	const tasks = themeLibrary({

--- a/test/lib/build/definitions/themeLibrary.js
+++ b/test/lib/build/definitions/themeLibrary.js
@@ -75,7 +75,7 @@ test("Standard build", async (t) => {
 			requiresDependencies: true
 		},
 		generateThemeDesignerResources: {
-			taskFunction: async () => {}
+			taskFunction: null
 		}
 	}, "Correct task definitions");
 
@@ -83,8 +83,7 @@ test("Standard build", async (t) => {
 	t.is(taskUtil.getBuildOption.getCall(0).args[0], "cssVariables",
 		"taskUtil#getBuildOption got called with correct argument");
 
-	const result = await generateThemeDesignerResourcesTaskFunction.taskFunction();
-	t.is(result, undefined, "Empty function used");
+	t.is(generateThemeDesignerResourcesTaskFunction.taskFunction, null, "taskFunction is explicitly set to null");
 });
 
 test("Standard build (framework project)", (t) => {
@@ -137,7 +136,7 @@ test("Standard build for non root project", (t) => {
 			requiresDependencies: true
 		},
 		generateThemeDesignerResources: {
-			taskFunction: async () => {}
+			taskFunction: null
 		}
 	}, "Correct task definitions");
 

--- a/test/lib/build/definitions/themeLibrary.js
+++ b/test/lib/build/definitions/themeLibrary.js
@@ -41,12 +41,13 @@ test.beforeEach((t) => {
 	t.context.getTask = sinon.stub();
 });
 
-test("Standard build", (t) => {
+test("Standard build", async (t) => {
 	const {project, taskUtil, getTask} = t.context;
 
 	const tasks = themeLibrary({
 		project, taskUtil, getTask
 	});
+	const generateThemeDesignerResourcesTaskFunction = tasks.get("generateThemeDesignerResources");
 	t.deepEqual(Object.fromEntries(tasks), {
 		replaceCopyright: {
 			options: {
@@ -81,6 +82,9 @@ test("Standard build", (t) => {
 	t.is(taskUtil.getBuildOption.callCount, 1, "taskUtil#getBuildOption got called once");
 	t.is(taskUtil.getBuildOption.getCall(0).args[0], "cssVariables",
 		"taskUtil#getBuildOption got called with correct argument");
+
+	const result = await generateThemeDesignerResourcesTaskFunction.taskFunction();
+	t.is(result, undefined, "Empty function used");
 });
 
 test("Standard build (framework project)", (t) => {

--- a/test/lib/build/definitions/themeLibrary.js
+++ b/test/lib/build/definitions/themeLibrary.js
@@ -72,6 +72,9 @@ test("Standard build", (t) => {
 		},
 		generateResourcesJson: {
 			requiresDependencies: true
+		},
+		generateThemeDesignerResources: {
+			taskFunction: async () => {}
 		}
 	}, "Correct task definitions");
 
@@ -128,6 +131,9 @@ test("Standard build for non root project", (t) => {
 		},
 		generateResourcesJson: {
 			requiresDependencies: true
+		},
+		generateThemeDesignerResources: {
+			taskFunction: async () => {}
 		}
 	}, "Correct task definitions");
 


### PR DESCRIPTION
This change allows custom tasks to subscribe to any standard task, even disabled ones, ensuring custom tasks' execution and the correct order.

Background information:
When transitioning a project from V2 to V3, we often need to adjust the before/after task assignments for custom tasks due to the removal of the `uglify` task. The new `minify` task now runs earlier than the previous `uglify` task.
Developers typically used `uglify` as the last enabled standard task to subscribe to. 

You can find updated documentation here: https://github.com/SAP/ui5-tooling/pull/874

JIRA: CPOUI5FOUNDATION-724