### PR TITLE
[INTERNAL] npm/maven Registry: Restore use of shared keep-alive agents

### DIFF
--- a/lib/ui5Framework/maven/Registry.js
+++ b/lib/ui5Framework/maven/Registry.js
@@ -40,15 +40,7 @@ class Registry {
 				`${groupId.replaceAll(".", "/")}/${artifactId}/${optionalVersion}maven-metadata.xml`;
 
 			log.verbose(`Fetching: ${url}`);
-			const res = await fetch(url, {
-				// Disable usage of shared keep-alive agents.
-				// make-fetch-happen uses a hard-coded 15 seconds freeSocketTimeout
-				// that can be easily reached (Error: Socket timeout) and there doesn't
-				// seem to be another way to disable or increase it.
-				// Also see: https://github.com/node-modules/agentkeepalive/issues/106
-				// The same applies in npm/Registry.js
-				agent: false,
-			});
+			const res = await fetch(url);
 			if (!res.ok) {
 				throw new Error(`[HTTP Error] ${res.status} ${res.statusText}`);
 			}

--- a/lib/ui5Framework/npm/Registry.js
+++ b/lib/ui5Framework/npm/Registry.js
@@ -75,17 +75,6 @@ class Registry {
 		// Always use our cache dir instead of the configured one
 		config.cache = this._cacheDir;
 
-		if (!config.proxy && !config.httpsProxy) {
-			// Disable usage of shared keep-alive agents unless a proxy is configured
-			// which only works with agents.
-
-			// make-fetch-happen uses a hard-coded 15 seconds freeSocketTimeout
-			// that can be easily reached (Error: Socket timeout) and there doesn't
-			// seem to be another way to disable or increase it.
-			// Also see: https://github.com/node-modules/agentkeepalive/issues/106
-			config.agent = false;
-		}
-
 		log.verbose(`Using npm configuration (extract):`);
 		// Do not log full configuration as it may contain authentication tokens
 		logConfig(config, "registry");

--- a/test/lib/ui5framework/npm/Registry.js
+++ b/test/lib/ui5framework/npm/Registry.js
@@ -77,7 +77,6 @@ test.serial("_getPacoteOptions", async (t) => {
 
 	const expectedPacoteOptions = {
 		fake: "config",
-		agent: false,
 		cache: "cacheDir"
 	};
 	npmConfigFlat.value(npmConfig);


### PR DESCRIPTION
This ultimately reverts https://github.com/SAP/ui5-project/pull/579
since make-fetch-happen dropped agentkeepalive in favor of @npmcli/agent
which in our tests did not show the problematic behavior.

Depends on: https://github.com/SAP/ui5-project/pull/643