### PR TITLE
[FIX] Application: Fallback to manifest.appdescr_variant if manifest.json is not found

### DIFF
--- a/lib/specifications/types/Application.js
+++ b/lib/specifications/types/Application.js
@@ -124,7 +124,7 @@ class Application extends ComponentProject {
 		try {
 			return await this._getNamespaceFromManifestJson();
 		} catch (manifestJsonError) {
-			if (manifestJsonError.cause?.code !== "ENOENT") {
+			if (manifestJsonError.code !== "ENOENT") {
 				throw manifestJsonError;
 			}
 			// No manifest.json present
@@ -132,7 +132,7 @@ class Application extends ComponentProject {
 			try {
 				return await this._getNamespaceFromManifestAppDescVariant();
 			} catch (appDescVarError) {
-				if (appDescVarError.cause?.code === "ENOENT") {
+				if (appDescVarError.code === "ENOENT") {
 					// Fallback not possible: No manifest.appdescr_variant present
 					// => Throw error indicating missing manifest.json
 					// 	(do not mention manifest.appdescr_variant since it is only
@@ -221,11 +221,12 @@ class Application extends ComponentProject {
 				}
 				return JSON.parse(await resource.getString());
 			}).catch((err) => {
+				if (err.code === "ENOENT") {
+					throw err;
+				}
 				throw new Error(
 					`Failed to read ${filePath} for project ` +
-					`${this.getName()}: ${err.message}`, {
-						cause: err
-					});
+					`${this.getName()}: ${err.message}`);
 			});
 	}
 }

--- a/lib/specifications/types/Application.js
+++ b/lib/specifications/types/Application.js
@@ -124,7 +124,7 @@ class Application extends ComponentProject {
 		try {
 			return await this._getNamespaceFromManifestJson();
 		} catch (manifestJsonError) {
-			if (manifestJsonError.code !== "ENOENT") {
+			if (manifestJsonError.cause?.code !== "ENOENT") {
 				throw manifestJsonError;
 			}
 			// No manifest.json present
@@ -132,7 +132,7 @@ class Application extends ComponentProject {
 			try {
 				return await this._getNamespaceFromManifestAppDescVariant();
 			} catch (appDescVarError) {
-				if (appDescVarError.code === "ENOENT") {
+				if (appDescVarError.cause?.code === "ENOENT") {
 					// Fallback not possible: No manifest.appdescr_variant present
 					// => Throw error indicating missing manifest.json
 					// 	(do not mention manifest.appdescr_variant since it is only
@@ -214,14 +214,18 @@ class Application extends ComponentProject {
 		return this._pManifests[filePath] = this._getRawSourceReader().byPath(filePath)
 			.then(async (resource) => {
 				if (!resource) {
-					throw new Error(
+					const error = new Error(
 						`Could not find resource ${filePath} in project ${this.getName()}`);
+					error.code = "ENOENT"; // "File or directory does not exist"
+					throw error;
 				}
 				return JSON.parse(await resource.getString());
 			}).catch((err) => {
 				throw new Error(
 					`Failed to read ${filePath} for project ` +
-					`${this.getName()}: ${err.message}`);
+					`${this.getName()}: ${err.message}`, {
+						cause: err
+					});
 			});
 	}
 }


### PR DESCRIPTION
This fixes a regression presumably present since ui5-project v3.0.0,
which prevented proper fallback to manifest.appdescr_variant in case no
manifest.json is found in the project.