### PR TITLE
[INTERNAL] GitHub: Include lib/** in file finder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text=auto eol=lf
 lib/build/** linguist-generated=false
+lib/** linguist-vendored=false
+lib/** linguist-generated=false


### PR DESCRIPTION
File finder still won't find files in lib/build/ dir, so GitHub support
suggested adding these lines for further investigation.

Follow up to https://github.com/SAP/ui5-project/pull/679
GitHub Support Ticket: #2427846