### PR TITLE
[FEATURE] Resolvers: Allow ranges / npm tags for version resolution

### DIFF
--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -258,6 +258,7 @@ class AbstractResolver {
 			}
 		}
 
+		// Covers versions and ranges, as versions are also valid ranges
 		if (semver.validRange(version)) {
 			return version;
 		}

--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -215,35 +215,54 @@ class AbstractResolver {
 	}
 
 	static async resolveVersion(version, {ui5HomeDir, cwd} = {}) {
-		if (version === "latest") {
-			const tagVersion = this.fetchTag("latest", {ui5HomeDir, cwd});
-			if (tagVersion) {
-				return tagVersion;
+		// Don't allow nullish values
+		// An empty string is a valid semver range that converts to "*", which should not be supported
+		if (!version) {
+			throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
+		}
+
+		const isSnapshotVersion = version.toLowerCase().endsWith("-snapshot");
+		if (isSnapshotVersion) {
+			const versionMatch = version.match(VERSION_RANGE_REGEXP);
+			if (versionMatch) {
+				// For snapshot version ranges we need to insert a stand-in "x" for the patch level
+				// and - in case none is provided - another "x" for the major version in order to
+				// convert it to a valid semver range:
+				// "1-SNAPSHOT" becomes "1.x.x-SNAPSHOT" and "1.112-SNAPSHOT" becomes "1.112.x-SNAPSHOT"
+				version = `${versionMatch[1]}.${versionMatch[2] || "x"}.x-SNAPSHOT`;
 			}
 		}
 
 		let spec;
-		const isSnapshotVersion = version.toLowerCase().endsWith("-snapshot");
-		if (version === "latest" || version === "latest-snapshot") {
-			// Use a wildcard to resolve to the latest available version
-			spec = "*";
-		} else if (SEMVER_VERSION_REGEXP.test(version)) {
-			// Fully qualified version, can be used directly
+
+		if (semver.validRange(version)) {
+			// Note: Fully qualified versions are also valid ranges
 			spec = version;
-		} else {
-			const versionMatch = version.match(VERSION_RANGE_REGEXP);
-			if (versionMatch) {
-				if (isSnapshotVersion) {
-					// For snapshot version ranges we need to insert a stand-in "x" for the patch level
-					// and - in case none is provided - another "x" for the major version in order to
-					// make the semver check work: "1-SNAPSHOT" or "1.112-SNAPSHOT" becomes "1.112.x-SNAPSHOT"
-					spec = `${versionMatch[1]}.${versionMatch[2] || "x"}.x-SNAPSHOT`;
-				} else {
-					spec = version;
+		} else if (encodeURIComponent(version) === version) {
+			// Valid tag name (same check as npm does)
+			const allTags = await this.fetchAllTags({ui5HomeDir, cwd});
+			if (!allTags) {
+				// Resolver doesn't support tags (e.g. Sapui5MavenSnapshotResolver)
+				if (version === "latest" || version === "latest-snapshot") {
+					// Only latest and latest-snapshot are supported which both resolve
+					// to the latest available version.
+					// See isSnapshotVersion flag for -snapshot handling
+					spec = "*";
 				}
+			} else if (allTags[version]) {
+				// Use version from tag
+				spec = allTags[version];
 			} else {
-				throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
+				throw new Error(
+					`Could not resolve framework version via tag '${version}'. ` +
+					`Make sure the tag is available in the configured registry.`
+				);
 			}
+		}
+
+		// For all invalid cases which are not explicitly handled above
+		if (!spec) {
+			throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
 		}
 
 		const versions = await this.fetchAllVersions({ui5HomeDir, cwd});
@@ -279,8 +298,8 @@ class AbstractResolver {
 	static fetchAllVersions(options) {
 		throw new Error("AbstractResolver: static fetchAllVersions must be implemented!");
 	}
-	static fetchTag(tagName, options) {
-		throw new Error("AbstractResolver: static fetchDistTag must be implemented!");
+	static fetchAllTags(options) {
+		return null;
 	}
 }
 

--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -4,15 +4,6 @@ import {getLogger} from "@ui5/logger";
 const log = getLogger("ui5Framework:AbstractResolver");
 import semver from "semver";
 
-// Matches Semantic Versioning 2.0.0 versions
-// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-//
-// This needs to be aligned with the ui5.yaml JSON schema:
-// lib/validation/schema/specVersion/kind/project.json#/definitions/framework/properties/version/pattern
-//
-// eslint-disable-next-line max-len
-const SEMVER_VERSION_REGEXP = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
-
 // Reduced Semantic Versioning pattern
 // Matches MAJOR or MAJOR.MINOR as a simple version range to be resolved to the latest minor/patch
 const VERSION_RANGE_REGEXP = /^(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:-SNAPSHOT)?$/;
@@ -221,8 +212,8 @@ class AbstractResolver {
 			throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
 		}
 
-		const isSnapshotVersion = version.toLowerCase().endsWith("-snapshot");
-		if (isSnapshotVersion) {
+		const isSnapshotVersionOrRange = version.toLowerCase().endsWith("-snapshot");
+		if (isSnapshotVersionOrRange) {
 			const versionMatch = version.match(VERSION_RANGE_REGEXP);
 			if (versionMatch) {
 				// For snapshot version ranges we need to insert a stand-in "x" for the patch level
@@ -236,7 +227,6 @@ class AbstractResolver {
 		let spec;
 
 		if (semver.validRange(version)) {
-			// Note: Fully qualified versions are also valid ranges
 			spec = version;
 		} else if (encodeURIComponent(version) === version) {
 			// Valid tag name (same check as npm does)
@@ -246,7 +236,7 @@ class AbstractResolver {
 				if (version === "latest" || version === "latest-snapshot") {
 					// Only latest and latest-snapshot are supported which both resolve
 					// to the latest available version.
-					// See isSnapshotVersion flag for -snapshot handling
+					// See "isSnapshotVersionOrRange" for -snapshot handling
 					spec = "*";
 				}
 			} else if (allTags[version]) {
@@ -267,7 +257,9 @@ class AbstractResolver {
 
 		const versions = await this.fetchAllVersions({ui5HomeDir, cwd});
 		const resolvedVersion = semver.maxSatisfying(versions, spec, {
-			includePrerelease: isSnapshotVersion
+			// Allow ranges that end with -SNAPSHOT to match any -SNAPSHOT version
+			// like a normal version in order to support ranges like 1.x.x-SNAPSHOT.
+			includePrerelease: isSnapshotVersionOrRange
 		});
 		if (!resolvedVersion) {
 			if (semver.valid(spec)) {
@@ -301,12 +293,6 @@ class AbstractResolver {
 	static fetchAllTags(options) {
 		return null;
 	}
-}
-
-/* istanbul ignore else */
-if (process.env.NODE_ENV === "test") {
-	// Export pattern for testing to be checked against JSON schema pattern
-	AbstractResolver._SEMVER_VERSION_REGEXP = SEMVER_VERSION_REGEXP;
 }
 
 export default AbstractResolver;

--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -212,45 +212,9 @@ class AbstractResolver {
 			throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
 		}
 
-		const isSnapshotVersionOrRange = version.toLowerCase().endsWith("-snapshot");
-		if (isSnapshotVersionOrRange) {
-			const versionMatch = version.match(VERSION_RANGE_REGEXP);
-			if (versionMatch) {
-				// For snapshot version ranges we need to insert a stand-in "x" for the patch level
-				// and - in case none is provided - another "x" for the major version in order to
-				// convert it to a valid semver range:
-				// "1-SNAPSHOT" becomes "1.x.x-SNAPSHOT" and "1.112-SNAPSHOT" becomes "1.112.x-SNAPSHOT"
-				version = `${versionMatch[1]}.${versionMatch[2] || "x"}.x-SNAPSHOT`;
-			}
-		}
+		const spec = await this._getVersionSpec(version, {ui5HomeDir, cwd});
 
-		let spec;
-
-		if (semver.validRange(version)) {
-			spec = version;
-		} else if (encodeURIComponent(version) === version) {
-			// Valid tag name (same check as npm does)
-			const allTags = await this.fetchAllTags({ui5HomeDir, cwd});
-			if (!allTags) {
-				// Resolver doesn't support tags (e.g. Sapui5MavenSnapshotResolver)
-				if (version === "latest" || version === "latest-snapshot") {
-					// Only latest and latest-snapshot are supported which both resolve
-					// to the latest available version.
-					// See "isSnapshotVersionOrRange" for -snapshot handling
-					spec = "*";
-				}
-			} else if (allTags[version]) {
-				// Use version from tag
-				spec = allTags[version];
-			} else {
-				throw new Error(
-					`Could not resolve framework version via tag '${version}'. ` +
-					`Make sure the tag is available in the configured registry.`
-				);
-			}
-		}
-
-		// For all invalid cases which are not explicitly handled above
+		// For all invalid cases which are not explicitly handled in _getVersionSpec
 		if (!spec) {
 			throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
 		}
@@ -259,8 +223,9 @@ class AbstractResolver {
 		const resolvedVersion = semver.maxSatisfying(versions, spec, {
 			// Allow ranges that end with -SNAPSHOT to match any -SNAPSHOT version
 			// like a normal version in order to support ranges like 1.x.x-SNAPSHOT.
-			includePrerelease: isSnapshotVersionOrRange
+			includePrerelease: this._isSnapshotVersionOrRange(version)
 		});
+
 		if (!resolvedVersion) {
 			if (semver.valid(spec)) {
 				if (this.name === "Sapui5Resolver" && semver.lt(spec, "1.76.0")) {
@@ -277,7 +242,58 @@ class AbstractResolver {
 				`Could not resolve framework version ${version}. ` +
 				`Make sure the version is valid and available in the configured registry.`);
 		}
+
 		return resolvedVersion;
+	}
+
+	static async _getVersionSpec(version, {ui5HomeDir, cwd}) {
+		if (this._isSnapshotVersionOrRange(version)) {
+			const versionMatch = version.match(VERSION_RANGE_REGEXP);
+			if (versionMatch) {
+				// For snapshot version ranges we need to insert a stand-in "x" for the patch level
+				// and - in case none is provided - another "x" for the major version in order to
+				// convert it to a valid semver range:
+				// "1-SNAPSHOT" becomes "1.x.x-SNAPSHOT" and "1.112-SNAPSHOT" becomes "1.112.x-SNAPSHOT"
+				return `${versionMatch[1]}.${versionMatch[2] || "x"}.x-SNAPSHOT`;
+			}
+		}
+
+		if (semver.validRange(version)) {
+			return version;
+		}
+
+		// Check for invalid tag name (same check as npm does)
+		if (encodeURIComponent(version) !== version) {
+			return null;
+		}
+
+		const allTags = await this.fetchAllTags({ui5HomeDir, cwd});
+
+		if (!allTags && (version === "latest" || version === "latest-snapshot")) {
+			// Resolver doesn't support tags (e.g. Sapui5MavenSnapshotResolver)
+			// Only latest and latest-snapshot are supported which both resolve
+			// to the latest available version.
+			// See "isSnapshotVersionOrRange" for -snapshot handling
+			return "*";
+		}
+
+		if (!allTags) {
+			return null;
+		}
+
+		if (!allTags[version]) {
+			throw new Error(
+				`Could not resolve framework version via tag '${version}'. ` +
+				`Make sure the tag is available in the configured registry.`
+			);
+		}
+
+		// Use version from tag
+		return allTags[version];
+	}
+
+	static _isSnapshotVersionOrRange(version) {
+		return version.toLowerCase().endsWith("-snapshot");
 	}
 
 	// To be implemented by resolver

--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -215,6 +215,13 @@ class AbstractResolver {
 	}
 
 	static async resolveVersion(version, {ui5HomeDir, cwd} = {}) {
+		if (version === "latest") {
+			const tagVersion = this.fetchTag("latest", {ui5HomeDir, cwd});
+			if (tagVersion) {
+				return tagVersion;
+			}
+		}
+
 		let spec;
 		const isSnapshotVersion = version.toLowerCase().endsWith("-snapshot");
 		if (version === "latest" || version === "latest-snapshot") {
@@ -238,6 +245,7 @@ class AbstractResolver {
 				throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
 			}
 		}
+
 		const versions = await this.fetchAllVersions({ui5HomeDir, cwd});
 		const resolvedVersion = semver.maxSatisfying(versions, spec, {
 			includePrerelease: isSnapshotVersion
@@ -270,6 +278,9 @@ class AbstractResolver {
 	}
 	static fetchAllVersions(options) {
 		throw new Error("AbstractResolver: static fetchAllVersions must be implemented!");
+	}
+	static fetchTag(tagName, options) {
+		throw new Error("AbstractResolver: static fetchDistTag must be implemented!");
 	}
 }
 

--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -269,16 +269,16 @@ class AbstractResolver {
 
 		const allTags = await this.fetchAllTags({ui5HomeDir, cwd});
 
-		if (!allTags && (version === "latest" || version === "latest-snapshot")) {
+		if (!allTags) {
 			// Resolver doesn't support tags (e.g. Sapui5MavenSnapshotResolver)
 			// Only latest and latest-snapshot are supported which both resolve
 			// to the latest available version.
 			// See "isSnapshotVersionOrRange" for -snapshot handling
-			return "*";
-		}
-
-		if (!allTags) {
-			return null;
+			if ((version === "latest" || version === "latest-snapshot")) {
+				return "*";
+			} else {
+				return null;
+			}
 		}
 
 		if (!allTags[version]) {

--- a/lib/ui5Framework/Openui5Resolver.js
+++ b/lib/ui5Framework/Openui5Resolver.js
@@ -84,24 +84,23 @@ class Openui5Resolver extends AbstractResolver {
 			})
 		};
 	}
-	static async fetchAllVersions({ui5HomeDir, cwd} = {}) {
-		const installer = new Installer({
-			cwd: cwd ? path.resolve(cwd) : process.cwd(),
-			ui5HomeDir:
-				ui5HomeDir ? path.resolve(ui5HomeDir) :
-					path.join(os.homedir(), ".ui5")
-		});
+	static async fetchAllVersions(options) {
+		const installer = this._getInstaller(options);
 		return await installer.fetchPackageVersions({pkgName: OPENUI5_CORE_PACKAGE});
 	}
 
-	static async fetchAllTags({ui5HomeDir, cwd} = {}) {
-		const installer = new Installer({
+	static async fetchAllTags(options) {
+		const installer = this._getInstaller(options);
+		return installer.fetchPackageDistTags({pkgName: OPENUI5_CORE_PACKAGE});
+	}
+
+	static _getInstaller({ui5HomeDir, cwd} = {}) {
+		return new Installer({
 			cwd: cwd ? path.resolve(cwd) : process.cwd(),
 			ui5HomeDir:
 				ui5HomeDir ? path.resolve(ui5HomeDir) :
 					path.join(os.homedir(), ".ui5")
 		});
-		return installer.fetchPackageDistTags({pkgName: OPENUI5_CORE_PACKAGE});
 	}
 }
 

--- a/lib/ui5Framework/Openui5Resolver.js
+++ b/lib/ui5Framework/Openui5Resolver.js
@@ -93,6 +93,17 @@ class Openui5Resolver extends AbstractResolver {
 		});
 		return await installer.fetchPackageVersions({pkgName: OPENUI5_CORE_PACKAGE});
 	}
+
+	static async fetchTag(tagName, {ui5HomeDir, cwd} = {}) {
+		const installer = new Installer({
+			cwd: cwd ? path.resolve(cwd) : process.cwd(),
+			ui5HomeDir:
+				ui5HomeDir ? path.resolve(ui5HomeDir) :
+					path.join(os.homedir(), ".ui5")
+		});
+		const distTags = await installer.fetchPackageDistTags({pkgName: OPENUI5_CORE_PACKAGE});
+		return distTags[tagName];
+	}
 }
 
 export default Openui5Resolver;

--- a/lib/ui5Framework/Openui5Resolver.js
+++ b/lib/ui5Framework/Openui5Resolver.js
@@ -94,15 +94,14 @@ class Openui5Resolver extends AbstractResolver {
 		return await installer.fetchPackageVersions({pkgName: OPENUI5_CORE_PACKAGE});
 	}
 
-	static async fetchTag(tagName, {ui5HomeDir, cwd} = {}) {
+	static async fetchAllTags({ui5HomeDir, cwd} = {}) {
 		const installer = new Installer({
 			cwd: cwd ? path.resolve(cwd) : process.cwd(),
 			ui5HomeDir:
 				ui5HomeDir ? path.resolve(ui5HomeDir) :
 					path.join(os.homedir(), ".ui5")
 		});
-		const distTags = await installer.fetchPackageDistTags({pkgName: OPENUI5_CORE_PACKAGE});
-		return distTags[tagName];
+		return installer.fetchPackageDistTags({pkgName: OPENUI5_CORE_PACKAGE});
 	}
 }
 

--- a/lib/ui5Framework/Sapui5Resolver.js
+++ b/lib/ui5Framework/Sapui5Resolver.js
@@ -114,6 +114,17 @@ class Sapui5Resolver extends AbstractResolver {
 		});
 		return await installer.fetchPackageVersions({pkgName: DIST_PKG_NAME});
 	}
+
+	static async fetchTag(tagName, {ui5HomeDir, cwd} = {}) {
+		const installer = new Installer({
+			cwd: cwd ? path.resolve(cwd) : process.cwd(),
+			ui5HomeDir:
+				ui5HomeDir ? path.resolve(ui5HomeDir) :
+					path.join(os.homedir(), ".ui5")
+		});
+		const distTags = await installer.fetchPackageDistTags({pkgName: DIST_PKG_NAME});
+		return distTags[tagName];
+	}
 }
 
 export default Sapui5Resolver;

--- a/lib/ui5Framework/Sapui5Resolver.js
+++ b/lib/ui5Framework/Sapui5Resolver.js
@@ -105,24 +105,23 @@ class Sapui5Resolver extends AbstractResolver {
 			})
 		};
 	}
-	static async fetchAllVersions({ui5HomeDir, cwd} = {}) {
-		const installer = new Installer({
-			cwd: cwd ? path.resolve(cwd) : process.cwd(),
-			ui5HomeDir:
-				ui5HomeDir ? path.resolve(ui5HomeDir) :
-					path.join(os.homedir(), ".ui5")
-		});
+	static async fetchAllVersions(options) {
+		const installer = this._getInstaller(options);
 		return await installer.fetchPackageVersions({pkgName: DIST_PKG_NAME});
 	}
 
-	static async fetchAllTags({ui5HomeDir, cwd} = {}) {
-		const installer = new Installer({
+	static async fetchAllTags(options) {
+		const installer = this._getInstaller(options);
+		return installer.fetchPackageDistTags({pkgName: DIST_PKG_NAME});
+	}
+
+	static _getInstaller({ui5HomeDir, cwd} = {}) {
+		return new Installer({
 			cwd: cwd ? path.resolve(cwd) : process.cwd(),
 			ui5HomeDir:
 				ui5HomeDir ? path.resolve(ui5HomeDir) :
 					path.join(os.homedir(), ".ui5")
 		});
-		return installer.fetchPackageDistTags({pkgName: DIST_PKG_NAME});
 	}
 }
 

--- a/lib/ui5Framework/Sapui5Resolver.js
+++ b/lib/ui5Framework/Sapui5Resolver.js
@@ -115,15 +115,14 @@ class Sapui5Resolver extends AbstractResolver {
 		return await installer.fetchPackageVersions({pkgName: DIST_PKG_NAME});
 	}
 
-	static async fetchTag(tagName, {ui5HomeDir, cwd} = {}) {
+	static async fetchAllTags({ui5HomeDir, cwd} = {}) {
 		const installer = new Installer({
 			cwd: cwd ? path.resolve(cwd) : process.cwd(),
 			ui5HomeDir:
 				ui5HomeDir ? path.resolve(ui5HomeDir) :
 					path.join(os.homedir(), ".ui5")
 		});
-		const distTags = await installer.fetchPackageDistTags({pkgName: DIST_PKG_NAME});
-		return distTags[tagName];
+		return installer.fetchPackageDistTags({pkgName: DIST_PKG_NAME});
 	}
 }
 

--- a/lib/ui5Framework/npm/Installer.js
+++ b/lib/ui5Framework/npm/Installer.js
@@ -57,6 +57,11 @@ class Installer extends AbstractInstaller {
 		return Object.keys(packument.versions);
 	}
 
+	async fetchPackageDistTags({pkgName}) {
+		const packument = await this.getRegistry().requestPackagePackument(pkgName);
+		return packument["dist-tags"];
+	}
+
 	async fetchPackageManifest({pkgName, version}) {
 		const targetDir = this._getTargetDirForPackage({pkgName, version});
 		try {

--- a/test/lib/graph/helpers/ui5Framework.integration.js
+++ b/test/lib/graph/helpers/ui5Framework.integration.js
@@ -150,6 +150,7 @@ test.afterEach.always((t) => {
 	esmock.purge(t.context.Registry);
 	esmock.purge(t.context.Installer);
 	esmock.purge(t.context.AbstractResolver);
+	esmock.purge(t.context.Openui5Resolver);
 	esmock.purge(t.context.Sapui5Resolver);
 	esmock.purge(t.context.Application);
 	esmock.purge(t.context.Library);

--- a/test/lib/ui5framework/AbstractResolver.js
+++ b/test/lib/ui5framework/AbstractResolver.js
@@ -2,8 +2,6 @@ import test from "ava";
 import sinon from "sinon";
 import path from "node:path";
 import os from "node:os";
-import {fileURLToPath} from "node:url";
-import {readFile} from "node:fs/promises";
 import esmock from "esmock";
 
 test.beforeEach(async (t) => {

--- a/test/lib/ui5framework/AbstractResolver.js
+++ b/test/lib/ui5framework/AbstractResolver.js
@@ -815,60 +815,241 @@ test.serial("AbstractResolver: Static resolveVersion throws error for 'lts'", as
 	t.is(fetchAllVersionsStub.callCount, 0, "fetchAllVersions should not be called");
 });
 
-test.serial("AbstractResolver: Static resolveVersion throws error for '1.x'", async (t) => {
+test.serial("AbstractResolver: Static resolveVersion resolves '1.x'", async (t) => {
 	const {MyResolver} = t.context;
-	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions");
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.76.0", "2.0.0"]);
 
-	const error = await t.throwsAsync(MyResolver.resolveVersion("1.x", {
+	const version = await MyResolver.resolveVersion("1.x", {
 		cwd: "/cwd",
 		ui5HomeDir: "/ui5HomeDir"
-	}));
+	});
 
-	t.is(error.message, `Framework version specifier "1.x" is incorrect or not supported`);
+	t.is(version, "1.76.0", "Resolved version should be correct");
 
-	t.is(fetchAllVersionsStub.callCount, 0, "fetchAllVersions should not be called");
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
 });
 
-test.serial("AbstractResolver: Static resolveVersion throws error for '1.75.x'", async (t) => {
+test.serial("AbstractResolver: Static resolveVersion resolves '1.75.x'", async (t) => {
 	const {MyResolver} = t.context;
-	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions");
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.76.0", "2.0.0"]);
 
-	const error = await t.throwsAsync(MyResolver.resolveVersion("1.75.x", {
+	const version = await MyResolver.resolveVersion("1.75.x", {
 		cwd: "/cwd",
 		ui5HomeDir: "/ui5HomeDir"
-	}));
+	});
 
-	t.is(error.message, `Framework version specifier "1.75.x" is incorrect or not supported`);
+	t.is(version, "1.75.1", "Resolved version should be correct");
 
-	t.is(fetchAllVersionsStub.callCount, 0, "fetchAllVersions should not be called");
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
 });
 
-test.serial("AbstractResolver: Static resolveVersion throws error for '^1.75.0'", async (t) => {
+test.serial("AbstractResolver: Static resolveVersion resolves '^1.75.0'", async (t) => {
 	const {MyResolver} = t.context;
-	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions");
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.76.0", "2.0.0"]);
 
-	const error = await t.throwsAsync(MyResolver.resolveVersion("^1.75.0", {
+	const version = await MyResolver.resolveVersion("^1.75.0", {
 		cwd: "/cwd",
 		ui5HomeDir: "/ui5HomeDir"
-	}));
+	});
 
-	t.is(error.message, `Framework version specifier "^1.75.0" is incorrect or not supported`);
+	t.is(version, "1.76.0", "Resolved version should be correct");
 
-	t.is(fetchAllVersionsStub.callCount, 0, "fetchAllVersions should not be called");
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
 });
 
-test.serial("AbstractResolver: Static resolveVersion throws error for '~1.75.0'", async (t) => {
+test.serial("AbstractResolver: Static resolveVersion resolves '~1.75.0'", async (t) => {
 	const {MyResolver} = t.context;
-	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions");
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.76.0", "2.0.0"]);
 
-	const error = await t.throwsAsync(MyResolver.resolveVersion("~1.75.0", {
+	const version = await MyResolver.resolveVersion("~1.75.0", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	t.is(version, "1.75.1", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+});
+
+test.serial("AbstractResolver: Static resolveVersion resolves '> 1.75.0 < 1.75.3'", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.75.2", "1.75.3"]);
+
+	const version = await MyResolver.resolveVersion("> 1.75.0 < 1.75.3", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	t.is(version, "1.75.2", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+});
+
+test.serial("AbstractResolver: Static resolveVersion resolves 'next' using tags", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.0.0", "2.0.0"]);
+	const fetchAllTagsStub = sinon.stub(MyResolver, "fetchAllTags")
+		.resolves({
+			"latest": "1.0.0",
+			"next": "2.0.0"
+		});
+
+	const version = await MyResolver.resolveVersion("next", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	t.is(version, "2.0.0", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+	t.is(fetchAllTagsStub.callCount, 1, "fetchAllTagsStub should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllTags should be called with expected arguments");
+});
+
+test.serial("AbstractResolver: Static resolveVersion resolves 'next' to a pre-release using tags", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.0.0", "2.0.0-SNAPSHOT"]);
+	const fetchAllTagsStub = sinon.stub(MyResolver, "fetchAllTags")
+		.resolves({
+			"latest": "1.0.0",
+			"next": "2.0.0-SNAPSHOT"
+		});
+
+	const version = await MyResolver.resolveVersion("next", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	t.is(version, "2.0.0-SNAPSHOT", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+	t.is(fetchAllTagsStub.callCount, 1, "fetchAllTagsStub should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllTags should be called with expected arguments");
+});
+
+
+test.serial("AbstractResolver: Static resolveVersion resolves 'latest' using tags only " +
+"when the resolver supports them", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.76.0", "2.0.0"]);
+	const fetchAllTagsStub = sinon.stub(MyResolver, "fetchAllTags")
+		.resolves(null);
+
+	// Resolver does not support tags (resolves with "null" instead of an object)
+	// 'latest' should resolve to the highest version available
+	const version1 = await MyResolver.resolveVersion("latest", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+	t.is(version1, "2.0.0", "Resolved version should be correct");
+
+	t.is(fetchAllTagsStub.callCount, 1, "fetchAllTagsStub should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllTags should be called with expected arguments");
+
+	// Change behavior of Resolver to support tags, so that version should be used now
+	// instead of the highest version
+	fetchAllTagsStub.resolves({
+		"latest": "1.76.0"
+	});
+	const version2 = await MyResolver.resolveVersion("latest", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+	t.is(version2, "1.76.0", "Resolved version should be correct");
+
+	t.is(fetchAllTagsStub.callCount, 2, "fetchAllTagsStub should be called twice");
+	t.deepEqual(fetchAllVersionsStub.getCall(1).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllTags should be called with expected arguments");
+});
+
+test.serial("AbstractResolver: Static resolveVersion throws error for empty string", async (t) => {
+	const {MyResolver} = t.context;
+	sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.76.0"]);
+
+	const error = await t.throwsAsync(MyResolver.resolveVersion("", {
 		cwd: "/cwd",
 		ui5HomeDir: "/ui5HomeDir"
 	}));
 
-	t.is(error.message, `Framework version specifier "~1.75.0" is incorrect or not supported`);
+	t.is(error.message, `Framework version specifier "" is incorrect or not supported`);
+});
 
-	t.is(fetchAllVersionsStub.callCount, 0, "fetchAllVersions should not be called");
+test.serial("AbstractResolver: Static resolveVersion throws error for invalid tag name", async (t) => {
+	const {MyResolver} = t.context;
+	sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.76.0"]);
+
+	const error = await t.throwsAsync(MyResolver.resolveVersion("%20", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}));
+
+	t.is(error.message, `Framework version specifier "%20" is incorrect or not supported`);
+});
+
+test.serial("AbstractResolver: Static resolveVersion throws error for non-existing tag", async (t) => {
+	const {MyResolver} = t.context;
+	sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0", "1.75.1", "1.76.0"]);
+	sinon.stub(MyResolver, "fetchAllTags")
+		.resolves({"latest": "1.76.0"});
+
+	const error = await t.throwsAsync(MyResolver.resolveVersion("this-tag-does-not-exist", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}));
+
+	t.is(error.message, `Could not resolve framework version via tag 'this-tag-does-not-exist'. ` +
+		`Make sure the tag is available in the configured registry.`
+	);
 });
 
 test.serial("AbstractResolver: Static resolveVersion throws error for version not found", async (t) => {

--- a/test/lib/ui5framework/AbstractResolver.js
+++ b/test/lib/ui5framework/AbstractResolver.js
@@ -595,7 +595,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR'", async (t
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
-test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR-prerelease'", async (t) => {
+test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR-SNAPSHOT'", async (t) => {
 	const {MyResolver} = t.context;
 	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
 		.returns(["1.76.0", "1.77.0", "1.77.0-SNAPSHOT", "1.78.0", "1.79.0-SNAPSHOT"]);
@@ -633,7 +633,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR'", as
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
-test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR-prerelease'", async (t) => {
+test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR-SNAPSHOT'", async (t) => {
 	const {MyResolver} = t.context;
 	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
 		.returns(["1.76.0", "1.77.0", "1.77.0-SNAPSHOT", "1.78.0", "1.79.0-SNAPSHOT"]);
@@ -671,7 +671,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
-test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH-prerelease'", async (t) => {
+test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH-SNAPSHOT'", async (t) => {
 	const {MyResolver} = t.context;
 	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
 		.returns(["1.76.0", "1.77.0", "1.77.0-SNAPSHOT", "1.78.0", "1.79.0-SNAPSHOT"]);
@@ -720,44 +720,6 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'latest-snapshot'"
 	});
 
 	t.is(version, "1.76.1-SNAPSHOT", "Resolved version should be correct");
-
-	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
-	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
-		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
-	}], "fetchAllVersions should be called with expected arguments");
-});
-
-test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR-SNAPSHOT'", async (t) => {
-	const {MyResolver} = t.context;
-	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
-		.returns(["1.75.0-SNAPSHOT", "1.75.1-SNAPSHOT", "1.76.0-SNAPSHOT", "1.76.1-SNAPSHOT"]);
-
-	const version = await MyResolver.resolveVersion("1.75-SNAPSHOT", {
-		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
-	});
-
-	t.is(version, "1.75.1-SNAPSHOT", "Resolved version should be correct");
-
-	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
-	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
-		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
-	}], "fetchAllVersions should be called with expected arguments");
-});
-
-test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH-SNAPSHOT'", async (t) => {
-	const {MyResolver} = t.context;
-	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
-		.returns(["1.75.0-SNAPSHOT", "1.75.1-SNAPSHOT", "1.76.0-SNAPSHOT", "1.76.1-SNAPSHOT"]);
-
-	const version = await MyResolver.resolveVersion("1.75.0-SNAPSHOT", {
-		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
-	});
-
-	t.is(version, "1.75.0-SNAPSHOT", "Resolved version should be correct");
 
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
@@ -902,6 +864,69 @@ test.serial("AbstractResolver: Static resolveVersion resolves '> 1.75.0 < 1.75.3
 	});
 
 	t.is(version, "1.75.2", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+});
+
+test.serial("AbstractResolver: Static resolveVersion resolves 'x.x.x-SNAPSHOT'", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["1.75.0-SNAPSHOT", "1.76.0-SNAPSHOT", "1.77.0-SNAPSHOT"]);
+
+	const version = await MyResolver.resolveVersion("x.x.x-SNAPSHOT", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	// All ranges ending with -SNAPSHOT should use "includePrerelease" in order to
+	// properly match prerelease (i.e. -SNAPSHOT) versions.
+	t.is(version, "1.77.0-SNAPSHOT", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+});
+
+test.serial("AbstractResolver: Static resolveVersion resolves '^2.0.0-SNAPSHOT'", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["2.0.0-SNAPSHOT", "2.0.1-SNAPSHOT", "2.1.0-SNAPSHOT"]);
+
+	const version = await MyResolver.resolveVersion("^2.0.0-SNAPSHOT", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	// All ranges ending with -SNAPSHOT should use "includePrerelease" in order to
+	// properly match prerelease (i.e. -SNAPSHOT) versions.
+	t.is(version, "2.1.0-SNAPSHOT", "Resolved version should be correct");
+
+	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
+	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	}], "fetchAllVersions should be called with expected arguments");
+});
+
+test.serial("AbstractResolver: Static resolveVersion resolves '2.x.x-alpha'", async (t) => {
+	const {MyResolver} = t.context;
+	const fetchAllVersionsStub = sinon.stub(MyResolver, "fetchAllVersions")
+		.returns(["2.0.0-alpha", "2.0.1-alpha", "2.1.0-alpha"]);
+
+	const version = await MyResolver.resolveVersion("^2.0.0-alpha", {
+		cwd: "/cwd",
+		ui5HomeDir: "/ui5HomeDir"
+	});
+
+	// Prerelease ranges other than -SNAPSHOT should not use "includePrerelease"
+	// and therefore not match pre-releases like normal versions
+	t.is(version, "2.0.0-alpha", "Resolved version should be correct");
 
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
@@ -1181,15 +1206,3 @@ test.serial(
 		t.is(error.message, `Could not resolve framework version 1.99. ` +
 			`Make sure the version is valid and available in the configured registry.`);
 	});
-
-test.serial("AbstractResolver: SEMVER_VERSION_REGEXP should be aligned with JSON schema", async (t) => {
-	const {AbstractResolver} = t.context;
-
-	const projectSchema = JSON.parse(
-		await readFile(fileURLToPath(
-			new URL("../../../lib/validation/schema/specVersion/kind/project.json", import.meta.url)
-		), {encoding: "utf-8"})
-	);
-	const schemaPattern = projectSchema.definitions.framework.properties.version.pattern;
-	t.is(schemaPattern, AbstractResolver._SEMVER_VERSION_REGEXP.source);
-});

--- a/test/lib/ui5framework/Openui5Resolver.integration.js
+++ b/test/lib/ui5framework/Openui5Resolver.integration.js
@@ -1,0 +1,201 @@
+import test from "ava";
+import sinonGlobal from "sinon";
+import esmock from "esmock";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Use path within project as mocking base directory to reduce chance of side effects
+// in case mocks/stubs do not work and real fs is used
+const fakeBaseDir = path.join(__dirname, "fake-tmp");
+
+test.beforeEach(async (t) => {
+	const sinon = t.context.sinon = sinonGlobal.createSandbox();
+
+	t.context.logStub = {
+		info: sinon.stub(),
+		verbose: sinon.stub(),
+		silly: sinon.stub(),
+		warn: sinon.stub(),
+		error: sinon.stub(),
+		isLevelEnabled: sinon.stub().returns(false),
+		_getLogger: sinon.stub()
+	};
+	const ui5Logger = {
+		getLogger: sinon.stub().returns(t.context.logStub)
+	};
+
+	t.context.pacote = {
+		packument: sinon.stub().callsFake(async (...args) => {
+			throw new Error(`pacote.packument stub called with unknown args: ${args}`);
+		})
+	};
+
+	t.context.NpmcliConfig = sinon.stub().returns({
+		load: sinon.stub().resolves(),
+		flat: {
+			registry: "https://registry.fake"
+		}
+	});
+
+	t.context.Registry = await esmock.p("../../../lib/ui5Framework/npm/Registry.js", {
+		"@ui5/logger": ui5Logger,
+		"pacote": t.context.pacote,
+		"@npmcli/config": {
+			"default": t.context.NpmcliConfig
+		}
+	});
+
+	const AbstractInstaller = await esmock.p("../../../lib/ui5Framework/AbstractInstaller.js", {
+		"@ui5/logger": ui5Logger,
+		"../../../lib/utils/fs.js": {
+			mkdirp: sinon.stub().resolves()
+		},
+		"lockfile": {
+			lock: sinon.stub().yieldsAsync(),
+			unlock: sinon.stub().yieldsAsync()
+		}
+	});
+
+	t.context.Installer = await esmock.p("../../../lib/ui5Framework/npm/Installer.js", {
+		"@ui5/logger": ui5Logger,
+		"graceful-fs": {
+			rename: sinon.stub().yieldsAsync(),
+		},
+		"../../../lib/utils/fs.js": {
+			mkdirp: sinon.stub().resolves()
+		},
+		"../../../lib/ui5Framework/npm/Registry.js": t.context.Registry,
+		"../../../lib/ui5Framework/AbstractInstaller.js": AbstractInstaller
+	});
+
+	t.context.AbstractResolver = await esmock.p("../../../lib/ui5Framework/AbstractResolver.js", {
+		"@ui5/logger": ui5Logger,
+		"node:os": {
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+		},
+	});
+
+	t.context.Openui5Resolver = await esmock.p("../../../lib/ui5Framework/Openui5Resolver.js", {
+		"@ui5/logger": ui5Logger,
+		"node:os": {
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+		},
+		"../../../lib/ui5Framework/AbstractResolver.js": t.context.AbstractResolver,
+		"../../../lib/ui5Framework/npm/Installer.js": t.context.Installer
+	});
+});
+
+test.afterEach.always((t) => {
+	t.context.sinon.restore();
+	esmock.purge(t.context.Registry);
+	esmock.purge(t.context.Installer);
+	esmock.purge(t.context.AbstractResolver);
+	esmock.purge(t.context.Openui5Resolver);
+});
+
+test.serial("resolveVersion", async (t) => {
+	const {Openui5Resolver, pacote, logStub, NpmcliConfig} = t.context;
+
+	pacote.packument
+		.withArgs("@openui5/sap.ui.core")
+		.resolves({
+			"versions": {
+				"1.120.1": "",
+				"1.120.0": "",
+				"1.119.0": "",
+				"1.118.0": "",
+				"2.0.0-rc.1": "",
+				"1.123.4-SNAPSHOT": ""
+			},
+			"dist-tags": {
+				// NOTE: latest does not correspond to highest version in order to verify
+				// that this tag is used instead of picking the highest version
+				"latest": "1.120.0",
+
+				"next": "2.0.0-rc.1",
+
+				// NOTE: Tag ends with "-snapshot" in order to verify that the special handling
+				// of that
+				"not-a-snapshot": "1.118.0"
+			}
+		});
+
+	const defaultCwd = process.cwd();
+	const defaultUi5HomeDir = path.join(fakeBaseDir, "homedir", ".ui5");
+
+	// Generic testing without and with options argument
+	const optionsArguments = [
+		undefined,
+		{
+			cwd: path.join(fakeBaseDir, "custom-cwd"),
+			ui5HomeDir: path.join(fakeBaseDir, "custom-homedir", ".ui5")
+		}
+	];
+	for (const options of optionsArguments) {
+		// Reset calls to be able to check them per for-loop run
+		NpmcliConfig.resetHistory();
+		pacote.packument.resetHistory();
+
+		// Ranges
+		t.is(await Openui5Resolver.resolveVersion("1", options), "1.120.1");
+		t.is(await Openui5Resolver.resolveVersion("1.120", options), "1.120.1");
+		t.is(await Openui5Resolver.resolveVersion("1.x", options), "1.120.1");
+		t.is(await Openui5Resolver.resolveVersion("1.x.x", options), "1.120.1");
+		t.is(await Openui5Resolver.resolveVersion("^1", options), "1.120.1");
+		t.is(await Openui5Resolver.resolveVersion("*", options), "1.120.1");
+
+		// Tags
+		t.is(await Openui5Resolver.resolveVersion("latest", options), "1.120.0");
+		t.is(await Openui5Resolver.resolveVersion("next", options), "2.0.0-rc.1");
+		t.is(await Openui5Resolver.resolveVersion("not-a-snapshot", options), "1.118.0");
+
+		// Exact versions
+		t.is(await Openui5Resolver.resolveVersion("1.118.0", options), "1.118.0");
+		t.is(await Openui5Resolver.resolveVersion("2.0.0-rc.1", options), "2.0.0-rc.1");
+		t.is(await Openui5Resolver.resolveVersion("1.123.4-SNAPSHOT", options), "1.123.4-SNAPSHOT");
+
+		// SNAPSHOT ranges
+		t.is(await Openui5Resolver.resolveVersion("1-SNAPSHOT", options), "1.123.4-SNAPSHOT");
+		t.is(await Openui5Resolver.resolveVersion("1.123-SNAPSHOT", options), "1.123.4-SNAPSHOT");
+
+		// Error cases
+		await t.throwsAsync(Openui5Resolver.resolveVersion("", options), {
+			message: `Framework version specifier "" is incorrect or not supported`
+		});
+		await t.throwsAsync(Openui5Resolver.resolveVersion("tag-does-not-exist", options), {
+			message: `Could not resolve framework version via tag 'tag-does-not-exist'. ` +
+				`Make sure the tag is available in the configured registry.`
+		});
+		await t.throwsAsync(Openui5Resolver.resolveVersion("invalid-tag-%20", options), {
+			message: `Framework version specifier "invalid-tag-%20" is incorrect or not supported`
+		});
+
+		await t.throwsAsync(Openui5Resolver.resolveVersion("1.999.9", options), {
+			message: `Could not resolve framework version 1.999.9. ` +
+				`Make sure the version is valid and available in the configured registry.`
+		});
+		await t.throwsAsync(Openui5Resolver.resolveVersion("1.0.0", options), {
+			message: `Could not resolve framework version 1.0.0. ` +
+				`Note that OpenUI5 framework libraries can only be consumed by the UI5 Tooling ` +
+				`starting with OpenUI5 v1.52.5`
+		});
+		await t.throwsAsync(Openui5Resolver.resolveVersion("^999", options), {
+			message: `Could not resolve framework version ^999. ` +
+				`Make sure the version is valid and available in the configured registry.`
+		});
+
+		// Check whether options have been passed as expected
+		t.true(NpmcliConfig.alwaysCalledWithNew());
+		t.true(NpmcliConfig.alwaysCalledWithMatch(sinonGlobal.match({
+			cwd: options?.cwd ?? defaultCwd
+		})));
+		t.true(pacote.packument.alwaysCalledWithMatch("@openui5/sap.ui.core", {
+			cache: path.join(options?.ui5HomeDir ?? defaultUi5HomeDir, "framework", "cacache")
+		}));
+	}
+
+	t.is(logStub.warn.callCount, 0);
+	t.is(logStub.error.callCount, 0);
+});

--- a/test/lib/ui5framework/Openui5Resolver.js
+++ b/test/lib/ui5framework/Openui5Resolver.js
@@ -6,11 +6,13 @@ import os from "node:os";
 
 test.beforeEach(async (t) => {
 	t.context.InstallerStub = sinon.stub();
+	t.context.fetchPackageDistTags = sinon.stub();
 	t.context.fetchPackageManifestStub = sinon.stub();
 	t.context.fetchPackageVersionsStub = sinon.stub();
 	t.context.installPackageStub = sinon.stub();
 	t.context.InstallerStub.callsFake(() => {
 		return {
+			fetchPackageDistTags: t.context.fetchPackageDistTags,
 			fetchPackageManifest: t.context.fetchPackageManifestStub,
 			fetchPackageVersions: t.context.fetchPackageVersionsStub,
 			installPackage: t.context.installPackageStub
@@ -139,39 +141,47 @@ test.serial("Openui5Resolver: handleLibrary", async (t) => {
 	t.deepEqual(await promises.install, {pkgPath: "/foo/sap.ui.lib1"}, "Install should resolve with expected object");
 });
 
-test.serial("Openui5Resolver: Static fetchAllVersions", async (t) => {
+test.serial("Openui5Resolver: Static _getInstaller", (t) => {
 	const {Openui5Resolver} = t.context;
 
-	const expectedVersions = ["1.75.0", "1.75.1", "1.76.0"];
 	const options = {
 		cwd: "/cwd",
 		ui5HomeDir: "/ui5HomeDir"
 	};
 
-	t.context.fetchPackageVersionsStub.returns(expectedVersions);
-
-	const versions = await Openui5Resolver.fetchAllVersions(options);
-
-	t.deepEqual(versions, expectedVersions, "Fetched versions should be correct");
-
-	t.is(t.context.fetchPackageVersionsStub.callCount, 1, "fetchPackageVersions should be called once");
-	t.deepEqual(t.context.fetchPackageVersionsStub.getCall(0).args, [{pkgName: "@openui5/sap.ui.core"}],
-		"fetchPackageVersions should be called with expected arguments");
+	const installer = Openui5Resolver._getInstaller(options);
 
 	t.is(t.context.InstallerStub.callCount, 1, "Installer should be called once");
 	t.true(t.context.InstallerStub.calledWithNew(), "Installer should be called with new");
+	t.is(installer, t.context.InstallerStub.getCall(0).returnValue, "Installer instance is returned");
 	t.deepEqual(t.context.InstallerStub.getCall(0).args, [{
 		cwd: path.resolve("/cwd"),
 		ui5HomeDir: path.resolve("/ui5HomeDir")
 	}], "Installer should be called with expected arguments");
 });
 
-test.serial("Openui5Resolver: Static fetchAllVersions without options", async (t) => {
+test.serial("Openui5Resolver: Static _getInstaller without options", (t) => {
+	const {Openui5Resolver} = t.context;
+
+	const installer = Openui5Resolver._getInstaller();
+
+	t.is(t.context.InstallerStub.callCount, 1, "Installer should be called once");
+	t.true(t.context.InstallerStub.calledWithNew(), "Installer should be called with new");
+	t.is(installer, t.context.InstallerStub.getCall(0).returnValue, "Installer instance is returned");
+	t.deepEqual(t.context.InstallerStub.getCall(0).args, [{
+		cwd: process.cwd(),
+		ui5HomeDir: path.join(os.homedir(), ".ui5")
+	}], "Installer should be called with expected arguments");
+});
+
+test.serial("Openui5Resolver: Static fetchAllVersions", async (t) => {
 	const {Openui5Resolver} = t.context;
 
 	const expectedVersions = ["1.75.0", "1.75.1", "1.76.0"];
 
 	t.context.fetchPackageVersionsStub.returns(expectedVersions);
+
+	const getInstallerSpy = sinon.spy(Openui5Resolver, "_getInstaller");
 
 	const versions = await Openui5Resolver.fetchAllVersions();
 
@@ -181,10 +191,27 @@ test.serial("Openui5Resolver: Static fetchAllVersions without options", async (t
 	t.deepEqual(t.context.fetchPackageVersionsStub.getCall(0).args, [{pkgName: "@openui5/sap.ui.core"}],
 		"fetchPackageVersions should be called with expected arguments");
 
-	t.is(t.context.InstallerStub.callCount, 1, "Installer should be called once");
-	t.true(t.context.InstallerStub.calledWithNew(), "Installer should be called with new");
-	t.deepEqual(t.context.InstallerStub.getCall(0).args, [{
-		cwd: process.cwd(),
-		ui5HomeDir: path.join(os.homedir(), ".ui5")
-	}], "Installer should be called with expected arguments");
+	t.is(getInstallerSpy.callCount, 1, "_getInstaller should be called once");
+	t.is(getInstallerSpy.getCall(0).args[0], undefined, "_getInstaller should be called without any options");
+});
+
+test.serial("Openui5Resolver: Static fetchAllTags", async (t) => {
+	const {Openui5Resolver} = t.context;
+
+	const expectedTags = ["latest", "latest-1.71", "latest-1"];
+
+	t.context.fetchPackageDistTags.returns(expectedTags);
+
+	const getInstallerSpy = sinon.spy(Openui5Resolver, "_getInstaller");
+
+	const tags = await Openui5Resolver.fetchAllTags();
+
+	t.deepEqual(tags, expectedTags, "Fetched tags should be correct");
+
+	t.is(t.context.fetchPackageDistTags.callCount, 1, "fetchPackageVersions should be called once");
+	t.deepEqual(t.context.fetchPackageDistTags.getCall(0).args, [{pkgName: "@openui5/sap.ui.core"}],
+		"fetchPackageVersions should be called with expected arguments");
+
+	t.is(getInstallerSpy.callCount, 1, "_getInstaller should be called once");
+	t.is(getInstallerSpy.getCall(0).args[0], undefined, "_getInstaller should be called without any options");
 });

--- a/test/lib/ui5framework/Sapui5MavenSnapshotResolver.integration.js
+++ b/test/lib/ui5framework/Sapui5MavenSnapshotResolver.integration.js
@@ -1,0 +1,158 @@
+import test from "ava";
+import sinonGlobal from "sinon";
+import esmock from "esmock";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Use path within project as mocking base directory to reduce chance of side effects
+// in case mocks/stubs do not work and real fs is used
+const fakeBaseDir = path.join(__dirname, "fake-tmp");
+
+test.beforeEach(async (t) => {
+	const sinon = t.context.sinon = sinonGlobal.createSandbox();
+
+	process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT_URL = "_SNAPSHOT_URL_";
+
+	t.context.logStub = {
+		info: sinon.stub(),
+		verbose: sinon.stub(),
+		silly: sinon.stub(),
+		warn: sinon.stub(),
+		error: sinon.stub(),
+		isLevelEnabled: sinon.stub().returns(false),
+		_getLogger: sinon.stub()
+	};
+	const ui5Logger = {
+		getLogger: sinon.stub().returns(t.context.logStub)
+	};
+
+	t.context.makeFetchHappen = sinon.stub();
+
+	t.context.gracefulFs = {
+		stat: sinon.stub().yieldsAsync(),
+		readFile: sinon.stub().yieldsAsync(),
+		writeFile: sinon.stub().yieldsAsync(),
+		rename: sinon.stub().yieldsAsync(),
+		rm: sinon.stub().yieldsAsync(),
+		createWriteStream: sinon.stub()
+	};
+
+	t.context.Registry = await esmock.p("../../../lib/ui5Framework/maven/Registry.js", {
+		"@ui5/logger": ui5Logger,
+		"graceful-fs": t.context.gracefulFs,
+		"make-fetch-happen": t.context.makeFetchHappen,
+	});
+
+	const AbstractInstaller = await esmock.p("../../../lib/ui5Framework/AbstractInstaller.js", {
+		"@ui5/logger": ui5Logger,
+		"../../../lib/utils/fs.js": {
+			mkdirp: sinon.stub().resolves()
+		},
+		"lockfile": {
+			lock: sinon.stub().yieldsAsync(),
+			unlock: sinon.stub().yieldsAsync()
+		}
+	});
+
+	t.context.Installer = await esmock.p("../../../lib/ui5Framework/maven/Installer.js", {
+		"@ui5/logger": ui5Logger,
+		"graceful-fs": t.context.gracefulFs,
+		"../../../lib/utils/fs.js": {
+			mkdirp: sinon.stub().resolves()
+		},
+		"../../../lib/ui5Framework/maven/Registry.js": t.context.Registry,
+		"../../../lib/ui5Framework/AbstractInstaller.js": AbstractInstaller
+	});
+
+	t.context.AbstractResolver = await esmock.p("../../../lib/ui5Framework/AbstractResolver.js", {
+		"@ui5/logger": ui5Logger,
+		"node:os": {
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+		},
+	});
+
+	t.context.Sapui5MavenSnapshotResolver = await esmock.p("../../../lib/ui5Framework/Sapui5MavenSnapshotResolver.js", {
+		"@ui5/logger": ui5Logger,
+		"node:os": {
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+		},
+		"../../../lib/ui5Framework/AbstractResolver.js": t.context.AbstractResolver,
+		"../../../lib/ui5Framework/maven/Installer.js": t.context.Installer
+	});
+});
+
+test.afterEach.always((t) => {
+	t.context.sinon.restore();
+	esmock.purge(t.context.Registry);
+	esmock.purge(t.context.Installer);
+	esmock.purge(t.context.AbstractResolver);
+	esmock.purge(t.context.Sapui5MavenSnapshotResolver);
+	delete process.env.UI5_MAVEN_SNAPSHOT_ENDPOINT_URL;
+});
+
+test.serial("resolveVersion", async (t) => {
+	const {Sapui5MavenSnapshotResolver, makeFetchHappen, logStub, sinon} = t.context;
+
+	makeFetchHappen.withArgs("_SNAPSHOT_URL_/com/sap/ui5/dist/sapui5-sdk-dist/maven-metadata.xml")
+		.resolves({
+			ok: true,
+			buffer: sinon.stub().resolves(`
+			<?xml version="1.0" encoding="UTF-8"?>
+			<metadata>
+			  <versioning>
+				<versions>
+					<version>1.120.1</version>
+					<version>2.0.0-rc.1</version>
+					<version>1.120.1-SNAPSHOT</version>
+					<version>1.123.4-SNAPSHOT</version>
+					<version>2.0.0-SNAPSHOT</version>
+					<version>2.0.1-SNAPSHOT</version>
+					<version>2.1.2-SNAPSHOT</version>
+				</versions>
+			  </versioning>
+			</metadata>
+			`)
+		});
+
+
+	// Exact SNAPSHOT versions
+	t.is(await Sapui5MavenSnapshotResolver.resolveVersion("1.123.4-SNAPSHOT"), "1.123.4-SNAPSHOT");
+	t.is(await Sapui5MavenSnapshotResolver.resolveVersion("2.0.1-SNAPSHOT"), "2.0.1-SNAPSHOT");
+
+	// latest-snapshot
+	t.is(await Sapui5MavenSnapshotResolver.resolveVersion("latest-snapshot"), "2.1.2-SNAPSHOT");
+
+	// SNAPSHOT ranges
+	t.is(await Sapui5MavenSnapshotResolver.resolveVersion("1-SNAPSHOT"), "1.123.4-SNAPSHOT");
+	t.is(await Sapui5MavenSnapshotResolver.resolveVersion("2-SNAPSHOT"), "2.1.2-SNAPSHOT");
+	t.is(await Sapui5MavenSnapshotResolver.resolveVersion("1.123-SNAPSHOT"), "1.123.4-SNAPSHOT");
+
+	// Error cases
+	await t.throwsAsync(Sapui5MavenSnapshotResolver.resolveVersion(""), {
+		message: `Framework version specifier "" is incorrect or not supported`
+	});
+	await t.throwsAsync(Sapui5MavenSnapshotResolver.resolveVersion("tag-does-not-exist"), {
+		message: `Framework version specifier "tag-does-not-exist" is incorrect or not supported`
+	});
+	await t.throwsAsync(Sapui5MavenSnapshotResolver.resolveVersion("invalid-tag-%20"), {
+		message: `Framework version specifier "invalid-tag-%20" is incorrect or not supported`
+	});
+
+	await t.throwsAsync(Sapui5MavenSnapshotResolver.resolveVersion("1.999.9"), {
+		message: `Could not resolve framework version 1.999.9. ` +
+			`Make sure the version is valid and available in the configured registry.`
+	});
+	await t.throwsAsync(Sapui5MavenSnapshotResolver.resolveVersion("1.0.0-SNAPSHOT"), {
+		message: `Could not resolve framework version 1.0.0-SNAPSHOT. ` +
+			`Make sure the version is valid and available in the configured registry.`
+	});
+	await t.throwsAsync(Sapui5MavenSnapshotResolver.resolveVersion("3-SNAPSHOT"), {
+		message: `Could not resolve framework version 3-SNAPSHOT. ` +
+			`Make sure the version is valid and available in the configured registry.`
+	});
+
+	t.is(logStub.warn.callCount, 0);
+	t.is(logStub.error.callCount, 0);
+});

--- a/test/lib/ui5framework/Sapui5Resolver.integration.js
+++ b/test/lib/ui5framework/Sapui5Resolver.integration.js
@@ -191,7 +191,7 @@ test.serial("resolveVersion", async (t) => {
 		t.true(NpmcliConfig.alwaysCalledWithMatch(sinonGlobal.match({
 			cwd: options?.cwd ?? defaultCwd
 		})));
-		t.true(pacote.packument.alwaysCalledWithMatch("@openui5/sap.ui.core", {
+		t.true(pacote.packument.alwaysCalledWithMatch("@sapui5/distribution-metadata", {
 			cache: path.join(options?.ui5HomeDir ?? defaultUi5HomeDir, "framework", "cacache")
 		}));
 	}

--- a/test/lib/ui5framework/Sapui5Resolver.integration.js
+++ b/test/lib/ui5framework/Sapui5Resolver.integration.js
@@ -1,0 +1,201 @@
+import test from "ava";
+import sinonGlobal from "sinon";
+import esmock from "esmock";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Use path within project as mocking base directory to reduce chance of side effects
+// in case mocks/stubs do not work and real fs is used
+const fakeBaseDir = path.join(__dirname, "fake-tmp");
+
+test.beforeEach(async (t) => {
+	const sinon = t.context.sinon = sinonGlobal.createSandbox();
+
+	t.context.logStub = {
+		info: sinon.stub(),
+		verbose: sinon.stub(),
+		silly: sinon.stub(),
+		warn: sinon.stub(),
+		error: sinon.stub(),
+		isLevelEnabled: sinon.stub().returns(false),
+		_getLogger: sinon.stub()
+	};
+	const ui5Logger = {
+		getLogger: sinon.stub().returns(t.context.logStub)
+	};
+
+	t.context.pacote = {
+		packument: sinon.stub().callsFake(async (...args) => {
+			throw new Error(`pacote.packument stub called with unknown args: ${args}`);
+		})
+	};
+
+	t.context.NpmcliConfig = sinon.stub().returns({
+		load: sinon.stub().resolves(),
+		flat: {
+			registry: "https://registry.fake"
+		}
+	});
+
+	t.context.Registry = await esmock.p("../../../lib/ui5Framework/npm/Registry.js", {
+		"@ui5/logger": ui5Logger,
+		"pacote": t.context.pacote,
+		"@npmcli/config": {
+			"default": t.context.NpmcliConfig
+		}
+	});
+
+	const AbstractInstaller = await esmock.p("../../../lib/ui5Framework/AbstractInstaller.js", {
+		"@ui5/logger": ui5Logger,
+		"../../../lib/utils/fs.js": {
+			mkdirp: sinon.stub().resolves()
+		},
+		"lockfile": {
+			lock: sinon.stub().yieldsAsync(),
+			unlock: sinon.stub().yieldsAsync()
+		}
+	});
+
+	t.context.Installer = await esmock.p("../../../lib/ui5Framework/npm/Installer.js", {
+		"@ui5/logger": ui5Logger,
+		"graceful-fs": {
+			rename: sinon.stub().yieldsAsync(),
+		},
+		"../../../lib/utils/fs.js": {
+			mkdirp: sinon.stub().resolves()
+		},
+		"../../../lib/ui5Framework/npm/Registry.js": t.context.Registry,
+		"../../../lib/ui5Framework/AbstractInstaller.js": AbstractInstaller
+	});
+
+	t.context.AbstractResolver = await esmock.p("../../../lib/ui5Framework/AbstractResolver.js", {
+		"@ui5/logger": ui5Logger,
+		"node:os": {
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+		},
+	});
+
+	t.context.Sapui5Resolver = await esmock.p("../../../lib/ui5Framework/Sapui5Resolver.js", {
+		"@ui5/logger": ui5Logger,
+		"node:os": {
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+		},
+		"../../../lib/ui5Framework/AbstractResolver.js": t.context.AbstractResolver,
+		"../../../lib/ui5Framework/npm/Installer.js": t.context.Installer
+	});
+});
+
+test.afterEach.always((t) => {
+	t.context.sinon.restore();
+	esmock.purge(t.context.Registry);
+	esmock.purge(t.context.Installer);
+	esmock.purge(t.context.AbstractResolver);
+	esmock.purge(t.context.Sapui5Resolver);
+});
+
+test.serial("resolveVersion", async (t) => {
+	const {Sapui5Resolver, pacote, logStub, NpmcliConfig} = t.context;
+
+	pacote.packument
+		.withArgs("@sapui5/distribution-metadata")
+		.resolves({
+			"versions": {
+				"1.120.1": "",
+				"1.120.0": "",
+				"1.119.0": "",
+				"1.118.0": "",
+				"2.0.0-rc.1": "",
+				"1.123.4-SNAPSHOT": ""
+			},
+			"dist-tags": {
+				// NOTE: latest does not correspond to highest version in order to verify
+				// that this tag is used instead of picking the highest version
+				"latest": "1.120.0",
+
+				"next": "2.0.0-rc.1",
+
+				// NOTE: Tag ends with "-snapshot" in order to verify that the special handling
+				// of that
+				"not-a-snapshot": "1.118.0"
+			}
+		});
+
+	const defaultCwd = process.cwd();
+	const defaultUi5HomeDir = path.join(fakeBaseDir, "homedir", ".ui5");
+
+	// Generic testing without and with options argument
+	const optionsArguments = [
+		undefined,
+		{
+			cwd: path.join(fakeBaseDir, "custom-cwd"),
+			ui5HomeDir: path.join(fakeBaseDir, "custom-homedir", ".ui5")
+		}
+	];
+	for (const options of optionsArguments) {
+		// Reset calls to be able to check them per for-loop run
+		NpmcliConfig.resetHistory();
+		pacote.packument.resetHistory();
+
+		// Ranges
+		t.is(await Sapui5Resolver.resolveVersion("1", options), "1.120.1");
+		t.is(await Sapui5Resolver.resolveVersion("1.120", options), "1.120.1");
+		t.is(await Sapui5Resolver.resolveVersion("1.x", options), "1.120.1");
+		t.is(await Sapui5Resolver.resolveVersion("1.x.x", options), "1.120.1");
+		t.is(await Sapui5Resolver.resolveVersion("^1", options), "1.120.1");
+		t.is(await Sapui5Resolver.resolveVersion("*", options), "1.120.1");
+
+		// Tags
+		t.is(await Sapui5Resolver.resolveVersion("latest", options), "1.120.0");
+		t.is(await Sapui5Resolver.resolveVersion("next", options), "2.0.0-rc.1");
+		t.is(await Sapui5Resolver.resolveVersion("not-a-snapshot", options), "1.118.0");
+
+		// Exact versions
+		t.is(await Sapui5Resolver.resolveVersion("1.118.0", options), "1.118.0");
+		t.is(await Sapui5Resolver.resolveVersion("2.0.0-rc.1", options), "2.0.0-rc.1");
+		t.is(await Sapui5Resolver.resolveVersion("1.123.4-SNAPSHOT", options), "1.123.4-SNAPSHOT");
+
+		// SNAPSHOT ranges
+		t.is(await Sapui5Resolver.resolveVersion("1-SNAPSHOT", options), "1.123.4-SNAPSHOT");
+		t.is(await Sapui5Resolver.resolveVersion("1.123-SNAPSHOT", options), "1.123.4-SNAPSHOT");
+
+		// Error cases
+		await t.throwsAsync(Sapui5Resolver.resolveVersion("", options), {
+			message: `Framework version specifier "" is incorrect or not supported`
+		});
+		await t.throwsAsync(Sapui5Resolver.resolveVersion("tag-does-not-exist", options), {
+			message: `Could not resolve framework version via tag 'tag-does-not-exist'. ` +
+				`Make sure the tag is available in the configured registry.`
+		});
+		await t.throwsAsync(Sapui5Resolver.resolveVersion("invalid-tag-%20", options), {
+			message: `Framework version specifier "invalid-tag-%20" is incorrect or not supported`
+		});
+
+		await t.throwsAsync(Sapui5Resolver.resolveVersion("1.999.9", options), {
+			message: `Could not resolve framework version 1.999.9. ` +
+				`Make sure the version is valid and available in the configured registry.`
+		});
+		await t.throwsAsync(Sapui5Resolver.resolveVersion("1.0.0", options), {
+			message: `Could not resolve framework version 1.0.0. ` +
+				`Note that SAPUI5 framework libraries can only be consumed by the UI5 Tooling ` +
+				`starting with SAPUI5 v1.76.0`
+		});
+		await t.throwsAsync(Sapui5Resolver.resolveVersion("^999", options), {
+			message: `Could not resolve framework version ^999. ` +
+				`Make sure the version is valid and available in the configured registry.`
+		});
+
+		// Check whether options have been passed as expected
+		t.true(NpmcliConfig.alwaysCalledWithNew());
+		t.true(NpmcliConfig.alwaysCalledWithMatch(sinonGlobal.match({
+			cwd: options?.cwd ?? defaultCwd
+		})));
+		t.true(pacote.packument.alwaysCalledWithMatch("@openui5/sap.ui.core", {
+			cache: path.join(options?.ui5HomeDir ?? defaultUi5HomeDir, "framework", "cacache")
+		}));
+	}
+
+	t.is(logStub.warn.callCount, 0);
+	t.is(logStub.error.callCount, 0);
+});


### PR DESCRIPTION
The framework version resolution now supports all valid node semver
ranges and uses tags from the corresponding registry for version
resolution (not supported for Sapui5MavenSnapshotResolver).

JIRA: CPOUI5FOUNDATION-722