### PR TITLE
[INTERNAL] GitHub: Include lib/build/* in file finder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+lib/build/** linguist-generated=false


### PR DESCRIPTION
The GitHub file finder feature assumes "build/" directories contain
generated code and therefore ignores them.

This change configures lib/build/* to not be treated as generated code.

Resources:
* https://github.blog/changelog/2022-07-28-file-finder-customize-default-exclusions/
* https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

GitHub Support Ticket: #2427846