### PR TITLE
[FEATURE] Bundling: Remove option 'usePredefineCalls'

### DIFF
--- a/lib/validation/schema/specVersion/kind/project.json
+++ b/lib/validation/schema/specVersion/kind/project.json
@@ -397,10 +397,6 @@
 					"type": "boolean",
 					"default": false
 				},
-				"usePredefineCalls": {
-					"type": "boolean",
-					"default": false
-				},
 				"numberOfParts": {
 					"type": "number",
 					"default": 1
@@ -420,10 +416,6 @@
 					"default": true
 				},
 				"addTryCatchRestartWrapper": {
-					"type": "boolean",
-					"default": false
-				},
-				"usePredefineCalls": {
 					"type": "boolean",
 					"default": false
 				},

--- a/test/lib/validation/schema/__helper__/builder-bundleOptions.js
+++ b/test/lib/validation/schema/__helper__/builder-bundleOptions.js
@@ -29,7 +29,6 @@ export default {
 								"optimize": false,
 								"decorateBootstrapModule": false,
 								"addTryCatchRestartWrapper": true,
-								"usePredefineCalls": true,
 								"numberOfParts": 8,
 								"sourceMap": false
 							}
@@ -82,7 +81,6 @@ export default {
 								"optimize": "invalid value",
 								"decorateBootstrapModule": {"invalid": "value"},
 								"addTryCatchRestartWrapper": ["invalid value"],
-								"usePredefineCalls": 12,
 								"numberOfParts": true,
 								"sourceMap": 55
 							}
@@ -110,15 +108,6 @@ export default {
 						keyword: "type",
 						dataPath:
 							"/builder/bundles/0/bundleOptions/addTryCatchRestartWrapper",
-						params: {
-							type: "boolean",
-						},
-						message: "should be boolean"
-					},
-					{
-						keyword: "type",
-						dataPath:
-							"/builder/bundles/0/bundleOptions/usePredefineCalls",
 						params: {
 							type: "boolean",
 						},

--- a/test/lib/validation/schema/specVersion/kind/project/application.js
+++ b/test/lib/validation/schema/specVersion/kind/project/application.js
@@ -107,8 +107,7 @@ SpecificationVersion.getVersionsForRange(">=2.0").forEach(function(specVersion) 
 						"bundleOptions": {
 							"optimize": true,
 							"decorateBootstrapModule": true,
-							"addTryCatchRestartWrapper": true,
-							"usePredefineCalls": true
+							"addTryCatchRestartWrapper": true
 						}
 					},
 					{

--- a/test/lib/validation/schema/specVersion/kind/project/library.js
+++ b/test/lib/validation/schema/specVersion/kind/project/library.js
@@ -107,8 +107,7 @@ SpecificationVersion.getVersionsForRange(">=2.0").forEach(function(specVersion) 
 						"bundleOptions": {
 							"optimize": true,
 							"decorateBootstrapModule": true,
-							"addTryCatchRestartWrapper": true,
-							"usePredefineCalls": true
+							"addTryCatchRestartWrapper": true
 						}
 					},
 					{


### PR DESCRIPTION
Up until UI5 Tooling v3, the bundle option "usePredefineCalls" defaults to "false" and has to be activated explicitly in a custom bundle configuration.
For default bundles, such as Component-preload or self-contained bundle (sap-ui-custom.js), there is no way to use the option apart from re-defining the whole bundle via custom bundle definition.

With UI5 Tooling v4 bundles are generated with the usage sap.ui.predefine calls instead of the former default function wrapper. This leads to smaller bundle sizes and less overhead at runtime.

As the option only affects the internal handling of bundling without affecting the actual users,
the option is removed completely, instead of just changing the default value of the option.

Related to https://github.com/SAP/ui5-builder/pull/1021.

Documentation update covered in https://github.com/SAP/ui5-tooling/pull/957.

JIRA: CPOUI5FOUNDATION-760