### PR TITLE
[BREAKING] Require Node.js 20.11.x/>=21.2.0 and npm >=10

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Use Node.js LTS 16.18.0
+    - name: Use Node.js LTS 20.11.0
       uses: actions/setup-node@v4.0.2
       with:
-        node-version: 16.18.0
+        node-version: 20.11.0
 
     - name: Install dependencies
       run: npm ci

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,32 +6,35 @@
 trigger:
 - main
 
+variables:
+  CI: true
+
 strategy:
   matrix:
-    linux_node_lts_16:
+    linux_node_lts_20_min_version:
       imageName: 'ubuntu-22.04'
-      node_version: 16.x
-    linux_node_lts_18_min_version:
+      node_version: 20.11.0
+    linux_node_21_min_version:
       imageName: 'ubuntu-22.04'
-      node_version: 18.12.0
-    linux_node_lts_18:
+      node_version: 21.2.0
+    linux_node_lts_20:
       imageName: 'ubuntu-22.04'
-      node_version: 18.x
-    mac_node_lts_18:
+      node_version: 20.x
+    mac_node_lts_20:
       imageName: 'macos-12'
-      node_version: 18.x
-    windows_node_lts_18:
+      node_version: 20.x
+    windows_node_lts_20:
       imageName: 'windows-2022'
-      node_version: 18.x
+      node_version: 20.x
     linux_node_current:
       imageName: 'ubuntu-22.04'
-      node_version: 20.x
+      node_version: 21.x
     mac_node_current:
       imageName: 'macos-12'
-      node_version: 20.x
+      node_version: 21.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 20.x
+      node_version: 21.x
 
 pool:
   vmImage: $(imageName)

--- a/lib/build/helpers/createBuildManifest.js
+++ b/lib/build/helpers/createBuildManifest.js
@@ -1,6 +1,6 @@
 import {createRequire} from "node:module";
 
-// Using CommonsJS require as importing json files causes an ExperimentalWarning
+// Using CommonsJS require since JSON module imports are still experimental
 const require = createRequire(import.meta.url);
 
 async function getVersion(pkg) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,8 +57,8 @@
 				"tap-xunit": "^2.4.1"
 			},
 			"engines": {
-				"node": "^16.18.0 || >=18.12.0",
-				"npm": ">= 8"
+				"node": "^20.11.0 || >=21.2.0",
+				"npm": ">= 10"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
 		"./package.json": "./package.json"
 	},
 	"engines": {
-		"node": "^16.18.0 || >=18.12.0",
-		"npm": ">= 8"
+		"node": "^20.11.0 || >=21.2.0",
+		"npm": ">= 10"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run depcheck",

--- a/test/lib/build/helpers/composeProjectList.js
+++ b/test/lib/build/helpers/composeProjectList.js
@@ -2,10 +2,9 @@ import test from "ava";
 import sinon from "sinon";
 import esmock from "esmock";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import {graphFromObject} from "../../../../lib/graph/graph.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.a");
 const libraryEPath = path.join(__dirname, "..", "..", "..", "fixtures", "library.e");

--- a/test/lib/build/helpers/createBuildManifest.integration.js
+++ b/test/lib/build/helpers/createBuildManifest.integration.js
@@ -1,11 +1,10 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import createBuildManifest from "../../../../lib/build/helpers/createBuildManifest.js";
 import Module from "../../../../lib/graph/Module.js";
 import Specification from "../../../../lib/specifications/Specification.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.a");
 const buildDescrApplicationAPath =

