### PR TITLE
[FIX] decorateBootstrapModule should default to "false"

### DIFF
--- a/lib/validation/schema/specVersion/kind/project.json
+++ b/lib/validation/schema/specVersion/kind/project.json
@@ -420,7 +420,7 @@
 								}
 							},
 							"$comment": "Add async prop only if mode = 'require'"
-						}, 
+						},
 						"then": {
 							"type": "object",
 							"additionalProperties": false,
@@ -517,7 +517,7 @@
 				},
 				"decorateBootstrapModule": {
 					"type": "boolean",
-					"default": true
+					"default": false
 				},
 				"addTryCatchRestartWrapper": {
 					"type": "boolean",
@@ -543,7 +543,7 @@
 				},
 				"decorateBootstrapModule": {
 					"type": "boolean",
-					"default": true
+					"default": false
 				},
 				"addTryCatchRestartWrapper": {
 					"type": "boolean",
@@ -573,7 +573,7 @@
 				},
 				"decorateBootstrapModule": {
 					"type": "boolean",
-					"default": true
+					"default": false
 				},
 				"addTryCatchRestartWrapper": {
 					"type": "boolean",


### PR DESCRIPTION
The default value in the schema was not aligned with the actual default
value in the code.
Starting with v4, the default values are applied to the bundle config,
which is why it now started to matter.