### PR TITLE
[INTERNAL] library: Replace buildtime timestamp in sap/ui/core/Core.js

### DIFF
--- a/lib/build/definitions/library.js
+++ b/lib/build/definitions/library.js
@@ -34,7 +34,7 @@ export default function({project, taskUtil, getTask}) {
 
 	tasks.set("replaceBuildtime", {
 		options: {
-			pattern: "/resources/sap/ui/Global.js"
+			pattern: "/resources/sap/ui/{Global,core/Core}.js"
 		}
 	});
 

--- a/test/lib/build/definitions/library.js
+++ b/test/lib/build/definitions/library.js
@@ -77,7 +77,7 @@ test("Standard build", async (t) => {
 		},
 		replaceBuildtime: {
 			options: {
-				pattern: "/resources/sap/ui/Global.js"
+				pattern: "/resources/sap/ui/{Global,core/Core}.js"
 			}
 		},
 		generateJsdoc: {
@@ -213,7 +213,7 @@ test("Standard build with legacy spec version", (t) => {
 		},
 		replaceBuildtime: {
 			options: {
-				pattern: "/resources/sap/ui/Global.js"
+				pattern: "/resources/sap/ui/{Global,core/Core}.js"
 			}
 		},
 		generateJsdoc: {
@@ -334,7 +334,7 @@ test("Custom bundles", async (t) => {
 		},
 		replaceBuildtime: {
 			options: {
-				pattern: "/resources/sap/ui/Global.js"
+				pattern: "/resources/sap/ui/{Global,core/Core}.js"
 			}
 		},
 		generateJsdoc: {
@@ -661,7 +661,7 @@ test("Standard build: nulled taskFunction to skip tasks", (t) => {
 		},
 		replaceBuildtime: {
 			options: {
-				pattern: "/resources/sap/ui/Global.js"
+				pattern: "/resources/sap/ui/{Global,core/Core}.js"
 			}
 		},
 		generateJsdoc: {


### PR DESCRIPTION
The framework intends to move the buildtime timestamp from Global.js to
Core.js. With this change, UI5 Tooling will always scan both files for
the placeholder and process it accordingly.

JIRA: CPOUI5FRAMEWORK-647