### PR TITLE
[FEATURE] Add support to autofill env-vars in config

### DIFF
--- a/lib/graph/Module.js
+++ b/lib/graph/Module.js
@@ -28,6 +28,16 @@ function clone(obj) {
  */
 class Module {
 	/**
+	 * Regular expression to identify environment variables in strings.
+	 * Environment variables have to be prefixed with "env:", e.g. "env:Path".
+	 *
+	 * @private
+	 * @static
+	 * @readonly
+	 */
+	static _ENVIRONMENT_VARIABLE_REGEX = /env:\S+/g;
+
+	/**
 	 * @param {object} parameters Module parameters
 	 * @param {string} parameters.id Unique ID for the module
 	 * @param {string} parameters.version Version of the module
@@ -403,7 +413,46 @@ class Module {
 		if (!config.kind) {
 			config.kind = "project"; // default
 		}
+		for (const key of Object.keys(config)) {
+			this._normalizeConfigValue(config, key);
+		}
 		return config;
+	}
+
+	/**
+	 * Normalizes the config value at object[key]. If the config value is an object / array,
+	 * this method will descend depth-first on its properties / elements. If the config value is a string
+	 * and contains any environment variables, they will be filled in at this point.
+	 *
+	 * @private
+	 * @param {(object|any[])} object An object or array
+	 * @param {(string|number)} key A key of the object or an index of the array
+	 */
+	_normalizeConfigValue(object, key) {
+		let value = object[key];
+		switch (typeof value) {
+		case "string": {
+			value = value.replace(Module._ENVIRONMENT_VARIABLE_REGEX, (substring) => {
+				const envVarName = substring.slice(4);
+				return process.env[envVarName] || substring;
+			});
+			object[key] = value;
+			break;
+		}
+		case "object": {
+			if (value === null) break;
+			if (Array.isArray(value)) {
+				for (let i = 0; i < value.length; i++) {
+					this._normalizeConfigValue(value, i);
+				}
+			} else {
+				for (const key of Object.keys(value)) {
+					this._normalizeConfigValue(value, key);
+				}
+			}
+			break;
+		}
+		}
 	}
 
 	/**

--- a/lib/graph/Module.js
+++ b/lib/graph/Module.js
@@ -349,6 +349,25 @@ class Module {
 			return configs;
 		}
 
+		try {
+			for (const config of configs) {
+				if (config.customConfiguration !== undefined) {
+					this._normalizeConfigValue(config, "customConfiguration");
+				}
+				if (config.builder?.customTasks !== undefined) {
+					this._normalizeConfigValue(config.builder, "customTasks");
+				}
+				if (config.server?.customMiddleware !== undefined) {
+					this._normalizeConfigValue(config.server, "customMiddleware");
+				}
+			}
+		} catch (err) {
+			throw new Error(
+				"Failed to parse configuration for project " +
+				`${this.getId()} at '${configPath}'\nError: ${err.message}`
+			);
+		}
+
 		// Validate found configurations with schema
 		// Validation is done again in the Specification class. But here we can reference the YAML file
 		// which adds helpful information like the line number
@@ -413,9 +432,6 @@ class Module {
 		if (!config.kind) {
 			config.kind = "project"; // default
 		}
-		for (const key of Object.keys(config)) {
-			this._normalizeConfigValue(config, key);
-		}
 		return config;
 	}
 
@@ -434,7 +450,10 @@ class Module {
 		case "string": {
 			value = value.replace(Module._ENVIRONMENT_VARIABLE_REGEX, (substring) => {
 				const envVarName = substring.slice(4);
-				return process.env[envVarName] || substring;
+				if (process.env[envVarName] === undefined) {
+					throw new Error(`The environment variable '${envVarName}' is not defined`);
+				}
+				return process.env[envVarName];
 			});
 			object[key] = value;
 			break;

--- a/test/fixtures/application.a/ui5-test-env.yaml
+++ b/test/fixtures/application.a/ui5-test-env.yaml
@@ -1,0 +1,25 @@
+---
+specVersion: "3.0"
+type: application
+metadata:
+  name: application.a
+customConfiguration:
+  stringWithEnvVar: env:testEnvVarForString
+  objectWithEnvVar:
+    someKey: env:testEnvVarForObject
+  arrayWithEnvVar:
+    - a
+    - env:testEnvVarForArray
+    - c
+builder:
+  customTasks:
+    - name: foo
+      afterTask: replaceVersion
+      configuration:
+        builderWithEnvVar: env:testEnvVarForBuilder
+server:
+  customMiddleware:
+    - name: bar
+      afterMiddleware: compression
+      configuration:
+        serverWithEnvVar: env:testEnvVarForServer

--- a/test/lib/graph/Module.js
+++ b/test/lib/graph/Module.js
@@ -408,7 +408,7 @@ test("Legacy patches are applied", async (t) => {
 			.map(testLegacyLibrary));
 });
 
-test("Environment variables in configuration", async (t) => {
+test.serial("Environment variables in configuration", async (t) => {
 	const testEnvVars = ["testEnvVarForString", "testEnvVarForObject", "testEnvVarForArray"].map(
 		(testEnvVar, index) => {
 			const wrapper = {


### PR DESCRIPTION
- Environment variables should be autofilled when the config is loaded

Fixes: [#935](https://github.com/SAP/ui5-tooling/issues/935)

Plenty of tasks and middlewares offer environment variables for some parts of their configuration. I agree with the aforementioned issue that this leads to inconsistent env variable usage between tasks and forces developers into a repetitive pattern of manually adding env vars for configuration options they deem worthy. 

The approach of directly referencing env variables in the configuration files seems like the most elegant solution to me, because it doesn't "hide" that the configuration occurs from the user and because it lets the user decide how they want to name their env variables (Which also allows them to reuse them between tasks freely). 

Example where we replace the string "${placeholder}" in all js files with the username (e.g. Fabian on my machine)
```yaml
builder:
  customTasks:
    - name: ui5-tooling-stringreplace-task
      afterTask: replaceVersion
      configuration:
        debug: true
        files:
          - "**/*.js"
        replace:
          - placeholder: ${placeholder}
            value: env:USERNAME
```
_env:USERNAME_ is replaced with the content of environment variable "USERNAME" at runtime.
This works with any value in a ui5.yaml. The change should be non-breaking as long as the wrapper / prefix of the environment variables is reasonably different from a string a user might enter. I chose _env:_ because that's the format [@sap/ux-ui5-tooling](https://www.npmjs.com/package/@sap/ux-ui5-tooling) currently uses, but a format that actually wraps the env variable is probably preferable. If the environment variable is not set, it currently does not get replaced.

I have not added any documentation yet. I look forward to your feedback, thanks in advance