### PR TITLE
[DEPENDENCY] Fix @ui5/builder peerDependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
 		"yesno": "^0.4.0"
 	},
 	"peerDependencies": {
-		"@ui5/builder": "^3.4.1 || ^4.0.0"
+		"@ui5/builder": "^4.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@ui5/builder": {


### PR DESCRIPTION
The range for v3.x had to be included for technical reasons before the first v4 release but it was not intended to be defined that way.
