### PR TITLE
[FIX] Ensure usage of provided UI5 data dir

### DIFF
--- a/lib/graph/helpers/ui5Framework.js
+++ b/lib/graph/helpers/ui5Framework.js
@@ -294,6 +294,7 @@ export default {
 		const rootProject = projectGraph.getRoot();
 		const frameworkName = rootProject.getFrameworkName();
 		const frameworkVersion = rootProject.getFrameworkVersion();
+		const cwd = rootProject.getRootPath();
 
 		// It is allowed to omit the framework version in ui5.yaml and only provide one via the override
 		// This is a common use case for framework libraries, which generally should not define a
@@ -330,6 +331,14 @@ export default {
 			);
 		}
 
+		const referencedLibraries = await utils.getFrameworkLibrariesFromGraph(projectGraph);
+		if (!referencedLibraries.length) {
+			log.verbose(
+				`No ${frameworkName} libraries referenced in project ${rootProject.getName()} ` +
+				`or in any of its dependencies`);
+			return projectGraph;
+		}
+
 		let Resolver;
 		if (version && version.toLowerCase().endsWith("-snapshot")) {
 			Resolver = (await import("../../ui5Framework/Sapui5MavenSnapshotResolver.js")).default;
@@ -339,19 +348,25 @@ export default {
 			Resolver = (await import("../../ui5Framework/Sapui5Resolver.js")).default;
 		}
 
+		// ENV var should take precedence over the dataDir from the configuration.
+		let ui5DataDir = process.env.UI5_DATA_DIR;
+		if (!ui5DataDir) {
+			const config = await Configuration.fromFile();
+			ui5DataDir = config.getUi5DataDir();
+		}
+		if (ui5DataDir) {
+			ui5DataDir = path.resolve(cwd, ui5DataDir);
+		}
+
 		if (options.versionOverride) {
-			version = await Resolver.resolveVersion(options.versionOverride, {cwd: rootProject.getRootPath()});
+			version = await Resolver.resolveVersion(options.versionOverride, {
+				ui5HomeDir: ui5DataDir,
+				cwd
+			});
 			log.info(
 				`Overriding configured ${frameworkName} version ` +
 				`${frameworkVersion} with version ${version}`
 			);
-		}
-		const referencedLibraries = await utils.getFrameworkLibrariesFromGraph(projectGraph);
-		if (!referencedLibraries.length) {
-			log.verbose(
-				`No ${frameworkName} libraries referenced in project ${rootProject.getName()} ` +
-				`or in any of its dependencies`);
-			return projectGraph;
 		}
 
 		if (version) {
@@ -365,20 +380,10 @@ export default {
 			});
 		}
 
