### PR TITLE
[FEATURE] TaskUtil: Add 'force' flag to cleanup task callback

### DIFF
--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -390,7 +390,8 @@ class ProjectBuilder {
 
 	async _executeCleanupTasks(force) {
 		this.#log.info("Executing cleanup tasks...");
-		await this._buildContext.executeCleanupTasks(forceCleanup);
+
+		await this._buildContext.executeCleanupTasks(force);
 	}
 
 	_registerCleanupSigHooks() {

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -388,9 +388,9 @@ class ProjectBuilder {
 		}));
 	}
 
-	async _executeCleanupTasks() {
+	async _executeCleanupTasks(exitCode) {
 		this.#log.info("Executing cleanup tasks...");
-		await this._buildContext.executeCleanupTasks();
+		await this._buildContext.executeCleanupTasks(exitCode);
 	}
 
 	_registerCleanupSigHooks() {
@@ -398,7 +398,7 @@ class ProjectBuilder {
 		function createListener(exitCode) {
 			return function() {
 				// Asynchronously cleanup resources, then exit
-				that._executeCleanupTasks().then(() => {
+				that._executeCleanupTasks({exitCode}).then(() => {
 					process.exit(exitCode);
 				});
 			};

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -388,9 +388,9 @@ class ProjectBuilder {
 		}));
 	}
 
-	async _executeCleanupTasks(exitCode) {
+	async _executeCleanupTasks(options) {
 		this.#log.info("Executing cleanup tasks...");
-		await this._buildContext.executeCleanupTasks(exitCode);
+		await this._buildContext.executeCleanupTasks(options);
 	}
 
 	_registerCleanupSigHooks() {

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -388,9 +388,9 @@ class ProjectBuilder {
 		}));
 	}
 
-	async _executeCleanupTasks(options) {
+	async _executeCleanupTasks(forceCleanup) {
 		this.#log.info("Executing cleanup tasks...");
-		await this._buildContext.executeCleanupTasks(options);
+		await this._buildContext.executeCleanupTasks(forceCleanup);
 	}
 
 	_registerCleanupSigHooks() {
@@ -398,7 +398,7 @@ class ProjectBuilder {
 		function createListener(exitCode) {
 			return function() {
 				// Asynchronously cleanup resources, then exit
-				that._executeCleanupTasks({exitCode}).then(() => {
+				that._executeCleanupTasks(true).then(() => {
 					process.exit(exitCode);
 				});
 			};

--- a/lib/build/ProjectBuilder.js
+++ b/lib/build/ProjectBuilder.js
@@ -388,7 +388,7 @@ class ProjectBuilder {
 		}));
 	}
 
-	async _executeCleanupTasks(forceCleanup) {
+	async _executeCleanupTasks(force) {
 		this.#log.info("Executing cleanup tasks...");
 		await this._buildContext.executeCleanupTasks(forceCleanup);
 	}

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -80,9 +80,9 @@ class BuildContext {
 		return projectBuildContext;
 	}
 
-	async executeCleanupTasks(options) {
+	async executeCleanupTasks(forceCleanup) {
 		await Promise.all(this._projectBuildContexts.map((ctx) => {
-			return ctx.executeCleanupTasks(options);
+			return ctx.executeCleanupTasks(forceCleanup);
 		}));
 	}
 }

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -80,9 +80,9 @@ class BuildContext {
 		return projectBuildContext;
 	}
 
-	async executeCleanupTasks(forceCleanup) {
+	async executeCleanupTasks(force) {
 		await Promise.all(this._projectBuildContexts.map((ctx) => {
-			return ctx.executeCleanupTasks(forceCleanup);
+			return ctx.executeCleanupTasks(force);
 		}));
 	}
 }

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -80,7 +80,7 @@ class BuildContext {
 		return projectBuildContext;
 	}
 
-	async executeCleanupTasks(force) {
+	async executeCleanupTasks(force = false) {
 		await Promise.all(this._projectBuildContexts.map((ctx) => {
 			return ctx.executeCleanupTasks(force);
 		}));

--- a/lib/build/helpers/BuildContext.js
+++ b/lib/build/helpers/BuildContext.js
@@ -80,9 +80,9 @@ class BuildContext {
 		return projectBuildContext;
 	}
 
-	async executeCleanupTasks() {
+	async executeCleanupTasks(options) {
 		await Promise.all(this._projectBuildContexts.map((ctx) => {
-			return ctx.executeCleanupTasks();
+			return ctx.executeCleanupTasks(options);
 		}));
 	}
 }

--- a/lib/build/helpers/ProjectBuildContext.js
+++ b/lib/build/helpers/ProjectBuildContext.js
@@ -47,9 +47,9 @@ class ProjectBuildContext {
 		this._queues.cleanup.push(callback);
 	}
 
-	async executeCleanupTasks(forceCleanup) {
+	async executeCleanupTasks(force) {
 		await Promise.all(this._queues.cleanup.map((callback) => {
-			return callback(forceCleanup);
+			return callback(force);
 		}));
 	}
 

--- a/lib/build/helpers/ProjectBuildContext.js
+++ b/lib/build/helpers/ProjectBuildContext.js
@@ -47,9 +47,9 @@ class ProjectBuildContext {
 		this._queues.cleanup.push(callback);
 	}
 
-	async executeCleanupTasks() {
+	async executeCleanupTasks(options) {
 		await Promise.all(this._queues.cleanup.map((callback) => {
-			return callback();
+			return callback(options);
 		}));
 	}
 

--- a/lib/build/helpers/ProjectBuildContext.js
+++ b/lib/build/helpers/ProjectBuildContext.js
@@ -47,9 +47,9 @@ class ProjectBuildContext {
 		this._queues.cleanup.push(callback);
 	}
 
-	async executeCleanupTasks(options) {
+	async executeCleanupTasks(forceCleanup) {
 		await Promise.all(this._queues.cleanup.map((callback) => {
-			return callback(options);
+			return callback(forceCleanup);
 		}));
 	}
 

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -168,9 +168,9 @@ class TaskUtil {
 	 *
 	 * @public
 	 * @callback @ui5/project/build/helpers/TaskUtil~cleanupTaskCallback
-	 * @param {boolean} force Specifies whether the cleanup callback should
+	 * @param {boolean} force Whether the cleanup callback should
 	 * 							gracefully wait for certain jobs to be completed (<code>false</code>)
-	 * 							or enforce immediate termination (<code>true</code>).
+	 * 							or enforce immediate termination (<code>true</code>)
 	 */
 
 	/**

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -164,7 +164,7 @@ class TaskUtil {
 	}
 
 	/**
-	 * Callback that will be executed once the build is finished
+	 * Callback that is executed once the build has finished
 	 *
 	 * @public
 	 * @callback @ui5/project/build/helpers/TaskUtil~cleanupTaskCallback

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -182,8 +182,8 @@ class TaskUtil {
 	 * This method is only available to custom task extensions defining
 	 * <b>Specification Version 2.2 and above</b>.
 	 *
-	 * @param {@ui5/project/build/helpers/TaskUtil~cleanupTaskCallback} callback Callback to register; it will be waited for if it returns a Promise
-	 * 			
+	 * @param {@ui5/project/build/helpers/TaskUtil~cleanupTaskCallback} callback Callback to
+	 * 									register; it will be waited for if it returns a Promise
 	 * @public
 	 */
 	registerCleanupTask(callback) {

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -164,6 +164,16 @@ class TaskUtil {
 	}
 
 	/**
+	 * Callback that will be executed once the build is finished
+	 *
+	 * @public
+	 * @callback @ui5/project/build/helpers/TaskUtil~cleanupTaskCallback
+	 * @param {boolean} force Specifies whether the cleanup callback should
+	 * 							gracefully wait for certain jobs to be completed
+	 * 							or enforce immediate termination and cleanup of those jobs.
+	 */
+
+	/**
 	 * Register a function that must be executed once the build is finished. This can be used to, for example,
 	 * clean up files temporarily created on the file system. If the callback returns a Promise, it will be waited for.
 	 * It will also be executed in cases where the build has failed or has been aborted.
@@ -172,7 +182,8 @@ class TaskUtil {
 	 * This method is only available to custom task extensions defining
 	 * <b>Specification Version 2.2 and above</b>.
 	 *
-	 * @param {Function} callback Callback to register. If it returns a Promise, it will be waited for
+	 * @param {@ui5/project/build/helpers/TaskUtil~cleanupTaskCallback} callback Callback to register.
+	 * 			If it returns a Promise, it will be waited for
 	 * @public
 	 */
 	registerCleanupTask(callback) {

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -169,8 +169,8 @@ class TaskUtil {
 	 * @public
 	 * @callback @ui5/project/build/helpers/TaskUtil~cleanupTaskCallback
 	 * @param {boolean} force Specifies whether the cleanup callback should
-	 * 							gracefully wait for certain jobs to be completed
-	 * 							or enforce immediate termination and cleanup of those jobs.
+	 * 							gracefully wait for certain jobs to be completed (<code>false</code>)
+	 * 							or enforce immediate termination (<code>true</code>).
 	 */
 
 	/**

--- a/lib/build/helpers/TaskUtil.js
+++ b/lib/build/helpers/TaskUtil.js
@@ -182,8 +182,8 @@ class TaskUtil {
 	 * This method is only available to custom task extensions defining
 	 * <b>Specification Version 2.2 and above</b>.
 	 *
-	 * @param {@ui5/project/build/helpers/TaskUtil~cleanupTaskCallback} callback Callback to register.
-	 * 			If it returns a Promise, it will be waited for
+	 * @param {@ui5/project/build/helpers/TaskUtil~cleanupTaskCallback} callback Callback to register; it will be waited for if it returns a Promise
+	 * 			
 	 * @public
 	 */
 	registerCleanupTask(callback) {

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -727,7 +727,7 @@ test("_executeCleanupTasks", async (t) => {
 	const executeCleanupTasksStub = sinon.stub(builder._buildContext, "executeCleanupTasks");
 	await builder._executeCleanupTasks();
 	t.is(executeCleanupTasksStub.callCount, 1, "BuildContext#executeCleanupTasks got called once");
-	t.deepEqual(executeCleanupTasksStub.getCall(0).args, [],
+	t.deepEqual(executeCleanupTasksStub.getCall(0).args, [undefined],
 		"BuildContext#executeCleanupTasks got called with no arguments");
 });
 

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -729,6 +729,14 @@ test("_executeCleanupTasks", async (t) => {
 	t.is(executeCleanupTasksStub.callCount, 1, "BuildContext#executeCleanupTasks got called once");
 	t.deepEqual(executeCleanupTasksStub.getCall(0).args, [undefined],
 		"BuildContext#executeCleanupTasks got called with no arguments");
+
+	// reset stub
+	executeCleanupTasksStub.reset();
+	// Call with enforcement flag
+	await builder._executeCleanupTasks(true);
+	t.is(executeCleanupTasksStub.callCount, 1, "BuildContext#executeCleanupTasks got called once");
+	t.deepEqual(executeCleanupTasksStub.getCall(0).args, [true],
+		"BuildContext#executeCleanupTasks got called with force flag");
 });
 
 test("instantiate new logger for every ProjectBuilder", async (t) => {

--- a/test/lib/build/ProjectBuilder.js
+++ b/test/lib/build/ProjectBuilder.js
@@ -728,7 +728,7 @@ test("_executeCleanupTasks", async (t) => {
 	await builder._executeCleanupTasks();
 	t.is(executeCleanupTasksStub.callCount, 1, "BuildContext#executeCleanupTasks got called once");
 	t.deepEqual(executeCleanupTasksStub.getCall(0).args, [undefined],
-		"BuildContext#executeCleanupTasks got called with no arguments");
+		"BuildContext#executeCleanupTasks got called with correct arguments");
 
 	// reset stub
 	executeCleanupTasksStub.reset();
@@ -736,7 +736,7 @@ test("_executeCleanupTasks", async (t) => {
 	await builder._executeCleanupTasks(true);
 	t.is(executeCleanupTasksStub.callCount, 1, "BuildContext#executeCleanupTasks got called once");
 	t.deepEqual(executeCleanupTasksStub.getCall(0).args, [true],
-		"BuildContext#executeCleanupTasks got called with force flag");
+		"BuildContext#executeCleanupTasks got called with correct arguments");
 });
 
 test("instantiate new logger for every ProjectBuilder", async (t) => {

--- a/test/lib/build/helpers/BuildContext.js
+++ b/test/lib/build/helpers/BuildContext.js
@@ -203,4 +203,15 @@ test("executeCleanupTasks", async (t) => {
 
 	t.is(executeCleanupTasks.callCount, 2,
 		"Project context executeCleanupTasks got called twice");
+	t.is(executeCleanupTasks.getCall(0).firstArg, false,
+		"Project context executeCleanupTasks got called with expected arguments");
+
+
+	executeCleanupTasks.reset();
+	await buildContext.executeCleanupTasks(true);
+
+	t.is(executeCleanupTasks.callCount, 2,
+		"Project context executeCleanupTasks got called twice");
+	t.is(executeCleanupTasks.getCall(0).firstArg, true,
+		"Project context executeCleanupTasks got called with expected arguments");
 });


### PR DESCRIPTION
JIRA: CPOUI5FOUNDATION-751
\@ui5/builder PR that depends on this change: https://github.com/SAP/ui5-builder/pull/953

When cleaning up after tasks run, it can happen in couple cases:
- When the project is build
- When there's a SIGTERM signal
- (Maybe) on some error

We need to be able to distinguish between those cases as in some places we rely on graceful termination and cleanup. Especially, after the project has been build successfully. On the other hand when the user presses `Ctrl + C`, for example, we need to enforce the termination.

This cahnge provides this context.