### PR TITLE
[INTERNAL] Enhance range of @ui5/builder peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
 		"yesno": "^0.4.0"
 	},
 	"peerDependencies": {
-		"@ui5/builder": "^3.4.1"
+		"@ui5/builder": "^3.4.1 || 4.0.0-alpha"
 	},
 	"peerDependenciesMeta": {
 		"@ui5/builder": {


### PR DESCRIPTION
This is required for local development. Otherwise npm would error out
since the local 4.x version does not satisfy the ^3 range.