-		// ENV var should take precedence over the dataDir from the configuration.
-		let ui5DataDir = process.env.UI5_DATA_DIR;
-		if (!ui5DataDir) {
-			const config = await Configuration.fromFile();
-			ui5DataDir = config.getUi5DataDir();
-		}
-		if (ui5DataDir) {
-			ui5DataDir = path.resolve(rootProject.getRootPath(), ui5DataDir);
-		}
-
 		// Note: version might be undefined here and the Resolver will throw an error when calling
 		// #install and it can't be resolved via the provided library metadata
 		const resolver = new Resolver({
-			cwd: rootProject.getRootPath(),
+			cwd,
 			version,
 			providedLibraryMetadata,
 			cacheMode,

--- a/test/lib/graph/helpers/ui5Framework.js
+++ b/test/lib/graph/helpers/ui5Framework.js
@@ -334,6 +334,12 @@ test.serial("enrichProjectGraph: With versionOverride", async (t) => {
 
 	await ui5Framework.enrichProjectGraph(projectGraph, {versionOverride: "1.99"});
 
+	t.is(Sapui5ResolverResolveVersionStub.callCount, 1);
+	t.deepEqual(Sapui5ResolverResolveVersionStub.getCall(0).args, ["1.99", {
+		cwd: dependencyTree.path,
+		ui5HomeDir: undefined,
+	}]);
+
 	t.is(Sapui5ResolverStub.callCount, 1, "Sapui5Resolver#constructor should be called once");
 	t.deepEqual(Sapui5ResolverStub.getCall(0).args, [{
 		cacheMode: undefined,
@@ -389,6 +395,12 @@ test.serial("enrichProjectGraph: With versionOverride containing snapshot versio
 	const projectGraph = await projectGraphBuilder(provider);
 
 	await ui5Framework.enrichProjectGraph(projectGraph, {versionOverride: "1.99-SNAPSHOT"});
+
+	t.is(Sapui5MavenSnapshotResolverResolveVersionStub.callCount, 1);
+	t.deepEqual(Sapui5MavenSnapshotResolverResolveVersionStub.getCall(0).args, ["1.99-SNAPSHOT", {
+		cwd: dependencyTree.path,
+		ui5HomeDir: undefined,
+	}]);
 
 	t.is(Sapui5MavenSnapshotResolverStub.callCount, 1,
 		"Sapui5MavenSnapshotResolverStub#constructor should be called once");
@@ -447,6 +459,12 @@ test.serial("enrichProjectGraph: With versionOverride containing latest-snapshot
 
 	await ui5Framework.enrichProjectGraph(projectGraph, {versionOverride: "latest-snapshot"});
 
+	t.is(Sapui5MavenSnapshotResolverResolveVersionStub.callCount, 1);
+	t.deepEqual(Sapui5MavenSnapshotResolverResolveVersionStub.getCall(0).args, ["latest-snapshot", {
+		cwd: dependencyTree.path,
+		ui5HomeDir: undefined,
+	}]);
+
 	t.is(Sapui5MavenSnapshotResolverStub.callCount, 1,
 		"Sapui5MavenSnapshotResolverStub#constructor should be called once");
 	t.deepEqual(Sapui5MavenSnapshotResolverStub.getCall(0).args, [{
@@ -459,7 +477,7 @@ test.serial("enrichProjectGraph: With versionOverride containing latest-snapshot
 });
 
 test.serial("enrichProjectGraph shouldn't throw when no framework version and no libraries are provided", async (t) => {
-	const {ui5Framework, log} = t.context;
+	const {ui5Framework, log, Sapui5ResolverResolveVersionStub} = t.context;
 	const dependencyTree = {
 		id: "test-id",
 		version: "1.2.3",
@@ -483,6 +501,9 @@ test.serial("enrichProjectGraph shouldn't throw when no framework version and no
 	await ui5Framework.enrichProjectGraph(projectGraph, {
 		versionOverride: "1.75.0"
 	});
+
+	t.is(Sapui5ResolverResolveVersionStub.callCount, 0,
+		"resolveVersion should not be called when no libraries are provided");
 
 	t.is(log.verbose.callCount, 2);
 	t.deepEqual(log.verbose.getCall(0).args, [
@@ -702,6 +723,12 @@ test.serial("enrichProjectGraph should resolve framework project " +
 
 	await ui5Framework.enrichProjectGraph(projectGraph, {versionOverride: "3.4.5"});
 	t.is(projectGraph.getSize(), 3, "Project graph should remain unchanged");
+
+	t.is(Sapui5ResolverResolveVersionStub.callCount, 1);
+	t.deepEqual(Sapui5ResolverResolveVersionStub.getCall(0).args, ["3.4.5", {
+		cwd: dependencyTree.path,
+		ui5HomeDir: undefined,
+	}]);
 
 	t.is(Sapui5ResolverStub.callCount, 1, "Sapui5Resolver#constructor should be called once");
 	t.is(getFrameworkLibrariesFromGraphStub.callCount, 1, "getFrameworkLibrariesFromGraph should be called once");


### PR DESCRIPTION
Also moves check for framework libraries to earlier point as further
steps such as choosing a resolver and calling resolveVersion are only
needed when libraries are referenced.
This aligns the behavior with not having a framework configuration at
all but still passing "versionOverride" which is then also not
resolved/checked for correctness.