--- a/test/lib/build/helpers/createBuildManifest.js
+++ b/test/lib/build/helpers/createBuildManifest.js
@@ -1,11 +1,10 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import semver from "semver";
 import createBuildManifest from "../../../../lib/build/helpers/createBuildManifest.js";
 import Specification from "../../../../lib/specifications/Specification.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.a");
 const applicationProjectInput = {

--- a/test/lib/graph/Module.js
+++ b/test/lib/graph/Module.js
@@ -1,10 +1,9 @@
 import test from "ava";
 import sinon from "sinon";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import Module from "../../../lib/graph/Module.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const fixturesPath = path.join(__dirname, "..", "..", "fixtures");
 const applicationAPath = path.join(fixturesPath, "application.a");

--- a/test/lib/graph/ProjectGraph.js
+++ b/test/lib/graph/ProjectGraph.js
@@ -1,11 +1,10 @@
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import test from "ava";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import Specification from "../../../lib/specifications/Specification.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "fixtures", "application.a");
 

--- a/test/lib/graph/Workspace.js
+++ b/test/lib/graph/Workspace.js
@@ -1,11 +1,10 @@
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import test from "ava";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import Module from "../../../lib/graph/Module.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const libraryD = path.join(__dirname, "..", "..", "fixtures", "library.d");
 const libraryE = path.join(__dirname, "..", "..", "fixtures", "library.e");
 const collectionLibraryA = path.join(__dirname, "..", "..", "fixtures", "collection", "library.a");

--- a/test/lib/graph/graph.integration.js
+++ b/test/lib/graph/graph.integration.js
@@ -1,11 +1,10 @@
 import test from "ava";
-import {fileURLToPath} from "node:url";
 import path from "node:path";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import Workspace from "../../../lib/graph/Workspace.js";
 import CacheMode from "../../../lib/ui5Framework/maven/CacheMode.js";
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const fixturesPath = path.join(__dirname, "..", "..", "fixtures");
 const libraryHPath = path.join(fixturesPath, "library.h");

--- a/test/lib/graph/graph.js
+++ b/test/lib/graph/graph.js
@@ -1,11 +1,10 @@
 import test from "ava";
-import {fileURLToPath} from "node:url";
 import path from "node:path";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import CacheMode from "../../../lib/ui5Framework/maven/CacheMode.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const fixturesPath = path.join(__dirname, "..", "..", "fixtures");
 
 test.beforeEach(async (t) => {

--- a/test/lib/graph/graphFromObject.js
+++ b/test/lib/graph/graphFromObject.js
@@ -1,11 +1,10 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import ValidationError from "../../../lib/validation/ValidationError.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "fixtures", "application.a");
 const applicationBPath = path.join(__dirname, "..", "..", "fixtures", "application.b");

--- a/test/lib/graph/graphFromPackageDependencies.js
+++ b/test/lib/graph/graphFromPackageDependencies.js
@@ -1,10 +1,9 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinonGlobal from "sinon";
 import {graphFromPackageDependencies} from "../../../lib/graph/graph.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "fixtures", "application.a");
 test.beforeEach((t) => {

--- a/test/lib/graph/graphFromStaticFile.js
+++ b/test/lib/graph/graphFromStaticFile.js
@@ -1,11 +1,10 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinonGlobal from "sinon";
 
 import {graphFromStaticFile} from "../../../lib/graph/graph.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationHPath = path.join(__dirname, "..", "..", "fixtures", "application.h");
 const applicationAPath = path.join(__dirname, "..", "..", "fixtures", "application.a");

--- a/test/lib/graph/helpers/createWorkspace.js
+++ b/test/lib/graph/helpers/createWorkspace.js
@@ -1,10 +1,9 @@
 import test from "ava";
-import {fileURLToPath} from "node:url";
 import path from "node:path";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const fixturesPath = path.join(__dirname, "..", "..", "..", "fixtures");
 const libraryHPath = path.join(fixturesPath, "library.h");
 

--- a/test/lib/graph/helpers/ui5Framework.integration.js
+++ b/test/lib/graph/helpers/ui5Framework.integration.js
@@ -2,10 +2,9 @@ import test from "ava";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import DependencyTreeProvider from "../../../../lib/graph/providers/DependencyTree.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 // Use path within project as mocking base directory to reduce chance of side effects
 // in case mocks/stubs do not work and real fs is used

--- a/test/lib/graph/helpers/ui5Framework.js
+++ b/test/lib/graph/helpers/ui5Framework.js
@@ -1,5 +1,4 @@
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import test from "ava";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
@@ -8,7 +7,7 @@ import projectGraphBuilder from "../../../../lib/graph/projectGraphBuilder.js";
 import Specification from "../../../../lib/specifications/Specification.js";
 import CacheMode from "../../../../lib/ui5Framework/maven/CacheMode.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.a");
 const libraryDPath = path.join(__dirname, "..", "..", "..", "fixtures", "library.d");

--- a/test/lib/graph/projectGraphBuilder.js
+++ b/test/lib/graph/projectGraphBuilder.js
@@ -1,11 +1,10 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import projectGraphBuilder from "../../../lib/graph/projectGraphBuilder.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const libraryEPath = path.join(__dirname, "..", "..", "fixtures", "library.e");
 const libraryFPath = path.join(__dirname, "..", "..", "fixtures", "library.f");

--- a/test/lib/graph/providers/NodePackageDependencies.integration.js
+++ b/test/lib/graph/providers/NodePackageDependencies.integration.js
@@ -1,9 +1,8 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinonGlobal from "sinon";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.a");
 const applicationAAliasesPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.a.aliases");

--- a/test/lib/package-exports.js
+++ b/test/lib/package-exports.js
@@ -1,7 +1,7 @@
 import test from "ava";
 import {createRequire} from "node:module";
 
-// Using CommonsJS require as importing json files causes an ExperimentalWarning
+// Using CommonsJS require since JSON module imports are still experimental
 const require = createRequire(import.meta.url);
 
 // package.json should be exported to allow reading version (e.g. from @ui5/cli)

--- a/test/lib/specifications/ComponentProject.js
+++ b/test/lib/specifications/ComponentProject.js
@@ -1,6 +1,5 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinon from "sinon";
 import Specification from "../../../lib/specifications/Specification.js";
 
@@ -8,7 +7,7 @@ function clone(o) {
 	return JSON.parse(JSON.stringify(o));
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "fixtures", "application.a");
 const basicProjectInput = {

--- a/test/lib/specifications/Project.js
+++ b/test/lib/specifications/Project.js
@@ -1,6 +1,5 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import chalk from "chalk";
 import Specification from "../../../lib/specifications/Specification.js";
 
@@ -8,7 +7,7 @@ function clone(obj) {
 	return JSON.parse(JSON.stringify(obj));
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "fixtures", "application.a");
 const basicProjectInput = {

--- a/test/lib/specifications/Specification.js
+++ b/test/lib/specifications/Specification.js
@@ -1,7 +1,6 @@
 import test from "ava";
 import esmock from "esmock";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinon from "sinon";
 import Specification from "../../../lib/specifications/Specification.js";
 import Application from "../../../lib/specifications/types/Application.js";
@@ -12,7 +11,7 @@ import Task from "../../../lib/specifications/extensions/Task.js";
 import ProjectShim from "../../../lib/specifications/extensions/ProjectShim.js";
 import ServerMiddleware from "../../../lib/specifications/extensions/ServerMiddleware.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "fixtures", "application.a");
 const libraryHPath = path.join(__dirname, "..", "..", "fixtures", "library.h");

--- a/test/lib/specifications/extensions/ProjectShim.js
+++ b/test/lib/specifications/extensions/ProjectShim.js
@@ -1,6 +1,5 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinon from "sinon";
 import Specification from "../../../../lib/specifications/Specification.js";
 import ProjectShim from "../../../../lib/specifications/extensions/ProjectShim.js";
@@ -9,7 +8,7 @@ function clone(obj) {
 	return JSON.parse(JSON.stringify(obj));
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const nonExistingPath = path.join(__dirname, "..", "..", "..", "fixtures", "does-not-exist");
 const basicProjectShimInput = {

--- a/test/lib/specifications/extensions/ServerMiddleware.js
+++ b/test/lib/specifications/extensions/ServerMiddleware.js
@@ -1,6 +1,5 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinon from "sinon";
 import Specification from "../../../../lib/specifications/Specification.js";
 import ServerMiddleware from "../../../../lib/specifications/extensions/ServerMiddleware.js";
@@ -9,7 +8,7 @@ function clone(obj) {
 	return JSON.parse(JSON.stringify(obj));
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const genericCjsExtensionPath = path.join(__dirname, "..", "..", "..", "fixtures", "extension.a");
 const genericEsmExtensionPath = path.join(__dirname, "..", "..", "..", "fixtures", "extension.a.esm");

--- a/test/lib/specifications/extensions/Task.js
+++ b/test/lib/specifications/extensions/Task.js
@@ -1,6 +1,5 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinon from "sinon";
 import Specification from "../../../../lib/specifications/Specification.js";
 import Task from "../../../../lib/specifications/extensions/Task.js";
@@ -9,7 +8,7 @@ function clone(obj) {
 	return JSON.parse(JSON.stringify(obj));
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const genericCjsExtensionPath = path.join(__dirname, "..", "..", "..", "fixtures", "extension.a");
 const genericEsmExtensionPath = path.join(__dirname, "..", "..", "..", "fixtures", "extension.a.esm");

--- a/test/lib/specifications/types/Application.js
+++ b/test/lib/specifications/types/Application.js
@@ -1,12 +1,11 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import {createResource} from "@ui5/fs/resourceFactory";
 import sinonGlobal from "sinon";
 import Specification from "../../../../lib/specifications/Specification.js";
 import Application from "../../../../lib/specifications/types/Application.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const applicationAPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.a");
 const applicationHPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.h");
 

--- a/test/lib/specifications/types/Library.js
+++ b/test/lib/specifications/types/Library.js
@@ -1,10 +1,9 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinonGlobal from "sinon";
 import Library from "../../../../lib/specifications/types/Library.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const libraryDPath = path.join(__dirname, "..", "..", "..", "fixtures", "library.d");
 const libraryHPath = path.join(__dirname, "..", "..", "..", "fixtures", "library.h");
 

--- a/test/lib/specifications/types/Module.js
+++ b/test/lib/specifications/types/Module.js
@@ -1,10 +1,9 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinonGlobal from "sinon";
 import Specification from "../../../../lib/specifications/Specification.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const moduleAPath = path.join(__dirname, "..", "..", "..", "fixtures", "module.a");
 
 test.beforeEach((t) => {

--- a/test/lib/specifications/types/ThemeLibrary.js
+++ b/test/lib/specifications/types/ThemeLibrary.js
@@ -1,10 +1,9 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import sinonGlobal from "sinon";
 import Specification from "../../../../lib/specifications/Specification.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const themeLibraryEPath = path.join(__dirname, "..", "..", "..", "fixtures", "theme.library.e");
 
 test.beforeEach((t) => {

--- a/test/lib/ui5framework/Openui5Resolver.integration.js
+++ b/test/lib/ui5framework/Openui5Resolver.integration.js
@@ -2,9 +2,8 @@ import test from "ava";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 // Use path within project as mocking base directory to reduce chance of side effects
 // in case mocks/stubs do not work and real fs is used

--- a/test/lib/ui5framework/Sapui5MavenSnapshotResolver.integration.js
+++ b/test/lib/ui5framework/Sapui5MavenSnapshotResolver.integration.js
@@ -2,9 +2,8 @@ import test from "ava";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 // Use path within project as mocking base directory to reduce chance of side effects
 // in case mocks/stubs do not work and real fs is used

--- a/test/lib/ui5framework/Sapui5Resolver.integration.js
+++ b/test/lib/ui5framework/Sapui5Resolver.integration.js
@@ -2,9 +2,8 @@ import test from "ava";
 import sinonGlobal from "sinon";
 import esmock from "esmock";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 // Use path within project as mocking base directory to reduce chance of side effects
 // in case mocks/stubs do not work and real fs is used

--- a/test/lib/ui5framework/npm/Installer.js
+++ b/test/lib/ui5framework/npm/Installer.js
@@ -2,9 +2,8 @@ import test from "ava";
 import sinon from "sinon";
 import esmock from "esmock";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 test.beforeEach(async (t) => {
 	t.context.mkdirpStub = sinon.stub().resolves();

--- a/test/lib/utils/fs.js
+++ b/test/lib/utils/fs.js
@@ -1,10 +1,9 @@
 import test from "ava";
 import path from "node:path";
 import {stat} from "node:fs/promises";
-import {fileURLToPath} from "node:url";
 import {mkdirp} from "../../../lib/utils/fs.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 test("mkdirp: Create directory hierarchy", async (t) => {
 	const targetPath = path.join(__dirname, "..", "..", "tmp", "mkdir-test", "this", "is", "a", "directory");


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js and npm releases has been dropped.
Only Node.js 20.11.x and >=21.2.0 as well as npm v10 or higher are supported.

JIRA: CPOUI5FOUNDATION-800