### PR TITLE
[INTERNAL] GitHub: Include build/** in file finder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto eol=lf
+build/** -linguist-generated=false
 lib/build/** linguist-generated=false
 lib/** linguist-vendored=false
 lib/** linguist-generated=false


### PR DESCRIPTION
GitHub Support suggests to add this line since thir default
configuration uses the pattern "build/**" too.

Follow up to #680
GitHub Support Ticket: #2427846