### PR TITLE
[FIX] Resolve UI5 data directory relative to project

### DIFF
--- a/lib/config/Configuration.js
+++ b/lib/config/Configuration.js
@@ -10,17 +10,29 @@ import os from "node:os";
  * @alias @ui5/project/config/Configuration
  */
 class Configuration {
-	#mavenSnapshotEndpointUrl;
-	#ui5DataDir;
+	/**
+	 * @public
+	 * @static
+	 */
+	static availableOptions = [
+		"mavenSnapshotEndpointUrl",
+		"ui5DataDir"
+	];
+
+	#options = new Map();
 
 	/**
 	 * @param {object} configuration
 	 * @param {string} [configuration.mavenSnapshotEndpointUrl]
 	 * @param {string} [configuration.ui5DataDir]
 	 */
-	constructor({mavenSnapshotEndpointUrl, ui5DataDir}) {
-		this.#mavenSnapshotEndpointUrl = mavenSnapshotEndpointUrl;
-		this.#ui5DataDir = ui5DataDir;
+	constructor(configuration) {
+		Object.entries(configuration).forEach(([key, value]) => {
+			if (!Configuration.availableOptions.includes(key)) {
+				throw new Error(`Unknown configuration option '${key}'`);
+			}
+			this.#options.set(key, value);
+		});
 	}
 
 	/**
@@ -31,7 +43,7 @@ class Configuration {
 	 * @returns {string}
 	 */
 	getMavenSnapshotEndpointUrl() {
-		return this.#mavenSnapshotEndpointUrl;
+		return this.#options.get("mavenSnapshotEndpointUrl");
 	}
 
 	/**
@@ -41,7 +53,7 @@ class Configuration {
 	 * @returns {string}
 	 */
 	getUi5DataDir() {
-		return this.#ui5DataDir;
+		return this.#options.get("ui5DataDir");
 	}
 
 	/**
@@ -50,8 +62,8 @@ class Configuration {
 	 */
 	toJson() {
 		return {
-			mavenSnapshotEndpointUrl: this.#mavenSnapshotEndpointUrl,
-			ui5DataDir: this.#ui5DataDir,
+			mavenSnapshotEndpointUrl: this.getMavenSnapshotEndpointUrl(),
+			ui5DataDir: this.getUi5DataDir()
 		};
 	}
 

--- a/lib/config/Configuration.js
+++ b/lib/config/Configuration.js
@@ -11,15 +11,17 @@ import os from "node:os";
  */
 class Configuration {
 	/**
+	 * A list of all configuration settings.
+	 *
 	 * @public
 	 * @static
 	 */
-	static availableOptions = [
+	static SETTINGS = [
 		"mavenSnapshotEndpointUrl",
 		"ui5DataDir"
 	];
 
-	#options = new Map();
+	#settings = new Map();
 
 	/**
 	 * @param {object} configuration
@@ -27,11 +29,14 @@ class Configuration {
 	 * @param {string} [configuration.ui5DataDir]
 	 */
 	constructor(configuration) {
+		// Initialize map with undefined values for every setting
+		Configuration.SETTINGS.forEach((key) => this.#settings.set(key, undefined));
+
 		Object.entries(configuration).forEach(([key, value]) => {
-			if (!Configuration.availableOptions.includes(key)) {
-				throw new Error(`Unknown configuration option '${key}'`);
+			if (!Configuration.SETTINGS.includes(key)) {
+				throw new Error(`Unknown configuration setting '${key}'`);
 			}
-			this.#options.set(key, value);
+			this.#settings.set(key, value);
 		});
 	}
 
@@ -43,7 +48,7 @@ class Configuration {
 	 * @returns {string}
 	 */
 	getMavenSnapshotEndpointUrl() {
-		return this.#options.get("mavenSnapshotEndpointUrl");
+		return this.#settings.get("mavenSnapshotEndpointUrl");
 	}
 
 	/**
@@ -53,7 +58,7 @@ class Configuration {
 	 * @returns {string}
 	 */
 	getUi5DataDir() {
-		return this.#options.get("ui5DataDir");
+		return this.#settings.get("ui5DataDir");
 	}
 
 	/**
@@ -61,10 +66,7 @@ class Configuration {
 	 * @returns {object} The configuration in a JSON format
 	 */
 	toJson() {
-		return {
-			mavenSnapshotEndpointUrl: this.getMavenSnapshotEndpointUrl(),
-			ui5DataDir: this.getUi5DataDir()
-		};
+		return Object.fromEntries(this.#settings);
 	}
 
 	/**

--- a/lib/config/Configuration.js
+++ b/lib/config/Configuration.js
@@ -2,7 +2,7 @@ import path from "node:path";
 import os from "node:os";
 
 /**
- * Provides basic configuration settings for @ui5/project/ui5Framework/* resolvers.
+ * Provides basic configuration for @ui5/project.
  * Reads/writes configuration from/to ~/.ui5rc
  *
  * @public
@@ -11,17 +11,17 @@ import os from "node:os";
  */
 class Configuration {
 	/**
-	 * A list of all configuration settings.
+	 * A list of all configuration options.
 	 *
 	 * @public
 	 * @static
 	 */
-	static SETTINGS = [
+	static OPTIONS = [
 		"mavenSnapshotEndpointUrl",
 		"ui5DataDir"
 	];
 
-	#settings = new Map();
+	#options = new Map();
 
 	/**
 	 * @param {object} configuration
@@ -29,14 +29,15 @@ class Configuration {
 	 * @param {string} [configuration.ui5DataDir]
 	 */
 	constructor(configuration) {
-		// Initialize map with undefined values for every setting
-		Configuration.SETTINGS.forEach((key) => this.#settings.set(key, undefined));
+		// Initialize map with undefined values for every option so that they are
+		// returned via toJson()
+		Configuration.OPTIONS.forEach((key) => this.#options.set(key, undefined));
 
 		Object.entries(configuration).forEach(([key, value]) => {
-			if (!Configuration.SETTINGS.includes(key)) {
-				throw new Error(`Unknown configuration setting '${key}'`);
+			if (!Configuration.OPTIONS.includes(key)) {
+				throw new Error(`Unknown configuration option '${key}'`);
 			}
-			this.#settings.set(key, value);
+			this.#options.set(key, value);
 		});
 	}
 
@@ -48,7 +49,7 @@ class Configuration {
 	 * @returns {string}
 	 */
 	getMavenSnapshotEndpointUrl() {
-		return this.#settings.get("mavenSnapshotEndpointUrl");
+		return this.#options.get("mavenSnapshotEndpointUrl");
 	}
 
 	/**
@@ -58,7 +59,7 @@ class Configuration {
 	 * @returns {string}
 	 */
 	getUi5DataDir() {
-		return this.#settings.get("ui5DataDir");
+		return this.#options.get("ui5DataDir");
 	}
 
 	/**
@@ -66,7 +67,7 @@ class Configuration {
 	 * @returns {object} The configuration in a JSON format
 	 */
 	toJson() {
-		return Object.fromEntries(this.#settings);
+		return Object.fromEntries(this.#options);
 	}
 
 	/**

--- a/lib/graph/helpers/ui5Framework.js
+++ b/lib/graph/helpers/ui5Framework.js
@@ -365,11 +365,15 @@ export default {
 			});
 		}
 
-		const config = await Configuration.fromFile();
 		// ENV var should take precedence over the dataDir from the configuration.
-		const ui5HomeDir = process.env.UI5_DATA_DIR ?
-			path.resolve(process.env.UI5_DATA_DIR) :
-			config.getUi5DataDir();
+		let ui5DataDir = process.env.UI5_DATA_DIR;
+		if (!ui5DataDir) {
+			const config = await Configuration.fromFile();
+			ui5DataDir = config.getUi5DataDir();
+		}
+		if (ui5DataDir) {
+			ui5DataDir = path.resolve(rootProject.getRootPath(), ui5DataDir);
+		}
 
 		// Note: version might be undefined here and the Resolver will throw an error when calling
 		// #install and it can't be resolved via the provided library metadata
@@ -378,7 +382,7 @@ export default {
 			version,
 			providedLibraryMetadata,
 			cacheMode,
-			ui5HomeDir
+			ui5HomeDir: ui5DataDir
 		});
 
 		let startTime;

--- a/test/lib/config/Configuration.js
+++ b/test/lib/config/Configuration.js
@@ -60,6 +60,18 @@ test.serial("Overwrite defaults defaults", (t) => {
 	t.deepEqual(config.toJson(), params);
 });
 
+test.serial("Unknown configuration option", (t) => {
+	const {Configuration} = t.context;
+
+	const params = {
+		unknown: "foo"
+	};
+
+	t.throws(() => new Configuration(params), {
+		message: `Unknown configuration option 'unknown'`
+	});
+});
+
 test.serial("Check getters", (t) => {
 	const {Configuration} = t.context;
 

--- a/test/lib/config/Configuration.js
+++ b/test/lib/config/Configuration.js
@@ -28,9 +28,9 @@ test.afterEach.always((t) => {
 	esmock.purge(t.context.Configuration);
 });
 
-test.serial("Available configuration settings", (t) => {
+test.serial("Configuration options", (t) => {
 	const {Configuration} = t.context;
-	t.deepEqual(Configuration.SETTINGS, [
+	t.deepEqual(Configuration.OPTIONS, [
 		"mavenSnapshotEndpointUrl",
 		"ui5DataDir"
 	]);

--- a/test/lib/config/Configuration.js
+++ b/test/lib/config/Configuration.js
@@ -28,6 +28,14 @@ test.afterEach.always((t) => {
 	esmock.purge(t.context.Configuration);
 });
 
+test.serial("Available configuration settings", (t) => {
+	const {Configuration} = t.context;
+	t.deepEqual(Configuration.SETTINGS, [
+		"mavenSnapshotEndpointUrl",
+		"ui5DataDir"
+	]);
+});
+
 test.serial("Build configuration with defaults", (t) => {
 	const {Configuration} = t.context;
 
@@ -38,7 +46,6 @@ test.serial("Build configuration with defaults", (t) => {
 		ui5DataDir: undefined,
 	});
 });
-
 
 test.serial("Overwrite defaults defaults", (t) => {
 	const {Configuration} = t.context;

--- a/test/lib/graph/helpers/ui5Framework.integration.js
+++ b/test/lib/graph/helpers/ui5Framework.integration.js
@@ -125,11 +125,19 @@ test.beforeEach(async (t) => {
 		"../../../../lib/specifications/Specification.js": t.context.Specification
 	});
 
+	// Stub os homedir to prevent that the actual ~/.ui5rc from being used in tests
+	t.context.Configuration = await esmock.p("../../../../lib/config/Configuration.js", {
+		"node:os": {
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+		}
+	});
+
 	t.context.ui5Framework = await esmock.p("../../../../lib/graph/helpers/ui5Framework.js", {
 		"@ui5/logger": ui5Logger,
 		"../../../../lib/graph/Module.js": t.context.Module,
 		"../../../../lib/ui5Framework/Openui5Resolver.js": t.context.Openui5Resolver,
 		"../../../../lib/ui5Framework/Sapui5Resolver.js": t.context.Sapui5Resolver,
+		"../../../../lib/config/Configuration.js": t.context.Configuration
 	});
 
 	t.context.projectGraphBuilder = await esmock.p("../../../../lib/graph/projectGraphBuilder.js", {

--- a/test/lib/graph/helpers/ui5Framework.integration.js
+++ b/test/lib/graph/helpers/ui5Framework.integration.js
@@ -125,7 +125,7 @@ test.beforeEach(async (t) => {
 		"../../../../lib/specifications/Specification.js": t.context.Specification
 	});
 
-	// Stub os homedir to prevent that the actual ~/.ui5rc from being used in tests
+	// Stub os homedir to prevent the actual ~/.ui5rc from being used in tests
 	t.context.Configuration = await esmock.p("../../../../lib/config/Configuration.js", {
 		"node:os": {
 			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))

--- a/test/lib/graph/helpers/ui5Framework.js
+++ b/test/lib/graph/helpers/ui5Framework.js
@@ -16,6 +16,10 @@ const libraryEPath = path.join(__dirname, "..", "..", "..", "fixtures", "library
 const libraryFPath = path.join(__dirname, "..", "..", "..", "fixtures", "library.f");
 
 test.beforeEach(async (t) => {
+	// Tests either rely on not having UI5_DATA_DIR defined, or explicitly define it
+	t.context.originalUi5DataDirEnv = process.env.UI5_DATA_DIR;
+	delete process.env.UI5_DATA_DIR;
+
 	const sinon = t.context.sinon = sinonGlobal.createSandbox();
 
 	t.context.log = {
@@ -51,9 +55,11 @@ test.beforeEach(async (t) => {
 	t.context.Sapui5MavenSnapshotResolverResolveVersionStub = sinon.stub();
 	t.context.Sapui5MavenSnapshotResolverStub.resolveVersion = t.context.Sapui5MavenSnapshotResolverResolveVersionStub;
 
+	t.context.getUi5DataDirStub = sinon.stub().returns(undefined);
+
 	t.context.ConfigurationStub = {
 		fromFile: sinon.stub().resolves({
-			getUi5DataDir: sinon.stub().returns(undefined)
+			getUi5DataDir: t.context.getUi5DataDirStub
 		})
 	};
 
@@ -67,6 +73,12 @@ test.beforeEach(async (t) => {
 });
 
 test.afterEach.always((t) => {
+	// Reset UI5_DATA_DIR env
+	if (typeof t.context.originalUi5DataDirEnv === "undefined") {
+		delete process.env.UI5_DATA_DIR;
+	} else {
+		process.env.UI5_DATA_DIR = t.context.originalUi5DataDirEnv;
+	}
 	t.context.sinon.restore();
 	esmock.purge(t.context.ui5Framework);
 });
@@ -1025,6 +1037,174 @@ test.serial("enrichProjectGraph should allow omitting framework version in case 
 		providedLibraryMetadata: workspaceFrameworkLibraryMetadata
 	}], "Sapui5Resolver#constructor should be called with expected args");
 	t.is(Sapui5ResolverStub.getCall(0).args[0].providedLibraryMetadata, workspaceFrameworkLibraryMetadata);
+});
+
+test.serial("enrichProjectGraph should use UI5 data dir from env var", async (t) => {
+	const {sinon, ui5Framework, utils, Sapui5ResolverInstallStub} = t.context;
+
+	const dependencyTree = {
+		id: "test1",
+		version: "1.0.0",
+		path: applicationAPath,
+		configuration: {
+			specVersion: "2.0",
+			type: "application",
+			metadata: {
+				name: "application.a"
+			},
+			framework: {
+				name: "SAPUI5",
+				version: "1.75.0"
+			}
+		}
+	};
+
+	const referencedLibraries = ["sap.ui.lib1", "sap.ui.lib2", "sap.ui.lib3"];
+	const libraryMetadata = {fake: "metadata"};
+
+	sinon.stub(utils, "getFrameworkLibrariesFromGraph")
+		.resolves(referencedLibraries);
+
+	Sapui5ResolverInstallStub.resolves({libraryMetadata});
+
+
+	const addProjectToGraphStub = sinon.stub();
+	sinon.stub(utils, "ProjectProcessor")
+		.callsFake(() => {
+			return {
+				addProjectToGraph: addProjectToGraphStub
+			};
+		});
+
+	const provider = new DependencyTreeProvider({dependencyTree});
+	const projectGraph = await projectGraphBuilder(provider);
+
+	process.env.UI5_DATA_DIR = "./ui5-data-dir-from-env-var";
+
+	const expectedUi5DataDir = path.resolve(dependencyTree.path, "./ui5-data-dir-from-env-var");
+
+	await ui5Framework.enrichProjectGraph(projectGraph);
+
+	t.is(t.context.Sapui5ResolverStub.callCount, 1, "Sapui5Resolver#constructor should be called once");
+	t.deepEqual(t.context.Sapui5ResolverStub.getCall(0).args, [{
+		cacheMode: undefined,
+		cwd: dependencyTree.path,
+		version: dependencyTree.configuration.framework.version,
+		ui5HomeDir: expectedUi5DataDir,
+		providedLibraryMetadata: undefined
+	}], "Sapui5Resolver#constructor should be called with expected args");
+});
+
+test.serial("enrichProjectGraph should use UI5 data dir from configuration", async (t) => {
+	const {sinon, ui5Framework, utils, Sapui5ResolverInstallStub, getUi5DataDirStub} = t.context;
+
+	const dependencyTree = {
+		id: "test1",
+		version: "1.0.0",
+		path: applicationAPath,
+		configuration: {
+			specVersion: "2.0",
+			type: "application",
+			metadata: {
+				name: "application.a"
+			},
+			framework: {
+				name: "SAPUI5",
+				version: "1.75.0"
+			}
+		}
+	};
+
+	const referencedLibraries = ["sap.ui.lib1", "sap.ui.lib2", "sap.ui.lib3"];
+	const libraryMetadata = {fake: "metadata"};
+
+	sinon.stub(utils, "getFrameworkLibrariesFromGraph")
+		.resolves(referencedLibraries);
+
+	Sapui5ResolverInstallStub.resolves({libraryMetadata});
+
+
+	const addProjectToGraphStub = sinon.stub();
+	sinon.stub(utils, "ProjectProcessor")
+		.callsFake(() => {
+			return {
+				addProjectToGraph: addProjectToGraphStub
+			};
+		});
+
+	const provider = new DependencyTreeProvider({dependencyTree});
+	const projectGraph = await projectGraphBuilder(provider);
+
+	getUi5DataDirStub.returns("./ui5-data-dir-from-config");
+
+	const expectedUi5DataDir = path.resolve(dependencyTree.path, "./ui5-data-dir-from-config");
+
+	await ui5Framework.enrichProjectGraph(projectGraph);
+
+	t.is(t.context.Sapui5ResolverStub.callCount, 1, "Sapui5Resolver#constructor should be called once");
+	t.deepEqual(t.context.Sapui5ResolverStub.getCall(0).args, [{
+		cacheMode: undefined,
+		cwd: dependencyTree.path,
+		version: dependencyTree.configuration.framework.version,
+		ui5HomeDir: expectedUi5DataDir,
+		providedLibraryMetadata: undefined
+	}], "Sapui5Resolver#constructor should be called with expected args");
+});
+
+test.serial("enrichProjectGraph should use absolute UI5 data dir from configuration", async (t) => {
+	const {sinon, ui5Framework, utils, Sapui5ResolverInstallStub, getUi5DataDirStub} = t.context;
+
+	const dependencyTree = {
+		id: "test1",
+		version: "1.0.0",
+		path: applicationAPath,
+		configuration: {
+			specVersion: "2.0",
+			type: "application",
+			metadata: {
+				name: "application.a"
+			},
+			framework: {
+				name: "SAPUI5",
+				version: "1.75.0"
+			}
+		}
+	};
+
+	const referencedLibraries = ["sap.ui.lib1", "sap.ui.lib2", "sap.ui.lib3"];
+	const libraryMetadata = {fake: "metadata"};
+
+	sinon.stub(utils, "getFrameworkLibrariesFromGraph")
+		.resolves(referencedLibraries);
+
+	Sapui5ResolverInstallStub.resolves({libraryMetadata});
+
+
+	const addProjectToGraphStub = sinon.stub();
+	sinon.stub(utils, "ProjectProcessor")
+		.callsFake(() => {
+			return {
+				addProjectToGraph: addProjectToGraphStub
+			};
+		});
+
+	const provider = new DependencyTreeProvider({dependencyTree});
+	const projectGraph = await projectGraphBuilder(provider);
+
+	getUi5DataDirStub.returns("/absolute-ui5-data-dir-from-config");
+
+	const expectedUi5DataDir = path.resolve("/absolute-ui5-data-dir-from-config");
+
+	await ui5Framework.enrichProjectGraph(projectGraph);
+
+	t.is(t.context.Sapui5ResolverStub.callCount, 1, "Sapui5Resolver#constructor should be called once");
+	t.deepEqual(t.context.Sapui5ResolverStub.getCall(0).args, [{
+		cacheMode: undefined,
+		cwd: dependencyTree.path,
+		version: dependencyTree.configuration.framework.version,
+		ui5HomeDir: expectedUi5DataDir,
+		providedLibraryMetadata: undefined
+	}], "Sapui5Resolver#constructor should be called with expected args");
 });
 
 test.serial("utils.shouldIncludeDependency", (t) => {

--- a/test/lib/graph/helpers/ui5Framework.js
+++ b/test/lib/graph/helpers/ui5Framework.js
@@ -51,10 +51,17 @@ test.beforeEach(async (t) => {
 	t.context.Sapui5MavenSnapshotResolverResolveVersionStub = sinon.stub();
 	t.context.Sapui5MavenSnapshotResolverStub.resolveVersion = t.context.Sapui5MavenSnapshotResolverResolveVersionStub;
 
+	t.context.ConfigurationStub = {
+		fromFile: sinon.stub().resolves({
+			getUi5DataDir: sinon.stub().returns(undefined)
+		})
+	};
+
 	t.context.ui5Framework = await esmock.p("../../../../lib/graph/helpers/ui5Framework.js", {
 		"@ui5/logger": ui5Logger,
 		"../../../../lib/ui5Framework/Sapui5Resolver.js": t.context.Sapui5ResolverStub,
 		"../../../../lib/ui5Framework/Sapui5MavenSnapshotResolver.js": t.context.Sapui5MavenSnapshotResolverStub,
+		"../../../../lib/config/Configuration.js": t.context.ConfigurationStub,
 	});
 	t.context.utils = t.context.ui5Framework._utils;
 });


### PR DESCRIPTION
The UI5 data directory (previously called UI5 home directory) should
always be resolved relative to the project directory, which is where
the package.json file is located at.

This change also adds a list of options to the Configuration class to be
used by the CLI config command to allow all available config options to
be set or retrieved.

Follow-up of https://github.com/SAP/ui5-project/pull/635

JIRA: CPOUI5FOUNDATION-715
JIRA: CPOUI5FOUNDATION-716