### PR TITLE
[FEATURE] AbstractResolver: Resolve version ranges specifying major version only

### DIFF
--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -14,8 +14,8 @@ import semver from "semver";
 const SEMVER_VERSION_REGEXP = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
 // Reduced Semantic Versioning pattern
-// Matches MAJOR.MINOR as a simple version range to be resolved to the latest patch
-const VERSION_RANGE_REGEXP = /^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-SNAPSHOT)?$/;
+// Matches MAJOR or MAJOR.MINOR as a simple version range to be resolved to the latest minor/patch
+const VERSION_RANGE_REGEXP = /^(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:-SNAPSHOT)?$/;
 
 /**
  * Abstract Resolver
@@ -223,16 +223,20 @@ class AbstractResolver {
 		} else if (SEMVER_VERSION_REGEXP.test(version)) {
 			// Fully qualified version, can be used directly
 			spec = version;
-		} else if (VERSION_RANGE_REGEXP.test(version)) {
-			if (isSnapshotVersion) {
-				// For snapshot version ranges we need to insert a stand-in "x" for the patch level
-				// in order to make the semver check work: "1.112-SNAPSHOT" becomes "1.112.x-SNAPSHOT"
-				spec = version.replace(/-SNAPSHOT$/, ".x-SNAPSHOT");
-			} else {
-				spec = version;
-			}
 		} else {
-			throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
+			const versionMatch = version.match(VERSION_RANGE_REGEXP);
+			if (versionMatch) {
+				if (isSnapshotVersion) {
+					// For snapshot version ranges we need to insert a stand-in "x" for the patch level
+					// and - in case none is provided - another "x" for the major version in order to
+					// make the semver check work: "1-SNAPSHOT" or "1.112-SNAPSHOT" becomes "1.112.x-SNAPSHOT"
+					spec = `${versionMatch[1]}.${versionMatch[2] || "x"}.x-SNAPSHOT`;
+				} else {
+					spec = version;
+				}
+			} else {
+				throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
+			}
 		}
 		const versions = await this.fetchAllVersions({ui5HomeDir, cwd});
 		const resolvedVersion = semver.maxSatisfying(versions, spec, {

--- a/test/lib/ui5framework/AbstractResolver.js
+++ b/test/lib/ui5framework/AbstractResolver.js
@@ -576,6 +576,44 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'latest'", async (
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
+test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR'", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.76.0"]);
+
+	const version = await MyResolver.resolveVersion("1", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	t.is(version, "1.76.0", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+});
+
+test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR-prerelease'", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.76.0", "1.77.0", "1.77.0-SNAPSHOT", "1.78.0", "1.79.0-SNAPSHOT"]);
+
+	const version = await MyResolver.resolveVersion("1-SNAPSHOT", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	t.is(version, "1.79.0-SNAPSHOT", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+});
+
 test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR'", async (t) => {
 	const {MyResolver} = t.context;
 	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
@@ -587,6 +625,25 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR'", as
 	});
 
 	t.is(version, "1.75.1", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+});
+
+test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR-prerelease'", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.76.0", "1.77.0", "1.77.0-SNAPSHOT", "1.78.0", "1.79.0-SNAPSHOT"]);
+
+	const version = await MyResolver.resolveVersion("1.79-SNAPSHOT", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	t.is(version, "1.79.0-SNAPSHOT", "Resolved version should be correct");
 
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
@@ -617,7 +674,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH
 test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH-prerelease'", async (t) => {
 	const {MyResolver} = t.context;
 	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
-		.returns(["1.76.0", "1.77.0", "1.78.0", "1.79.0-SNAPSHOT"]);
+		.returns(["1.76.0", "1.77.0", "1.77.0-SNAPSHOT", "1.78.0", "1.79.0-SNAPSHOT"]);
 
 	const version = await MyResolver.resolveVersion("1.79.0-SNAPSHOT", {
 		cwd: "/cwd",
@@ -754,20 +811,6 @@ test.serial("AbstractResolver: Static resolveVersion throws error for 'lts'", as
 	}));
 
 	t.is(error.message, `Framework version specifier "lts" is incorrect or not supported`);
-
-	t.is(fetchAllVersionsStub.callCount, 0, "fetchAllVersions should not be called");
-});
-
-test.serial("AbstractResolver: Static resolveVersion throws error for '1'", async (t) => {
-	const {MyResolver} = t.context;
-	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions");
-
-	const error = await t.throwsAsync(MyResolver.resolveVersion("1", {
-		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
-	}));
-
-	t.is(error.message, `Framework version specifier "1" is incorrect or not supported`);
 
 	t.is(fetchAllVersionsStub.callCount, 0, "fetchAllVersions should not be called");
 });


### PR DESCRIPTION
For example 'ui5 use 1' should resolve to the latest 1.x.x version