### PR TITLE
[INTERNAL] package.json: Allow npm >= v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
 			},
 			"engines": {
 				"node": "^20.11.0 || >=21.2.0",
-				"npm": ">= 10"
+				"npm": ">= 8"
 			},
 			"peerDependencies": {
 				"@ui5/builder": "^3.4.1 || 4.0.0-alpha"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	},
 	"engines": {
 		"node": "^20.11.0 || >=21.2.0",
-		"npm": ">= 10"
+		"npm": ">= 8"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run depcheck",


### PR DESCRIPTION
There is no actual need to increase the minimum npm version. Lockfile v3 is already supported