### PR TITLE
[INTERNAL] Azure Pipelines: Switch back to Node 20.5.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,13 +26,13 @@ strategy:
       node_version: 18.x
     linux_node_current:
       imageName: 'ubuntu-22.04'
-      node_version: 20.x
+      node_version: 20.5.x
     mac_node_current:
       imageName: 'macos-12'
-      node_version: 20.x
+      node_version: 20.5.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 20.x
+      node_version: 20.5.x
 
 pool:
   vmImage: $(imageName)


### PR DESCRIPTION
There are issues with the current Node 20.6.0 version.
See: https://github.com/nodejs/node/issues/49497
