### PR TITLE
[BREAKING] Rename ui5HomeDir to ui5DataDir in APIs

### DIFF
--- a/lib/graph/helpers/ui5Framework.js
+++ b/lib/graph/helpers/ui5Framework.js
@@ -360,7 +360,7 @@ export default {
 
 		if (options.versionOverride) {
 			version = await Resolver.resolveVersion(options.versionOverride, {
-				ui5HomeDir: ui5DataDir,
+				ui5DataDir,
 				cwd
 			});
 			log.info(
@@ -387,7 +387,7 @@ export default {
 			version,
 			providedLibraryMetadata,
 			cacheMode,
-			ui5HomeDir: ui5DataDir
+			ui5DataDir
 		});
 
 		let startTime;

--- a/lib/ui5Framework/AbstractInstaller.js
+++ b/lib/ui5Framework/AbstractInstaller.js
@@ -12,17 +12,17 @@ const illegalFileNameRegExp = /[^0-9a-zA-Z\-._@/]/;
 
 class AbstractInstaller {
 	/**
-	 * @param {string} ui5HomeDir UI5 home directory location. This will be used to store packages,
+	 * @param {string} ui5DataDir UI5 home directory location. This will be used to store packages,
 	 * metadata and configuration used by the resolvers.
 	 */
-	constructor(ui5HomeDir) {
+	constructor(ui5DataDir) {
 		if (new.target === AbstractInstaller) {
 			throw new TypeError("Class 'AbstractInstaller' is abstract");
 		}
-		if (!ui5HomeDir) {
-			throw new Error(`Installer: Missing parameter "ui5HomeDir"`);
+		if (!ui5DataDir) {
+			throw new Error(`Installer: Missing parameter "ui5DataDir"`);
 		}
-		this._lockDir = path.join(ui5HomeDir, "framework", "locks");
+		this._lockDir = path.join(ui5DataDir, "framework", "locks");
 	}
 
 	async _synchronize(lockName, callback) {

--- a/lib/ui5Framework/AbstractResolver.js
+++ b/lib/ui5Framework/AbstractResolver.js
@@ -26,7 +26,7 @@ class AbstractResolver {
 	 * @param {boolean} [options.sources=false] Whether to install framework libraries as sources or
 	 * 					pre-built (with build manifest)
 	 * @param {string} [options.cwd=process.cwd()] Current working directory
-	 * @param {string} [options.ui5HomeDir="~/.ui5"] UI5 home directory location. This will be used to store packages,
+	 * @param {string} [options.ui5DataDir="~/.ui5"] UI5 home directory location. This will be used to store packages,
 	 * metadata and configuration used by the resolvers. Relative to `process.cwd()`
 	 * @param {object.<string, @ui5/project/ui5Framework/AbstractResolver~LibraryMetadataEntry>} [options.providedLibraryMetadata]
 	 * Resolver skips installing listed libraries and uses the dependency information to resolve their dependencies.
@@ -34,15 +34,15 @@ class AbstractResolver {
 	 * Otherwise an error is thrown.
 	 */
 	/* eslint-enable max-len */
-	constructor({cwd, version, sources, ui5HomeDir, providedLibraryMetadata}) {
+	constructor({cwd, version, sources, ui5DataDir, providedLibraryMetadata}) {
 		if (new.target === AbstractResolver) {
 			throw new TypeError("Class 'AbstractResolver' is abstract");
 		}
 
 		// In some CI environments, the homedir might be set explicitly to a relative
 		// path (e.g. "./"), but tooling requires an absolute path
-		this._ui5HomeDir = path.resolve(
-			ui5HomeDir || path.join(os.homedir(), ".ui5")
+		this._ui5DataDir = path.resolve(
+			ui5DataDir || path.join(os.homedir(), ".ui5")
 		);
 		this._cwd = cwd ? path.resolve(cwd) : process.cwd();
 		this._version = version;
@@ -205,21 +205,21 @@ class AbstractResolver {
 		};
 	}
 
-	static async resolveVersion(version, {ui5HomeDir, cwd} = {}) {
+	static async resolveVersion(version, {ui5DataDir, cwd} = {}) {
 		// Don't allow nullish values
 		// An empty string is a valid semver range that converts to "*", which should not be supported
 		if (!version) {
 			throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
 		}
 
-		const spec = await this._getVersionSpec(version, {ui5HomeDir, cwd});
+		const spec = await this._getVersionSpec(version, {ui5DataDir, cwd});
 
 		// For all invalid cases which are not explicitly handled in _getVersionSpec
 		if (!spec) {
 			throw new Error(`Framework version specifier "${version}" is incorrect or not supported`);
 		}
 
-		const versions = await this.fetchAllVersions({ui5HomeDir, cwd});
+		const versions = await this.fetchAllVersions({ui5DataDir, cwd});
 		const resolvedVersion = semver.maxSatisfying(versions, spec, {
 			// Allow ranges that end with -SNAPSHOT to match any -SNAPSHOT version
 			// like a normal version in order to support ranges like 1.x.x-SNAPSHOT.
@@ -246,7 +246,7 @@ class AbstractResolver {
 		return resolvedVersion;
 	}
 
-	static async _getVersionSpec(version, {ui5HomeDir, cwd}) {
+	static async _getVersionSpec(version, {ui5DataDir, cwd}) {
 		if (this._isSnapshotVersionOrRange(version)) {
 			const versionMatch = version.match(VERSION_RANGE_REGEXP);
 			if (versionMatch) {
@@ -268,7 +268,7 @@ class AbstractResolver {
 			return null;
 		}
 
-		const allTags = await this.fetchAllTags({ui5HomeDir, cwd});
+		const allTags = await this.fetchAllTags({ui5DataDir, cwd});
 
 		if (!allTags) {
 			// Resolver doesn't support tags (e.g. Sapui5MavenSnapshotResolver)

--- a/lib/ui5Framework/Openui5Resolver.js
+++ b/lib/ui5Framework/Openui5Resolver.js
@@ -18,7 +18,7 @@ class Openui5Resolver extends AbstractResolver {
 	 * @param {*} options options
 	 * @param {string} options.version OpenUI5 version to use
 	 * @param {string} [options.cwd=process.cwd()] Working directory to resolve configurations like .npmrc
-	 * @param {string} [options.ui5HomeDir="~/.ui5"] UI5 home directory location. This will be used to store packages,
+	 * @param {string} [options.ui5DataDir="~/.ui5"] UI5 home directory location. This will be used to store packages,
 	 * metadata and configuration used by the resolvers. Relative to `process.cwd()`
 	 * @param {string} [options.cacheDir] Where to store temp/cached packages.
 	 * @param {string} [options.packagesDir] Where to install packages
@@ -31,7 +31,7 @@ class Openui5Resolver extends AbstractResolver {
 
 		this._installer = new Installer({
 			cwd: this._cwd,
-			ui5HomeDir: this._ui5HomeDir,
+			ui5DataDir: this._ui5DataDir,
 			cacheDir, packagesDir, stagingDir
 		});
 		this._loadLibraryMetadata = Object.create(null);
@@ -94,11 +94,11 @@ class Openui5Resolver extends AbstractResolver {
 		return installer.fetchPackageDistTags({pkgName: OPENUI5_CORE_PACKAGE});
 	}
 
-	static _getInstaller({ui5HomeDir, cwd} = {}) {
+	static _getInstaller({ui5DataDir, cwd} = {}) {
 		return new Installer({
 			cwd: cwd ? path.resolve(cwd) : process.cwd(),
-			ui5HomeDir:
-				ui5HomeDir ? path.resolve(ui5HomeDir) :
+			ui5DataDir:
+				ui5DataDir ? path.resolve(ui5DataDir) :
 					path.join(os.homedir(), ".ui5")
 		});
 	}

--- a/lib/ui5Framework/Sapui5MavenSnapshotResolver.js
+++ b/lib/ui5Framework/Sapui5MavenSnapshotResolver.js
@@ -32,7 +32,7 @@ class Sapui5MavenSnapshotResolver extends AbstractResolver {
 	 * @param {boolean} [options.sources=false] Whether to install framework libraries as sources or
 	 * pre-built (with build manifest)
 	 * @param {string} [options.cwd=process.cwd()] Current working directory
-	 * @param {string} [options.ui5HomeDir="~/.ui5"] UI5 home directory location. This will be used to store packages,
+	 * @param {string} [options.ui5DataDir="~/.ui5"] UI5 home directory location. This will be used to store packages,
 	 * metadata and configuration used by the resolvers. Relative to `process.cwd()`
 	 * @param {module:@ui5/project/ui5Framework/maven/CacheMode} [options.cacheMode=Default]
 	 * Cache mode to use
@@ -45,7 +45,7 @@ class Sapui5MavenSnapshotResolver extends AbstractResolver {
 		} = options;
 
 		this._installer = new Installer({
-			ui5HomeDir: this._ui5HomeDir,
+			ui5DataDir: this._ui5DataDir,
 			snapshotEndpointUrlCb:
 				Sapui5MavenSnapshotResolver._createSnapshotEndpointUrlCallback(options.snapshotEndpointUrl),
 			cacheMode,
@@ -144,11 +144,11 @@ class Sapui5MavenSnapshotResolver extends AbstractResolver {
 		};
 	}
 
-	static async fetchAllVersions({ui5HomeDir, cwd, snapshotEndpointUrl} = {}) {
+	static async fetchAllVersions({ui5DataDir, cwd, snapshotEndpointUrl} = {}) {
 		const installer = new Installer({
 			cwd: cwd ? path.resolve(cwd) : process.cwd(),
-			ui5HomeDir: path.resolve(
-				ui5HomeDir || path.join(os.homedir(), ".ui5")
+			ui5DataDir: path.resolve(
+				ui5DataDir || path.join(os.homedir(), ".ui5")
 			),
 			snapshotEndpointUrlCb: Sapui5MavenSnapshotResolver._createSnapshotEndpointUrlCallback(snapshotEndpointUrl),
 		});

--- a/lib/ui5Framework/Sapui5Resolver.js
+++ b/lib/ui5Framework/Sapui5Resolver.js
@@ -21,7 +21,7 @@ class Sapui5Resolver extends AbstractResolver {
 	 * @param {*} options options
 	 * @param {string} options.version SAPUI5 version to use
 	 * @param {string} [options.cwd=process.cwd()] Working directory to resolve configurations like .npmrc
-	 * @param {string} [options.ui5HomeDir="~/.ui5"] UI5 home directory location. This will be used to store packages,
+	 * @param {string} [options.ui5DataDir="~/.ui5"] UI5 home directory location. This will be used to store packages,
 	 * metadata and configuration used by the resolvers. Relative to `process.cwd()`
 	 * @param {string} [options.cacheDir] Where to store temp/cached packages.
 	 * @param {string} [options.packagesDir] Where to install packages
@@ -34,7 +34,7 @@ class Sapui5Resolver extends AbstractResolver {
 
 		this._installer = new Installer({
 			cwd: this._cwd,
-			ui5HomeDir: this._ui5HomeDir,
+			ui5DataDir: this._ui5DataDir,
 			cacheDir, packagesDir, stagingDir
 		});
 		this._loadDistMetadata = null;
@@ -115,11 +115,11 @@ class Sapui5Resolver extends AbstractResolver {
 		return installer.fetchPackageDistTags({pkgName: DIST_PKG_NAME});
 	}
 
-	static _getInstaller({ui5HomeDir, cwd} = {}) {
+	static _getInstaller({ui5DataDir, cwd} = {}) {
 		return new Installer({
 			cwd: cwd ? path.resolve(cwd) : process.cwd(),
-			ui5HomeDir:
-				ui5HomeDir ? path.resolve(ui5HomeDir) :
+			ui5DataDir:
+				ui5DataDir ? path.resolve(ui5DataDir) :
 					path.join(os.homedir(), ".ui5")
 		});
 	}

--- a/lib/ui5Framework/maven/Installer.js
+++ b/lib/ui5Framework/maven/Installer.js
@@ -22,20 +22,20 @@ const CACHE_TIME = 32400000; // 9 hours
 class Installer extends AbstractInstaller {
 	/**
 	 * @param {object} parameters Parameters
-	 * @param {string} parameters.ui5HomeDir UI5 home directory location. This will be used to store packages,
+	 * @param {string} parameters.ui5DataDir UI5 home directory location. This will be used to store packages,
 	 * metadata and configuration used by the resolvers.
 	 * @param {Function} parameters.snapshotEndpointUrlCb Callback that returns a Promise <string>,
 	 * 	resolving to the Maven repository URL.
 	 * 	Example: <code>https://registry.corp/vendor/build-snapshots/</code>
 	 * @param {module:@ui5/project/ui5Framework/maven/CacheMode} [parameters.cacheMode=Default] Cache mode to use
 	 */
-	constructor({ui5HomeDir, snapshotEndpointUrlCb, cacheMode = CacheMode.Default}) {
-		super(ui5HomeDir);
+	constructor({ui5DataDir, snapshotEndpointUrlCb, cacheMode = CacheMode.Default}) {
+		super(ui5DataDir);
 
-		this._artifactsDir = path.join(ui5HomeDir, "framework", "artifacts");
-		this._packagesDir = path.join(ui5HomeDir, "framework", "packages");
-		this._metadataDir = path.join(ui5HomeDir, "framework", "metadata");
-		this._stagingDir = path.join(ui5HomeDir, "framework", "staging");
+		this._artifactsDir = path.join(ui5DataDir, "framework", "artifacts");
+		this._packagesDir = path.join(ui5DataDir, "framework", "packages");
+		this._metadataDir = path.join(ui5DataDir, "framework", "metadata");
+		this._stagingDir = path.join(ui5DataDir, "framework", "staging");
 
 		this._cacheMode = cacheMode;
 		this._snapshotEndpointUrlCb = snapshotEndpointUrlCb;

--- a/lib/ui5Framework/npm/Installer.js
+++ b/lib/ui5Framework/npm/Installer.js
@@ -15,27 +15,27 @@ class Installer extends AbstractInstaller {
 	/**
 	 * @param {object} parameters Parameters
 	 * @param {string} parameters.cwd Current working directory
-	 * @param {string} parameters.ui5HomeDir UI5 home directory location. This will be used to store packages,
+	 * @param {string} parameters.ui5DataDir UI5 home directory location. This will be used to store packages,
 	 * metadata and configuration used by the resolvers.
-	 * @param {string} [parameters.packagesDir="${ui5HomeDir}/framework/packages"] Where to install packages
-	 * @param {string} [parameters.stagingDir="${ui5HomeDir}/framework/staging"] The staging directory for the packages
-	 * @param {string} [parameters.cacheDir="${ui5HomeDir}/framework/cacache"] Where to store temp/cached packages.
+	 * @param {string} [parameters.packagesDir="${ui5DataDir}/framework/packages"] Where to install packages
+	 * @param {string} [parameters.stagingDir="${ui5DataDir}/framework/staging"] The staging directory for the packages
+	 * @param {string} [parameters.cacheDir="${ui5DataDir}/framework/cacache"] Where to store temp/cached packages.
 	 */
-	constructor({cwd, ui5HomeDir, packagesDir, stagingDir, cacheDir}) {
-		super(ui5HomeDir);
+	constructor({cwd, ui5DataDir, packagesDir, stagingDir, cacheDir}) {
+		super(ui5DataDir);
 		if (!cwd) {
 			throw new Error(`Installer: Missing parameter "cwd"`);
 		}
 		this._packagesDir = packagesDir ?
-			path.resolve(packagesDir) : path.join(ui5HomeDir, "framework", "packages");
+			path.resolve(packagesDir) : path.join(ui5DataDir, "framework", "packages");
 
 		log.verbose(`Installing to: ${this._packagesDir}`);
 
 		this._cwd = cwd;
 		this._caCacheDir = cacheDir ?
-			path.resolve(cacheDir) : path.join(ui5HomeDir, "framework", "cacache");
+			path.resolve(cacheDir) : path.join(ui5DataDir, "framework", "cacache");
 		this._stagingDir = stagingDir ?
-			path.resolve(stagingDir) : path.join(ui5HomeDir, "framework", "staging");
+			path.resolve(stagingDir) : path.join(ui5DataDir, "framework", "staging");
 	}
 
 	getRegistry() {

--- a/test/lib/graph/helpers/ui5Framework.js
+++ b/test/lib/graph/helpers/ui5Framework.js
@@ -131,7 +131,7 @@ test.serial("enrichProjectGraph", async (t) => {
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: dependencyTree.configuration.framework.version,
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 		providedLibraryMetadata: undefined
 	}], "Sapui5Resolver#constructor should be called with expected args");
 
@@ -336,7 +336,7 @@ test.serial("enrichProjectGraph: With versionOverride", async (t) => {
 	t.is(Sapui5ResolverResolveVersionStub.callCount, 1);
 	t.deepEqual(Sapui5ResolverResolveVersionStub.getCall(0).args, ["1.99", {
 		cwd: dependencyTree.path,
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 	}]);
 
 	t.is(Sapui5ResolverStub.callCount, 1, "Sapui5Resolver#constructor should be called once");
@@ -344,7 +344,7 @@ test.serial("enrichProjectGraph: With versionOverride", async (t) => {
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: "1.99.9",
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 		providedLibraryMetadata: undefined
 	}], "Sapui5Resolver#constructor should be called with expected args");
 });
@@ -398,7 +398,7 @@ test.serial("enrichProjectGraph: With versionOverride containing snapshot versio
 	t.is(Sapui5MavenSnapshotResolverResolveVersionStub.callCount, 1);
 	t.deepEqual(Sapui5MavenSnapshotResolverResolveVersionStub.getCall(0).args, ["1.99-SNAPSHOT", {
 		cwd: dependencyTree.path,
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 	}]);
 
 	t.is(Sapui5MavenSnapshotResolverStub.callCount, 1,
@@ -407,7 +407,7 @@ test.serial("enrichProjectGraph: With versionOverride containing snapshot versio
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: "1.99.9-SNAPSHOT",
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 		providedLibraryMetadata: undefined
 	}], "Sapui5Resolver#constructor should be called with expected args");
 });
@@ -461,7 +461,7 @@ test.serial("enrichProjectGraph: With versionOverride containing latest-snapshot
 	t.is(Sapui5MavenSnapshotResolverResolveVersionStub.callCount, 1);
 	t.deepEqual(Sapui5MavenSnapshotResolverResolveVersionStub.getCall(0).args, ["latest-snapshot", {
 		cwd: dependencyTree.path,
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 	}]);
 
 	t.is(Sapui5MavenSnapshotResolverStub.callCount, 1,
@@ -470,7 +470,7 @@ test.serial("enrichProjectGraph: With versionOverride containing latest-snapshot
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: "1.99.9-SNAPSHOT",
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 		providedLibraryMetadata: undefined
 	}], "Sapui5Resolver#constructor should be called with expected args");
 });
@@ -630,7 +630,7 @@ test.serial("enrichProjectGraph should resolve framework project with version an
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: "1.2.3",
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 		providedLibraryMetadata: undefined
 	}], "Sapui5Resolver#constructor should be called with expected args");
 });
@@ -726,7 +726,7 @@ test.serial("enrichProjectGraph should resolve framework project " +
 	t.is(Sapui5ResolverResolveVersionStub.callCount, 1);
 	t.deepEqual(Sapui5ResolverResolveVersionStub.getCall(0).args, ["3.4.5", {
 		cwd: dependencyTree.path,
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 	}]);
 
 	t.is(Sapui5ResolverStub.callCount, 1, "Sapui5Resolver#constructor should be called once");
@@ -735,7 +735,7 @@ test.serial("enrichProjectGraph should resolve framework project " +
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: "1.99.9",
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 		providedLibraryMetadata: undefined
 	}], "Sapui5Resolver#constructor should be called with expected args");
 });
@@ -1000,7 +1000,7 @@ test.serial("enrichProjectGraph should use framework library metadata from works
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: "1.111.1",
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 		providedLibraryMetadata: workspaceFrameworkLibraryMetadata
 	}], "Sapui5Resolver#constructor should be called with expected args");
 	t.is(Sapui5ResolverStub.getCall(0).args[0].providedLibraryMetadata, workspaceFrameworkLibraryMetadata);
@@ -1058,7 +1058,7 @@ test.serial("enrichProjectGraph should allow omitting framework version in case 
 	t.deepEqual(Sapui5ResolverStub.getCall(0).args, [{
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
-		ui5HomeDir: undefined,
+		ui5DataDir: undefined,
 		version: undefined,
 		providedLibraryMetadata: workspaceFrameworkLibraryMetadata
 	}], "Sapui5Resolver#constructor should be called with expected args");
@@ -1116,7 +1116,7 @@ test.serial("enrichProjectGraph should use UI5 data dir from env var", async (t)
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: dependencyTree.configuration.framework.version,
-		ui5HomeDir: expectedUi5DataDir,
+		ui5DataDir: expectedUi5DataDir,
 		providedLibraryMetadata: undefined
 	}], "Sapui5Resolver#constructor should be called with expected args");
 });
@@ -1172,7 +1172,7 @@ test.serial("enrichProjectGraph should use UI5 data dir from configuration", asy
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: dependencyTree.configuration.framework.version,
-		ui5HomeDir: expectedUi5DataDir,
+		ui5DataDir: expectedUi5DataDir,
 		providedLibraryMetadata: undefined
 	}], "Sapui5Resolver#constructor should be called with expected args");
 });
@@ -1228,7 +1228,7 @@ test.serial("enrichProjectGraph should use absolute UI5 data dir from configurat
 		cacheMode: undefined,
 		cwd: dependencyTree.path,
 		version: dependencyTree.configuration.framework.version,
-		ui5HomeDir: expectedUi5DataDir,
+		ui5DataDir: expectedUi5DataDir,
 		providedLibraryMetadata: undefined
 	}], "Sapui5Resolver#constructor should be called with expected args");
 });

--- a/test/lib/ui5framework/AbstractResolver.js
+++ b/test/lib/ui5framework/AbstractResolver.js
@@ -95,7 +95,7 @@ test("AbstractResolver: Defaults 'cwd' to process.cwd()", (t) => {
 	const {MyResolver} = t.context;
 	const resolver = new MyResolver({
 		version: "1.75.0",
-		ui5DataDir: "/ui5home"
+		ui5DataDir: "/ui5data"
 	});
 	t.is(resolver._cwd, process.cwd(), "Should default to process.cwd()");
 });

--- a/test/lib/ui5framework/AbstractResolver.js
+++ b/test/lib/ui5framework/AbstractResolver.js
@@ -95,30 +95,30 @@ test("AbstractResolver: Defaults 'cwd' to process.cwd()", (t) => {
 	const {MyResolver} = t.context;
 	const resolver = new MyResolver({
 		version: "1.75.0",
-		ui5HomeDir: "/ui5home"
+		ui5DataDir: "/ui5home"
 	});
 	t.is(resolver._cwd, process.cwd(), "Should default to process.cwd()");
 });
 
-test("AbstractResolver: Set absolute 'ui5HomeDir'", (t) => {
+test("AbstractResolver: Set absolute 'ui5DataDir'", (t) => {
 	const {MyResolver} = t.context;
 	const resolver = new MyResolver({
 		version: "1.75.0",
-		ui5HomeDir: "/my-ui5HomeDir"
+		ui5DataDir: "/my-ui5DataDir"
 	});
-	t.is(resolver._ui5HomeDir, path.resolve("/my-ui5HomeDir"), "Should be resolved 'ui5HomeDir'");
+	t.is(resolver._ui5DataDir, path.resolve("/my-ui5DataDir"), "Should be resolved 'ui5DataDir'");
 });
 
-test("AbstractResolver: Set relative 'ui5HomeDir'", (t) => {
+test("AbstractResolver: Set relative 'ui5DataDir'", (t) => {
 	const {MyResolver} = t.context;
 	const resolver = new MyResolver({
 		version: "1.75.0",
-		ui5HomeDir: "./my-ui5HomeDir"
+		ui5DataDir: "./my-ui5DataDir"
 	});
-	t.is(resolver._ui5HomeDir, path.resolve("./my-ui5HomeDir"), "Should be resolved 'ui5HomeDir'");
+	t.is(resolver._ui5DataDir, path.resolve("./my-ui5DataDir"), "Should be resolved 'ui5DataDir'");
 });
 
-test("AbstractResolver: 'ui5HomeDir' overriden os.homedir()", (t) => {
+test("AbstractResolver: 'ui5DataDir' overriden os.homedir()", (t) => {
 	const {MyResolver, osHomeDirStub} = t.context;
 
 	osHomeDirStub.returns("./");
@@ -126,16 +126,16 @@ test("AbstractResolver: 'ui5HomeDir' overriden os.homedir()", (t) => {
 	const resolver = new MyResolver({
 		version: "1.75.0"
 	});
-	t.is(resolver._ui5HomeDir, path.resolve("./.ui5"), "Should be resolved 'ui5HomeDir'");
+	t.is(resolver._ui5DataDir, path.resolve("./.ui5"), "Should be resolved 'ui5DataDir'");
 });
 
-test("AbstractResolver: Defaults 'ui5HomeDir' to ~/.ui5", (t) => {
+test("AbstractResolver: Defaults 'ui5DataDir' to ~/.ui5", (t) => {
 	const {MyResolver} = t.context;
 	const resolver = new MyResolver({
 		version: "1.75.0",
 		cwd: "/test-project/"
 	});
-	t.is(resolver._ui5HomeDir, path.join(os.homedir(), ".ui5"), "Should default to ~/.ui5");
+	t.is(resolver._ui5DataDir, path.join(os.homedir(), ".ui5"), "Should default to ~/.ui5");
 });
 
 test("AbstractResolver: getLibraryMetadata should throw an Error when not implemented", async (t) => {
@@ -562,7 +562,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'latest'", async (
 
 	const version = await MyResolver.resolveVersion("latest", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.76.0", "Resolved version should be correct");
@@ -570,7 +570,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'latest'", async (
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -581,7 +581,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR'", async (t
 
 	const version = await MyResolver.resolveVersion("1", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.76.0", "Resolved version should be correct");
@@ -589,7 +589,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR'", async (t
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -600,7 +600,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR-SNAPSHOT'",
 
 	const version = await MyResolver.resolveVersion("1-SNAPSHOT", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.79.0-SNAPSHOT", "Resolved version should be correct");
@@ -608,7 +608,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR-SNAPSHOT'",
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -619,7 +619,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR'", as
 
 	const version = await MyResolver.resolveVersion("1.75", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.75.1", "Resolved version should be correct");
@@ -627,7 +627,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR'", as
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -638,7 +638,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR-SNAPS
 
 	const version = await MyResolver.resolveVersion("1.79-SNAPSHOT", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.79.0-SNAPSHOT", "Resolved version should be correct");
@@ -646,7 +646,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR-SNAPS
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -657,7 +657,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH
 
 	const version = await MyResolver.resolveVersion("1.75.0", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.75.0", "Resolved version should be correct");
@@ -665,7 +665,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -676,7 +676,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH
 
 	const version = await MyResolver.resolveVersion("1.79.0-SNAPSHOT", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.79.0-SNAPSHOT", "Resolved version should be correct");
@@ -684,7 +684,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'MAJOR.MINOR.PATCH
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -695,7 +695,7 @@ test.serial("AbstractResolver: Static resolveVersion does not include prerelease
 
 	const version = await MyResolver.resolveVersion("latest", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.78.0", "Resolved version should be correct");
@@ -703,7 +703,7 @@ test.serial("AbstractResolver: Static resolveVersion does not include prerelease
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -714,7 +714,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'latest-snapshot'"
 
 	const version = await MyResolver.resolveVersion("latest-snapshot", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.76.1-SNAPSHOT", "Resolved version should be correct");
@@ -722,7 +722,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'latest-snapshot'"
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -735,7 +735,7 @@ test.serial("AbstractResolver: Static resolveVersion includes non-prereleases fo
 
 	const version = await MyResolver.resolveVersion("latest-snapshot", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.79.1", "Resolved version should be correct");
@@ -743,7 +743,7 @@ test.serial("AbstractResolver: Static resolveVersion includes non-prereleases fo
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -757,7 +757,7 @@ test.serial("AbstractResolver: Static resolveVersion without options", async (t)
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: undefined,
-		ui5HomeDir: undefined
+		ui5DataDir: undefined
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -767,7 +767,7 @@ test.serial("AbstractResolver: Static resolveVersion throws error for 'lts'", as
 
 	const error = await t.throwsAsync(MyResolver.resolveVersion("lts", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}));
 
 	t.is(error.message, `Framework version specifier "lts" is incorrect or not supported`);
@@ -782,7 +782,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '1.x'", async (t) 
 
 	const version = await MyResolver.resolveVersion("1.x", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.76.0", "Resolved version should be correct");
@@ -790,7 +790,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '1.x'", async (t) 
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -801,7 +801,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '1.75.x'", async (
 
 	const version = await MyResolver.resolveVersion("1.75.x", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.75.1", "Resolved version should be correct");
@@ -809,7 +809,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '1.75.x'", async (
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -820,7 +820,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '^1.75.0'", async 
 
 	const version = await MyResolver.resolveVersion("^1.75.0", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.76.0", "Resolved version should be correct");
@@ -828,7 +828,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '^1.75.0'", async 
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -839,7 +839,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '~1.75.0'", async 
 
 	const version = await MyResolver.resolveVersion("~1.75.0", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.75.1", "Resolved version should be correct");
@@ -847,7 +847,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '~1.75.0'", async 
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -858,7 +858,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '> 1.75.0 < 1.75.3
 
 	const version = await MyResolver.resolveVersion("> 1.75.0 < 1.75.3", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "1.75.2", "Resolved version should be correct");
@@ -866,7 +866,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '> 1.75.0 < 1.75.3
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -877,7 +877,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'x.x.x-SNAPSHOT'",
 
 	const version = await MyResolver.resolveVersion("x.x.x-SNAPSHOT", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	// All ranges ending with -SNAPSHOT should use "includePrerelease" in order to
@@ -887,7 +887,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'x.x.x-SNAPSHOT'",
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -898,7 +898,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '^2.0.0-SNAPSHOT'"
 
 	const version = await MyResolver.resolveVersion("^2.0.0-SNAPSHOT", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	// All ranges ending with -SNAPSHOT should use "includePrerelease" in order to
@@ -908,7 +908,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '^2.0.0-SNAPSHOT'"
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -919,7 +919,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '2.x.x-alpha'", as
 
 	const version = await MyResolver.resolveVersion("^2.0.0-alpha", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	// Prerelease ranges other than -SNAPSHOT should not use "includePrerelease"
@@ -929,7 +929,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves '2.x.x-alpha'", as
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 });
 
@@ -945,7 +945,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'next' using tags"
 
 	const version = await MyResolver.resolveVersion("next", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "2.0.0", "Resolved version should be correct");
@@ -953,12 +953,12 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'next' using tags"
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 	t.is(fetchAllTagsStub.callCount, 1, "fetchAllTagsStub should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllTags should be called with expected arguments");
 });
 
@@ -974,7 +974,7 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'next' to a pre-re
 
 	const version = await MyResolver.resolveVersion("next", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 
 	t.is(version, "2.0.0-SNAPSHOT", "Resolved version should be correct");
@@ -982,12 +982,12 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'next' to a pre-re
 	t.is(fetchAllVersionsStub.callCount, 1, "fetchAllVersions should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllVersions should be called with expected arguments");
 	t.is(fetchAllTagsStub.callCount, 1, "fetchAllTagsStub should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllTags should be called with expected arguments");
 });
 
@@ -1004,14 +1004,14 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'latest' using tag
 	// 'latest' should resolve to the highest version available
 	const version1 = await MyResolver.resolveVersion("latest", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 	t.is(version1, "2.0.0", "Resolved version should be correct");
 
 	t.is(fetchAllTagsStub.callCount, 1, "fetchAllTagsStub should be called once");
 	t.deepEqual(fetchAllVersionsStub.getCall(0).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllTags should be called with expected arguments");
 
 	// Change behavior of Resolver to support tags, so that version should be used now
@@ -1021,14 +1021,14 @@ test.serial("AbstractResolver: Static resolveVersion resolves 'latest' using tag
 	});
 	const version2 = await MyResolver.resolveVersion("latest", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	});
 	t.is(version2, "1.76.0", "Resolved version should be correct");
 
 	t.is(fetchAllTagsStub.callCount, 2, "fetchAllTagsStub should be called twice");
 	t.deepEqual(fetchAllVersionsStub.getCall(1).args, [{
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}], "fetchAllTags should be called with expected arguments");
 });
 
@@ -1039,7 +1039,7 @@ test.serial("AbstractResolver: Static resolveVersion throws error for empty stri
 
 	const error = await t.throwsAsync(MyResolver.resolveVersion("", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}));
 
 	t.is(error.message, `Framework version specifier "" is incorrect or not supported`);
@@ -1052,7 +1052,7 @@ test.serial("AbstractResolver: Static resolveVersion throws error for invalid ta
 
 	const error = await t.throwsAsync(MyResolver.resolveVersion("%20", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}));
 
 	t.is(error.message, `Framework version specifier "%20" is incorrect or not supported`);
@@ -1067,7 +1067,7 @@ test.serial("AbstractResolver: Static resolveVersion throws error for non-existi
 
 	const error = await t.throwsAsync(MyResolver.resolveVersion("this-tag-does-not-exist", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}));
 
 	t.is(error.message, `Could not resolve framework version via tag 'this-tag-does-not-exist'. ` +
@@ -1082,7 +1082,7 @@ test.serial("AbstractResolver: Static resolveVersion throws error for version no
 
 	const error = await t.throwsAsync(MyResolver.resolveVersion("1.74.0", {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	}));
 
 	t.is(error.message, `Could not resolve framework version 1.74.0. ` +
@@ -1101,7 +1101,7 @@ test.serial(
 
 		const error = await t.throwsAsync(Openui5Resolver.resolveVersion("1.50.0", {
 			cwd: "/cwd",
-			ui5HomeDir: "/ui5HomeDir"
+			ui5DataDir: "/ui5DataDir"
 		}));
 
 		t.is(error.message,
@@ -1121,7 +1121,7 @@ test.serial(
 
 		const error = await t.throwsAsync(Sapui5Resolver.resolveVersion("1.75.0", {
 			cwd: "/cwd",
-			ui5HomeDir: "/ui5HomeDir"
+			ui5DataDir: "/ui5DataDir"
 		}));
 
 		t.is(error.message,
@@ -1141,7 +1141,7 @@ test.serial(
 
 		const error = await t.throwsAsync(Openui5Resolver.resolveVersion("latest", {
 			cwd: "/cwd",
-			ui5HomeDir: "/ui5HomeDir"
+			ui5DataDir: "/ui5DataDir"
 		}));
 
 		t.is(error.message, `Could not resolve framework version latest. ` +
@@ -1160,7 +1160,7 @@ test.serial(
 
 		const error = await t.throwsAsync(Sapui5Resolver.resolveVersion("latest", {
 			cwd: "/cwd",
-			ui5HomeDir: "/ui5HomeDir"
+			ui5DataDir: "/ui5DataDir"
 		}));
 
 		t.is(error.message, `Could not resolve framework version latest. ` +
@@ -1179,7 +1179,7 @@ test.serial(
 
 		const error = await t.throwsAsync(Openui5Resolver.resolveVersion("1.99", {
 			cwd: "/cwd",
-			ui5HomeDir: "/ui5HomeDir"
+			ui5DataDir: "/ui5DataDir"
 		}));
 
 		t.is(error.message, `Could not resolve framework version 1.99. ` +
@@ -1198,7 +1198,7 @@ test.serial(
 
 		const error = await t.throwsAsync(Sapui5Resolver.resolveVersion("1.99", {
 			cwd: "/cwd",
-			ui5HomeDir: "/ui5HomeDir"
+			ui5DataDir: "/ui5DataDir"
 		}));
 
 		t.is(error.message, `Could not resolve framework version 1.99. ` +

--- a/test/lib/ui5framework/Openui5Resolver.integration.js
+++ b/test/lib/ui5framework/Openui5Resolver.integration.js
@@ -122,14 +122,14 @@ test.serial("resolveVersion", async (t) => {
 		});
 
 	const defaultCwd = process.cwd();
-	const defaultUi5HomeDir = path.join(fakeBaseDir, "homedir", ".ui5");
+	const defaultUi5DataDir = path.join(fakeBaseDir, "datadir", ".ui5");
 
 	// Generic testing without and with options argument
 	const optionsArguments = [
 		undefined,
 		{
 			cwd: path.join(fakeBaseDir, "custom-cwd"),
-			ui5DataDir: path.join(fakeBaseDir, "custom-homedir", ".ui5")
+			ui5DataDir: path.join(fakeBaseDir, "custom-datadir", ".ui5")
 		}
 	];
 	for (const options of optionsArguments) {
@@ -191,7 +191,7 @@ test.serial("resolveVersion", async (t) => {
 			cwd: options?.cwd ?? defaultCwd
 		})));
 		t.true(pacote.packument.alwaysCalledWithMatch("@openui5/sap.ui.core", {
-			cache: path.join(options?.ui5DataDir ?? defaultUi5HomeDir, "framework", "cacache")
+			cache: path.join(options?.ui5DataDir ?? defaultUi5DataDir, "framework", "cacache")
 		}));
 	}
 

--- a/test/lib/ui5framework/Openui5Resolver.integration.js
+++ b/test/lib/ui5framework/Openui5Resolver.integration.js
@@ -72,14 +72,14 @@ test.beforeEach(async (t) => {
 	t.context.AbstractResolver = await esmock.p("../../../lib/ui5Framework/AbstractResolver.js", {
 		"@ui5/logger": ui5Logger,
 		"node:os": {
-			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "datadir"))
 		},
 	});
 
 	t.context.Openui5Resolver = await esmock.p("../../../lib/ui5Framework/Openui5Resolver.js", {
 		"@ui5/logger": ui5Logger,
 		"node:os": {
-			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "datadir"))
 		},
 		"../../../lib/ui5Framework/AbstractResolver.js": t.context.AbstractResolver,
 		"../../../lib/ui5Framework/npm/Installer.js": t.context.Installer

--- a/test/lib/ui5framework/Openui5Resolver.integration.js
+++ b/test/lib/ui5framework/Openui5Resolver.integration.js
@@ -129,7 +129,7 @@ test.serial("resolveVersion", async (t) => {
 		undefined,
 		{
 			cwd: path.join(fakeBaseDir, "custom-cwd"),
-			ui5HomeDir: path.join(fakeBaseDir, "custom-homedir", ".ui5")
+			ui5DataDir: path.join(fakeBaseDir, "custom-homedir", ".ui5")
 		}
 	];
 	for (const options of optionsArguments) {
@@ -191,7 +191,7 @@ test.serial("resolveVersion", async (t) => {
 			cwd: options?.cwd ?? defaultCwd
 		})));
 		t.true(pacote.packument.alwaysCalledWithMatch("@openui5/sap.ui.core", {
-			cache: path.join(options?.ui5HomeDir ?? defaultUi5HomeDir, "framework", "cacache")
+			cache: path.join(options?.ui5DataDir ?? defaultUi5HomeDir, "framework", "cacache")
 		}));
 	}
 

--- a/test/lib/ui5framework/Openui5Resolver.js
+++ b/test/lib/ui5framework/Openui5Resolver.js
@@ -146,7 +146,7 @@ test.serial("Openui5Resolver: Static _getInstaller", (t) => {
 
 	const options = {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	};
 
 	const installer = Openui5Resolver._getInstaller(options);
@@ -156,7 +156,7 @@ test.serial("Openui5Resolver: Static _getInstaller", (t) => {
 	t.is(installer, t.context.InstallerStub.getCall(0).returnValue, "Installer instance is returned");
 	t.deepEqual(t.context.InstallerStub.getCall(0).args, [{
 		cwd: path.resolve("/cwd"),
-		ui5HomeDir: path.resolve("/ui5HomeDir")
+		ui5DataDir: path.resolve("/ui5DataDir")
 	}], "Installer should be called with expected arguments");
 });
 
@@ -170,7 +170,7 @@ test.serial("Openui5Resolver: Static _getInstaller without options", (t) => {
 	t.is(installer, t.context.InstallerStub.getCall(0).returnValue, "Installer instance is returned");
 	t.deepEqual(t.context.InstallerStub.getCall(0).args, [{
 		cwd: process.cwd(),
-		ui5HomeDir: path.join(os.homedir(), ".ui5")
+		ui5DataDir: path.join(os.homedir(), ".ui5")
 	}], "Installer should be called with expected arguments");
 });
 

--- a/test/lib/ui5framework/Sapui5MavenSnapshotResolver.js
+++ b/test/lib/ui5framework/Sapui5MavenSnapshotResolver.js
@@ -365,7 +365,7 @@ test.serial("Sapui5MavenSnapshotResolver: Static fetchAllVersions", async (t) =>
 	const expectedVersions = ["1.75.0-SNAPSHOT", "1.75.1-SNAPSHOT", "1.76.0-SNAPSHOT"];
 	const options = {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	};
 
 	t.context.fetchPackageVersionsStub.returns(expectedVersions);
@@ -388,7 +388,7 @@ test.serial("Sapui5MavenSnapshotResolver: Static fetchAllVersions", async (t) =>
 	t.deepEqual(t.context.InstallerStub.getCall(0).args, [{
 		cwd: path.resolve("/cwd"),
 		snapshotEndpointUrlCb: "snapshotEndpointUrlCallback",
-		ui5HomeDir: path.resolve("/ui5HomeDir")
+		ui5DataDir: path.resolve("/ui5DataDir")
 	}], "Installer should be called with expected arguments");
 });
 
@@ -415,7 +415,7 @@ test.serial("Sapui5MavenSnapshotResolver: Static fetchAllVersions without option
 	t.deepEqual(t.context.InstallerStub.getCall(0).args, [{
 		cwd: process.cwd(),
 		snapshotEndpointUrlCb: "snapshotEndpointUrlCallback",
-		ui5HomeDir: path.join(os.homedir(), ".ui5")
+		ui5DataDir: path.join(os.homedir(), ".ui5")
 	}], "Installer should be called with expected arguments");
 });
 

--- a/test/lib/ui5framework/Sapui5Resolver.integration.js
+++ b/test/lib/ui5framework/Sapui5Resolver.integration.js
@@ -72,14 +72,14 @@ test.beforeEach(async (t) => {
 	t.context.AbstractResolver = await esmock.p("../../../lib/ui5Framework/AbstractResolver.js", {
 		"@ui5/logger": ui5Logger,
 		"node:os": {
-			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "datadir"))
 		},
 	});
 
 	t.context.Sapui5Resolver = await esmock.p("../../../lib/ui5Framework/Sapui5Resolver.js", {
 		"@ui5/logger": ui5Logger,
 		"node:os": {
-			homedir: sinon.stub().returns(path.join(fakeBaseDir, "homedir"))
+			homedir: sinon.stub().returns(path.join(fakeBaseDir, "datadir"))
 		},
 		"../../../lib/ui5Framework/AbstractResolver.js": t.context.AbstractResolver,
 		"../../../lib/ui5Framework/npm/Installer.js": t.context.Installer

--- a/test/lib/ui5framework/Sapui5Resolver.integration.js
+++ b/test/lib/ui5framework/Sapui5Resolver.integration.js
@@ -122,14 +122,14 @@ test.serial("resolveVersion", async (t) => {
 		});
 
 	const defaultCwd = process.cwd();
-	const defaultUi5HomeDir = path.join(fakeBaseDir, "homedir", ".ui5");
+	const defaultUi5DataDir = path.join(fakeBaseDir, "datadir", ".ui5");
 
 	// Generic testing without and with options argument
 	const optionsArguments = [
 		undefined,
 		{
 			cwd: path.join(fakeBaseDir, "custom-cwd"),
-			ui5DataDir: path.join(fakeBaseDir, "custom-homedir", ".ui5")
+			ui5DataDir: path.join(fakeBaseDir, "custom-datadir", ".ui5")
 		}
 	];
 	for (const options of optionsArguments) {
@@ -191,7 +191,7 @@ test.serial("resolveVersion", async (t) => {
 			cwd: options?.cwd ?? defaultCwd
 		})));
 		t.true(pacote.packument.alwaysCalledWithMatch("@sapui5/distribution-metadata", {
-			cache: path.join(options?.ui5DataDir ?? defaultUi5HomeDir, "framework", "cacache")
+			cache: path.join(options?.ui5DataDir ?? defaultUi5DataDir, "framework", "cacache")
 		}));
 	}
 

--- a/test/lib/ui5framework/Sapui5Resolver.integration.js
+++ b/test/lib/ui5framework/Sapui5Resolver.integration.js
@@ -129,7 +129,7 @@ test.serial("resolveVersion", async (t) => {
 		undefined,
 		{
 			cwd: path.join(fakeBaseDir, "custom-cwd"),
-			ui5HomeDir: path.join(fakeBaseDir, "custom-homedir", ".ui5")
+			ui5DataDir: path.join(fakeBaseDir, "custom-homedir", ".ui5")
 		}
 	];
 	for (const options of optionsArguments) {
@@ -191,7 +191,7 @@ test.serial("resolveVersion", async (t) => {
 			cwd: options?.cwd ?? defaultCwd
 		})));
 		t.true(pacote.packument.alwaysCalledWithMatch("@sapui5/distribution-metadata", {
-			cache: path.join(options?.ui5HomeDir ?? defaultUi5HomeDir, "framework", "cacache")
+			cache: path.join(options?.ui5DataDir ?? defaultUi5HomeDir, "framework", "cacache")
 		}));
 	}
 

--- a/test/lib/ui5framework/Sapui5Resolver.js
+++ b/test/lib/ui5framework/Sapui5Resolver.js
@@ -132,7 +132,7 @@ test.serial("Sapui5Resolver: Static _getInstaller", (t) => {
 
 	const options = {
 		cwd: "/cwd",
-		ui5HomeDir: "/ui5HomeDir"
+		ui5DataDir: "/ui5DataDir"
 	};
 
 	const installer = Sapui5Resolver._getInstaller(options);
@@ -142,7 +142,7 @@ test.serial("Sapui5Resolver: Static _getInstaller", (t) => {
 	t.is(installer, t.context.InstallerStub.getCall(0).returnValue, "Installer instance is returned");
 	t.deepEqual(t.context.InstallerStub.getCall(0).args, [{
 		cwd: path.resolve("/cwd"),
-		ui5HomeDir: path.resolve("/ui5HomeDir")
+		ui5DataDir: path.resolve("/ui5DataDir")
 	}], "Installer should be called with expected arguments");
 });
 
@@ -156,7 +156,7 @@ test.serial("Sapui5Resolver: Static _getInstaller without options", (t) => {
 	t.is(installer, t.context.InstallerStub.getCall(0).returnValue, "Installer instance is returned");
 	t.deepEqual(t.context.InstallerStub.getCall(0).args, [{
 		cwd: process.cwd(),
-		ui5HomeDir: path.join(os.homedir(), ".ui5")
+		ui5DataDir: path.join(os.homedir(), ".ui5")
 	}], "Installer should be called with expected arguments");
 });
 

--- a/test/lib/ui5framework/maven/Installer.js
+++ b/test/lib/ui5framework/maven/Installer.js
@@ -73,7 +73,7 @@ test.serial("constructor", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 	t.true(installer instanceof Installer, "Constructor returns instance of class");
@@ -84,14 +84,14 @@ test.serial("constructor", (t) => {
 	t.is(installer._lockDir, path.join("/ui5Home/", "framework", "locks"));
 });
 
-test.serial("constructor requires 'ui5HomeDir'", (t) => {
+test.serial("constructor requires 'ui5DataDir'", (t) => {
 	const {Installer} = t.context;
 
 	t.throws(() => {
 		new Installer({
 			cwd: "/cwd/"
 		});
-	}, {message: `Installer: Missing parameter "ui5HomeDir"`});
+	}, {message: `Installer: Missing parameter "ui5DataDir"`});
 });
 
 test.serial("constructor requires 'snapshotEndpointUrlCb'", (t) => {
@@ -100,7 +100,7 @@ test.serial("constructor requires 'snapshotEndpointUrlCb'", (t) => {
 	t.throws(() => {
 		new Installer({
 			cwd: "/cwd/",
-			ui5HomeDir: "/ui5Home"
+			ui5DataDir: "/ui5Home"
 		});
 	}, {message: `Installer: Missing Snapshot-Endpoint URL callback parameter`});
 });
@@ -110,7 +110,7 @@ test.serial("getRegistry", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -132,7 +132,7 @@ test.serial("getRegistry: Missing endpoint URL", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => Promise.resolve(null)
 	});
 
@@ -151,7 +151,7 @@ test.serial("fetchPackageVersions", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -178,7 +178,7 @@ test.serial("fetchPackageVersions throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -198,7 +198,7 @@ test.serial("_getLockPath", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -213,7 +213,7 @@ test.serial("readJson", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -229,7 +229,7 @@ test.serial("installPackage", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -285,7 +285,7 @@ test.serial("installPackage: No classifier", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -341,7 +341,7 @@ test.serial("installPackage: Already installed", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -374,7 +374,7 @@ test.serial("installPackage: Already installed only after lock acquired", async 
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -409,7 +409,7 @@ test.serial("installArtifact", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: async () => "url"
 	});
 
@@ -471,7 +471,7 @@ test.serial("installArtifact: Target revision provided", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: async () => "url"
 	});
 
@@ -527,7 +527,7 @@ test.serial("installArtifact: Already installed", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -567,7 +567,7 @@ test.serial("installArtifact: Already installed only after lock acquired", async
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -609,7 +609,7 @@ test.serial("_fetchArtifactMetadata", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -646,7 +646,7 @@ test.serial("_fetchArtifactMetadata: Cached", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {},
 	});
 
@@ -682,7 +682,7 @@ test.serial("_fetchArtifactMetadata: Cache available but disabled", async (t) =>
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {},
 		cacheMode: "Off"
 	});
@@ -718,7 +718,7 @@ test.serial("_fetchArtifactMetadata: Cache outdated but enforced", async (t) => 
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {},
 		cacheMode: "Force"
 	});
@@ -755,7 +755,7 @@ test.serial("_fetchArtifactMetadata throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {},
 		cacheMode: "Force"
 	});
@@ -779,7 +779,7 @@ test.serial("_getRemoteArtifactMetadata", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -813,7 +813,7 @@ test.serial("_getRemoteArtifactMetadata throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -832,7 +832,7 @@ test.serial("_getRemoteArtifactMetadata throws missing deployment metadata", asy
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -870,7 +870,7 @@ test.serial("_getLocalArtifactMetadata", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -885,7 +885,7 @@ test.serial("_getLocalArtifactMetadata file not found", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -904,7 +904,7 @@ test.serial("_getLocalArtifactMetadata throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -923,7 +923,7 @@ test.serial("_writeLocalArtifactMetadata", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -946,7 +946,7 @@ test.serial("_removeStaleRevisions", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -981,7 +981,7 @@ test.serial("_pathExists", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -998,7 +998,7 @@ test.serial("_pathExists file not found", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -1013,7 +1013,7 @@ test.serial("_pathExists throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -1031,7 +1031,7 @@ test.serial("_projectExists", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -1049,7 +1049,7 @@ test.serial("_projectExists: Does not exist", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -1067,7 +1067,7 @@ test.serial("_projectExists: Throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/",
+		ui5DataDir: "/ui5Home/",
 		snapshotEndpointUrlCb: () => {}
 	});
 

--- a/test/lib/ui5framework/maven/Installer.js
+++ b/test/lib/ui5framework/maven/Installer.js
@@ -73,15 +73,15 @@ test.serial("constructor", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 	t.true(installer instanceof Installer, "Constructor returns instance of class");
-	t.is(installer._artifactsDir, path.join("/ui5Home/", "framework", "artifacts"));
-	t.is(installer._packagesDir, path.join("/ui5Home/", "framework", "packages"));
-	t.is(installer._stagingDir, path.join("/ui5Home/", "framework", "staging"));
-	t.is(installer._metadataDir, path.join("/ui5Home/", "framework", "metadata"));
-	t.is(installer._lockDir, path.join("/ui5Home/", "framework", "locks"));
+	t.is(installer._artifactsDir, path.join("/ui5Data/", "framework", "artifacts"));
+	t.is(installer._packagesDir, path.join("/ui5Data/", "framework", "packages"));
+	t.is(installer._stagingDir, path.join("/ui5Data/", "framework", "staging"));
+	t.is(installer._metadataDir, path.join("/ui5Data/", "framework", "metadata"));
+	t.is(installer._lockDir, path.join("/ui5Data/", "framework", "locks"));
 });
 
 test.serial("constructor requires 'ui5DataDir'", (t) => {
@@ -100,7 +100,7 @@ test.serial("constructor requires 'snapshotEndpointUrlCb'", (t) => {
 	t.throws(() => {
 		new Installer({
 			cwd: "/cwd/",
-			ui5DataDir: "/ui5Home"
+			ui5DataDir: "/ui5Data"
 		});
 	}, {message: `Installer: Missing Snapshot-Endpoint URL callback parameter`});
 });
@@ -110,7 +110,7 @@ test.serial("getRegistry", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -132,7 +132,7 @@ test.serial("getRegistry: Missing endpoint URL", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => Promise.resolve(null)
 	});
 
@@ -151,7 +151,7 @@ test.serial("fetchPackageVersions", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -178,7 +178,7 @@ test.serial("fetchPackageVersions throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -198,13 +198,13 @@ test.serial("_getLockPath", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
 	const lockPath = installer._getLockPath("package-@openui5/sap.ui.lib1@1.2.3-SNAPSHOT");
 
-	t.is(lockPath, path.join("/ui5Home/", "framework", "locks", "package-@openui5-sap.ui.lib1@1.2.3-SNAPSHOT.lock"));
+	t.is(lockPath, path.join("/ui5Data/", "framework", "locks", "package-@openui5-sap.ui.lib1@1.2.3-SNAPSHOT.lock"));
 });
 
 test.serial("readJson", async (t) => {
@@ -213,7 +213,7 @@ test.serial("readJson", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -229,7 +229,7 @@ test.serial("installPackage", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -238,7 +238,7 @@ test.serial("installPackage", async (t) => {
 	sinon.stub(installer, "_pathExists").resolves(false);
 	sinon.stub(installer, "_synchronize").callsFake( async (pckg, callback) => await callback());
 	const installArtifactStub = sinon.stub(installer, "installArtifact").resolves({
-		artifactPath: "/ui5Home/framework/artifacts/com_sap_ui5_dist-sapui5-sdk-dist/5/npm-sources.zip",
+		artifactPath: "/ui5Data/framework/artifacts/com_sap_ui5_dist-sapui5-sdk-dist/5/npm-sources.zip",
 		removeArtifact: removeArtifactStub
 	});
 
@@ -254,7 +254,7 @@ test.serial("installPackage", async (t) => {
 	t.deepEqual(
 		installedPackage,
 		{pkgPath:
-				path.join("/ui5Home/", "framework", "packages", "@sapui5", "distribution-metadata", "5")},
+				path.join("/ui5Data/", "framework", "packages", "@sapui5", "distribution-metadata", "5")},
 		"Install the correct package"
 	);
 
@@ -285,7 +285,7 @@ test.serial("installPackage: No classifier", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -294,7 +294,7 @@ test.serial("installPackage: No classifier", async (t) => {
 	sinon.stub(installer, "_pathExists").resolves(false);
 	sinon.stub(installer, "_synchronize").callsFake( async (pckg, callback) => await callback());
 	const installArtifactStub = sinon.stub(installer, "installArtifact").resolves({
-		artifactPath: "/ui5Home/framework/artifacts/com_sap_ui5_dist-sapui5-sdk-dist/5/npm-sources.zip",
+		artifactPath: "/ui5Data/framework/artifacts/com_sap_ui5_dist-sapui5-sdk-dist/5/npm-sources.zip",
 		removeArtifact: removeArtifactStub
 	});
 
@@ -310,7 +310,7 @@ test.serial("installPackage: No classifier", async (t) => {
 	t.deepEqual(
 		installedPackage,
 		{pkgPath:
-				path.join("/ui5Home/", "framework", "packages", "@sapui5", "distribution-metadata", "5")},
+				path.join("/ui5Data/", "framework", "packages", "@sapui5", "distribution-metadata", "5")},
 		"Install the correct package"
 	);
 
@@ -341,7 +341,7 @@ test.serial("installPackage: Already installed", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -362,7 +362,7 @@ test.serial("installPackage: Already installed", async (t) => {
 	t.deepEqual(
 		installedPackage,
 		{pkgPath:
-				path.join("/ui5Home/", "framework", "packages", "@sapui5", "distribution-metadata", "5")},
+				path.join("/ui5Data/", "framework", "packages", "@sapui5", "distribution-metadata", "5")},
 		"Install the correct package"
 	);
 
@@ -374,7 +374,7 @@ test.serial("installPackage: Already installed only after lock acquired", async 
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -397,7 +397,7 @@ test.serial("installPackage: Already installed only after lock acquired", async 
 	t.deepEqual(
 		installedPackage,
 		{pkgPath:
-				path.join("/ui5Home/", "framework", "packages", "@sapui5", "distribution-metadata", "5")},
+				path.join("/ui5Data/", "framework", "packages", "@sapui5", "distribution-metadata", "5")},
 		"Install the correct package"
 	);
 
@@ -409,7 +409,7 @@ test.serial("installArtifact", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: async () => "url"
 	});
 
@@ -425,7 +425,7 @@ test.serial("installArtifact", async (t) => {
 		classifier: null
 	});
 
-	const expectedPath = path.join("/ui5Home/", "framework", "artifacts", "com_sap_ui5_dist-sapui5-sdk-dist", "5.jar");
+	const expectedPath = path.join("/ui5Data/", "framework", "artifacts", "com_sap_ui5_dist-sapui5-sdk-dist", "5.jar");
 	t.is(
 		installedArtifact.artifactPath,
 		expectedPath,
@@ -451,7 +451,7 @@ test.serial("installArtifact", async (t) => {
 		extension: "jar",
 	}, "Registry#requestArtifact got called with expected coordinates");
 	t.is(registryRequestArtifactStub.firstCall.args[1],
-		path.join("/ui5Home/", "framework", "staging", "com.sap.ui5.dist_sapui5-sdk-dist_5_jar"),
+		path.join("/ui5Data/", "framework", "staging", "com.sap.ui5.dist_sapui5-sdk-dist_5_jar"),
 		"Registry#requestArtifact got called with expected target directory");
 
 	t.is(
@@ -471,7 +471,7 @@ test.serial("installArtifact: Target revision provided", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: async () => "url"
 	});
 
@@ -488,7 +488,7 @@ test.serial("installArtifact: Target revision provided", async (t) => {
 		revision: "16"
 	});
 
-	const expectedPath = path.join("/ui5Home/", "framework", "artifacts",
+	const expectedPath = path.join("/ui5Data/", "framework", "artifacts",
 		"com_sap_ui5_dist-sapui5-sdk-dist", "16", "npm-sources.zip");
 	t.is(
 		installedArtifact.artifactPath,
@@ -508,7 +508,7 @@ test.serial("installArtifact: Target revision provided", async (t) => {
 		extension: "zip",
 	}, "Registry#requestArtifact got called with expected coordinates");
 	t.is(registryRequestArtifactStub.firstCall.args[1],
-		path.join("/ui5Home/", "framework", "staging", "com.sap.ui5.dist_sapui5-sdk-dist_16_npm-sources.zip"),
+		path.join("/ui5Data/", "framework", "staging", "com.sap.ui5.dist_sapui5-sdk-dist_16_npm-sources.zip"),
 		"Registry#requestArtifact got called with expected target directory");
 
 	t.is(
@@ -527,7 +527,7 @@ test.serial("installArtifact: Already installed", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -542,7 +542,7 @@ test.serial("installArtifact: Already installed", async (t) => {
 		extension: "jar",
 	});
 
-	const expectedPath = path.join("/ui5Home/", "framework", "artifacts", "com_sap_ui5_dist-sapui5-sdk-dist", "5.jar");
+	const expectedPath = path.join("/ui5Data/", "framework", "artifacts", "com_sap_ui5_dist-sapui5-sdk-dist", "5.jar");
 	t.is(
 		installedArtifact.artifactPath,
 		expectedPath,
@@ -567,7 +567,7 @@ test.serial("installArtifact: Already installed only after lock acquired", async
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -584,7 +584,7 @@ test.serial("installArtifact: Already installed only after lock acquired", async
 		extension: "jar",
 	});
 
-	const expectedPath = path.join("/ui5Home/", "framework", "artifacts", "com_sap_ui5_dist-sapui5-sdk-dist", "5.jar");
+	const expectedPath = path.join("/ui5Data/", "framework", "artifacts", "com_sap_ui5_dist-sapui5-sdk-dist", "5.jar");
 	t.is(
 		installedArtifact.artifactPath,
 		expectedPath,
@@ -609,7 +609,7 @@ test.serial("_fetchArtifactMetadata", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -646,7 +646,7 @@ test.serial("_fetchArtifactMetadata: Cached", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {},
 	});
 
@@ -682,7 +682,7 @@ test.serial("_fetchArtifactMetadata: Cache available but disabled", async (t) =>
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {},
 		cacheMode: "Off"
 	});
@@ -718,7 +718,7 @@ test.serial("_fetchArtifactMetadata: Cache outdated but enforced", async (t) => 
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {},
 		cacheMode: "Force"
 	});
@@ -755,7 +755,7 @@ test.serial("_fetchArtifactMetadata throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {},
 		cacheMode: "Force"
 	});
@@ -779,7 +779,7 @@ test.serial("_getRemoteArtifactMetadata", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -813,7 +813,7 @@ test.serial("_getRemoteArtifactMetadata throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -832,7 +832,7 @@ test.serial("_getRemoteArtifactMetadata throws missing deployment metadata", asy
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => Promise.resolve("endpoint-url")
 	});
 
@@ -870,7 +870,7 @@ test.serial("_getLocalArtifactMetadata", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -885,7 +885,7 @@ test.serial("_getLocalArtifactMetadata file not found", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -904,7 +904,7 @@ test.serial("_getLocalArtifactMetadata throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -923,7 +923,7 @@ test.serial("_writeLocalArtifactMetadata", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -936,7 +936,7 @@ test.serial("_writeLocalArtifactMetadata", async (t) => {
 	t.is(writeFileStub.callCount, 1, "_writeJson called");
 	t.deepEqual(
 		writeFileStub.args,
-		[[path.join("/ui5Home/", "framework", "metadata", "Id.json"), "{\"foo\":\"bar\"}"]],
+		[[path.join("/ui5Data/", "framework", "metadata", "Id.json"), "{\"foo\":\"bar\"}"]],
 		"_writeJson called with correct arguments"
 	);
 });
@@ -946,7 +946,7 @@ test.serial("_removeStaleRevisions", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -981,7 +981,7 @@ test.serial("_pathExists", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -998,7 +998,7 @@ test.serial("_pathExists file not found", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -1013,7 +1013,7 @@ test.serial("_pathExists throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -1031,7 +1031,7 @@ test.serial("_projectExists", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -1049,7 +1049,7 @@ test.serial("_projectExists: Does not exist", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 
@@ -1067,7 +1067,7 @@ test.serial("_projectExists: Throws", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/",
+		ui5DataDir: "/ui5Data/",
 		snapshotEndpointUrlCb: () => {}
 	});
 

--- a/test/lib/ui5framework/npm/Installer.js
+++ b/test/lib/ui5framework/npm/Installer.js
@@ -52,7 +52,7 @@ test.serial("Installer: constructor", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 	t.true(installer instanceof Installer, "Constructor returns instance of class");
 	t.is(installer._packagesDir, path.join("/ui5Home/", "framework", "packages"));
@@ -65,19 +65,19 @@ test.serial("Installer: constructor requires 'cwd'", (t) => {
 
 	t.throws(() => {
 		new Installer({
-			ui5HomeDir: "/ui5Home/"
+			ui5DataDir: "/ui5Home/"
 		});
 	}, {message: `Installer: Missing parameter "cwd"`});
 });
 
-test.serial("Installer: constructor requires 'ui5HomeDir'", (t) => {
+test.serial("Installer: constructor requires 'ui5DataDir'", (t) => {
 	const {Installer} = t.context;
 
 	t.throws(() => {
 		new Installer({
 			cwd: "/cwd/"
 		});
-	}, {message: `Installer: Missing parameter "ui5HomeDir"`});
+	}, {message: `Installer: Missing parameter "ui5DataDir"`});
 });
 
 test.serial("Installer: fetchPackageVersions", async (t) => {
@@ -85,7 +85,7 @@ test.serial("Installer: fetchPackageVersions", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	const registry = installer.getRegistry();
@@ -119,7 +119,7 @@ test.serial("Installer: _getLockPath", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	const lockPath = installer._getLockPath("lo/ck-n@me");
@@ -132,7 +132,7 @@ test.serial("Installer: _getLockPath with illegal characters", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.throws(() => installer._getLockPath("lock.näme"), {
@@ -148,7 +148,7 @@ test.serial("Installer: fetchPackageManifest (without existing package.json)", a
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	const mockedManifest = {
@@ -219,7 +219,7 @@ test.serial("Installer: fetchPackageManifest (with existing package.json)", asyn
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	const mockedManifest = {
@@ -280,7 +280,7 @@ test.serial("Installer: fetchPackageManifest (readJson throws error)", async (t)
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	const registry = installer.getRegistry();
@@ -315,7 +315,7 @@ test.serial("Installer: _synchronize", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -358,7 +358,7 @@ test.serial("Installer: _synchronize should unlock when callback promise has res
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -384,7 +384,7 @@ test.serial("Installer: _synchronize should throw when locking fails", async (t)
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.context.lockStub.yieldsAsync(new Error("Locking error"));
@@ -406,7 +406,7 @@ test.serial("Installer: _synchronize should still unlock when callback throws an
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -430,7 +430,7 @@ test.serial("Installer: _synchronize should still unlock when callback rejects w
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -454,7 +454,7 @@ test.serial("Installer: installPackage with new package", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -534,7 +534,7 @@ test.serial("Installer: installPackage with already installed package", async (t
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -588,7 +588,7 @@ test.serial("Installer: installPackage with install already in progress", async 
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -650,7 +650,7 @@ test.serial("Installer: installPackage with new package and existing target and 
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -735,7 +735,7 @@ test.serial("Installer: _pathExists - exists", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	const res = await installer._pathExists(__dirname);
@@ -750,7 +750,7 @@ test.serial("Installer: _pathExists - does not exist", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	const notFoundError = new Error("Not found");
@@ -769,7 +769,7 @@ test.serial("Installer: _pathExists - re-throws unexpected errors", async (t) =>
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	const notFoundError = new Error("Pony Error");
@@ -789,7 +789,7 @@ test.serial("Installer: Registry throws", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5HomeDir: "/ui5Home/"
+		ui5DataDir: "/ui5Home/"
 	});
 
 	installer._cwd = null;

--- a/test/lib/ui5framework/npm/Installer.js
+++ b/test/lib/ui5framework/npm/Installer.js
@@ -52,12 +52,12 @@ test.serial("Installer: constructor", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 	t.true(installer instanceof Installer, "Constructor returns instance of class");
-	t.is(installer._packagesDir, path.join("/ui5Home/", "framework", "packages"));
-	t.is(installer._lockDir, path.join("/ui5Home/", "framework", "locks"));
-	t.is(installer._stagingDir, path.join("/ui5Home/", "framework", "staging"));
+	t.is(installer._packagesDir, path.join("/ui5Data/", "framework", "packages"));
+	t.is(installer._lockDir, path.join("/ui5Data/", "framework", "locks"));
+	t.is(installer._stagingDir, path.join("/ui5Data/", "framework", "staging"));
 });
 
 test.serial("Installer: constructor requires 'cwd'", (t) => {
@@ -65,7 +65,7 @@ test.serial("Installer: constructor requires 'cwd'", (t) => {
 
 	t.throws(() => {
 		new Installer({
-			ui5DataDir: "/ui5Home/"
+			ui5DataDir: "/ui5Data/"
 		});
 	}, {message: `Installer: Missing parameter "cwd"`});
 });
@@ -85,7 +85,7 @@ test.serial("Installer: fetchPackageVersions", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	const registry = installer.getRegistry();
@@ -119,12 +119,12 @@ test.serial("Installer: _getLockPath", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	const lockPath = installer._getLockPath("lo/ck-n@me");
 
-	t.is(lockPath, path.join("/ui5Home/", "framework", "locks", "lo-ck-n@me.lock"));
+	t.is(lockPath, path.join("/ui5Data/", "framework", "locks", "lo-ck-n@me.lock"));
 });
 
 test.serial("Installer: _getLockPath with illegal characters", (t) => {
@@ -132,7 +132,7 @@ test.serial("Installer: _getLockPath with illegal characters", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.throws(() => installer._getLockPath("lock.näme"), {
@@ -148,7 +148,7 @@ test.serial("Installer: fetchPackageManifest (without existing package.json)", a
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	const mockedManifest = {
@@ -219,7 +219,7 @@ test.serial("Installer: fetchPackageManifest (with existing package.json)", asyn
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	const mockedManifest = {
@@ -280,7 +280,7 @@ test.serial("Installer: fetchPackageManifest (readJson throws error)", async (t)
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	const registry = installer.getRegistry();
@@ -315,7 +315,7 @@ test.serial("Installer: _synchronize", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -332,7 +332,7 @@ test.serial("Installer: _synchronize", async (t) => {
 		"_getLockPath should be called with expected args");
 
 	t.is(t.context.mkdirpStub.callCount, 1, "_mkdirp should be called once");
-	t.deepEqual(t.context.mkdirpStub.getCall(0).args, [path.join("/ui5Home/", "framework", "locks")],
+	t.deepEqual(t.context.mkdirpStub.getCall(0).args, [path.join("/ui5Data/", "framework", "locks")],
 		"_mkdirp should be called with expected args");
 
 	t.is(t.context.lockStub.callCount, 1, "lock should be called once");
@@ -358,7 +358,7 @@ test.serial("Installer: _synchronize should unlock when callback promise has res
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -384,7 +384,7 @@ test.serial("Installer: _synchronize should throw when locking fails", async (t)
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.context.lockStub.yieldsAsync(new Error("Locking error"));
@@ -406,7 +406,7 @@ test.serial("Installer: _synchronize should still unlock when callback throws an
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -430,7 +430,7 @@ test.serial("Installer: _synchronize should still unlock when callback rejects w
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -454,7 +454,7 @@ test.serial("Installer: installPackage with new package", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -517,7 +517,7 @@ test.serial("Installer: installPackage with new package", async (t) => {
 	t.is(extractPackageStub.callCount, 1, "_extractPackage should be called once");
 
 	t.is(t.context.mkdirpStub.callCount, 2, "mkdirp should be called twice");
-	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
+	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Data", "framework", "locks"),
 		"mkdirp should be called with the correct arguments on first call");
 	t.is(t.context.mkdirpStub.getCall(1).args[0], path.join("my", "package"),
 		"mkdirp should be called with the correct arguments on second call");
@@ -534,7 +534,7 @@ test.serial("Installer: installPackage with already installed package", async (t
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -588,7 +588,7 @@ test.serial("Installer: installPackage with install already in progress", async 
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -636,7 +636,7 @@ test.serial("Installer: installPackage with install already in progress", async 
 	t.is(t.context.rimrafStub.callCount, 0, "rimraf should never be called");
 
 	t.is(t.context.mkdirpStub.callCount, 1, "mkdirp should be called once");
-	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
+	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Data", "framework", "locks"),
 		"mkdirp should be called with the correct arguments");
 
 	t.is(getStagingDirForPackageStub.callCount, 0, "_getStagingDirForPackage should never be called");
@@ -650,7 +650,7 @@ test.serial("Installer: installPackage with new package and existing target and 
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	t.context.lockStub.yieldsAsync();
@@ -718,7 +718,7 @@ test.serial("Installer: installPackage with new package and existing target and 
 	t.is(extractPackageStub.callCount, 1, "_extractPackage should be called once");
 
 	t.is(t.context.mkdirpStub.callCount, 2, "mkdirp should be called twice");
-	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Home", "framework", "locks"),
+	t.is(t.context.mkdirpStub.getCall(0).args[0], path.join("/", "ui5Data", "framework", "locks"),
 		"mkdirp should be called with the correct arguments on first call");
 	t.is(t.context.mkdirpStub.getCall(1).args[0], path.join("my", "package"),
 		"mkdirp should be called with the correct arguments on second call");
@@ -735,7 +735,7 @@ test.serial("Installer: _pathExists - exists", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	const res = await installer._pathExists(__dirname);
@@ -750,7 +750,7 @@ test.serial("Installer: _pathExists - does not exist", async (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	const notFoundError = new Error("Not found");
@@ -769,7 +769,7 @@ test.serial("Installer: _pathExists - re-throws unexpected errors", async (t) =>
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	const notFoundError = new Error("Pony Error");
@@ -789,7 +789,7 @@ test.serial("Installer: Registry throws", (t) => {
 
 	const installer = new Installer({
 		cwd: "/cwd/",
-		ui5DataDir: "/ui5Home/"
+		ui5DataDir: "/ui5Data/"
 	});
 
 	installer._cwd = null;


### PR DESCRIPTION
BREAKING CHANGE:
Installers and Resolvers' argument `ui5HomeDir` is now renamed to `ui5DataDir`

JIRA: CPOUI5FOUNDATION-802
Relates to: https://github.com/SAP/ui5-tooling/issues/701