### PR TITLE
[FIX] Revert "[DEPENDENCY] Bump @npmcli/config from 9.0.0 to 10.4.0 #818"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,5 +2,3 @@
 registry=https://registry.npmjs.org/
 lockfile-version=3
 ignore-scripts=true
-# This will fail-fast "npm ci" if deps require node versions unsupported by the repo:
-engine-strict=true

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,5 @@
 registry=https://registry.npmjs.org/
 lockfile-version=3
 ignore-scripts=true
+# This will fail-fast "npm ci" if deps require node versions unsupported by the repo:
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.0.6",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@npmcli/config": "^10.4.2",
+				"@npmcli/config": "^9.0.0",
 				"@ui5/fs": "^4.0.3",
 				"@ui5/logger": "^4.0.2",
 				"ajv": "^6.12.6",
@@ -1012,21 +1012,21 @@
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
 		},
 		"node_modules/@npmcli/config": {
-			"version": "10.4.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/config/-/config-10.4.2.tgz",
-			"integrity": "sha512-wHcJiqWvC7lKX3L/BOtk6jefzXZyNNosU0dEBeNkF9U9rUXrZWB2MBupR717MyaAtLXko4XXzca3sOYNlkuxDw==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/config/-/config-9.0.0.tgz",
+			"integrity": "sha512-P5Vi16Y+c8E0prGIzX112ug7XxqfaPFUVW/oXAV+2VsxplKZEnJozqZ0xnK8V8w/SEsBf+TXhUihrEIAU4CA5Q==",
 			"dependencies": {
-				"@npmcli/map-workspaces": "^5.0.0",
-				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/map-workspaces": "^4.0.1",
+				"@npmcli/package-json": "^6.0.1",
 				"ci-info": "^4.0.0",
 				"ini": "^5.0.0",
-				"nopt": "^8.1.0",
+				"nopt": "^8.0.0",
 				"proc-log": "^5.0.0",
 				"semver": "^7.3.5",
-				"walk-up-path": "^4.0.0"
+				"walk-up-path": "^3.0.1"
 			},
 			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/@npmcli/fs": {
@@ -1041,30 +1041,27 @@
 			}
 		},
 		"node_modules/@npmcli/git": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.0.tgz",
-			"integrity": "sha512-vnz7BVGtOctJAIHouCJdvWBhsTVSICMeUgZo2c7XAi5d5Rrl80S1H7oPym7K03cRuinK5Q6s2dw36+PgXQTcMA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-6.0.3.tgz",
+			"integrity": "sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==",
 			"dependencies": {
 				"@npmcli/promise-spawn": "^8.0.0",
 				"ini": "^5.0.0",
-				"lru-cache": "^11.2.1",
-				"npm-pick-manifest": "^11.0.1",
+				"lru-cache": "^10.0.1",
+				"npm-pick-manifest": "^10.0.0",
 				"proc-log": "^5.0.0",
 				"promise-retry": "^2.0.1",
 				"semver": "^7.3.5",
 				"which": "^5.0.0"
 			},
 			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/@npmcli/git/node_modules/lru-cache": {
-			"version": "11.2.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-			"engines": {
-				"node": "20 || >=22"
-			}
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
 		},
 		"node_modules/@npmcli/installed-package-contents": {
 			"version": "3.0.0",
@@ -1082,17 +1079,92 @@
 			}
 		},
 		"node_modules/@npmcli/map-workspaces": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.0.tgz",
-			"integrity": "sha512-+YJN6+BIQEC5QL4EqffJ2I1S9ySspwn7GP7uQINtZhf3uy7P0KnnIg+Ab5WeSUTZYpg+jn3GSfMme2FutB7qEQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-4.0.2.tgz",
+			"integrity": "sha512-mnuMuibEbkaBTYj9HQ3dMe6L0ylYW+s/gfz7tBDMFY/la0w9Kf44P9aLn4/+/t3aTR3YUHKoT6XQL9rlicIe3Q==",
 			"dependencies": {
 				"@npmcli/name-from-folder": "^3.0.0",
-				"@npmcli/package-json": "^7.0.0",
-				"glob": "^11.0.3",
-				"minimatch": "^10.0.3"
+				"@npmcli/package-json": "^6.0.0",
+				"glob": "^10.2.2",
+				"minimatch": "^9.0.0"
 			},
 			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@npmcli/name-from-folder": {
@@ -1112,20 +1184,95 @@
 			}
 		},
 		"node_modules/@npmcli/package-json": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.1.tgz",
-			"integrity": "sha512-956YUeI0YITbk2+KnirCkD19HLzES0habV+Els+dyZaVsaM6VGSiNwnRu6t3CZaqDLz4KXy2zx+0N/Zy6YjlAA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.2.0.tgz",
+			"integrity": "sha512-rCNLSB/JzNvot0SEyXqWZ7tX2B5dD2a1br2Dp0vSYVo5jh8Z0EZ7lS9TsZ1UtziddB1UfNUaMCc538/HztnJGA==",
 			"dependencies": {
-				"@npmcli/git": "^7.0.0",
-				"glob": "^11.0.3",
-				"hosted-git-info": "^9.0.0",
+				"@npmcli/git": "^6.0.0",
+				"glob": "^10.2.2",
+				"hosted-git-info": "^8.0.0",
 				"json-parse-even-better-errors": "^4.0.0",
 				"proc-log": "^5.0.0",
 				"semver": "^7.5.3",
 				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+		},
+		"node_modules/@npmcli/package-json/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@npmcli/promise-spawn": {
@@ -1161,155 +1308,6 @@
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/@npmcli/git": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-6.0.3.tgz",
-			"integrity": "sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==",
-			"dependencies": {
-				"@npmcli/promise-spawn": "^8.0.0",
-				"ini": "^5.0.0",
-				"lru-cache": "^10.0.1",
-				"npm-pick-manifest": "^10.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"semver": "^7.3.5",
-				"which": "^5.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/@npmcli/package-json": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.2.0.tgz",
-			"integrity": "sha512-rCNLSB/JzNvot0SEyXqWZ7tX2B5dD2a1br2Dp0vSYVo5jh8Z0EZ7lS9TsZ1UtziddB1UfNUaMCc538/HztnJGA==",
-			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"glob": "^10.2.2",
-				"hosted-git-info": "^8.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
-				"proc-log": "^5.0.0",
-				"semver": "^7.5.3",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/hosted-git-info": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
-			"integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-		},
-		"node_modules/@npmcli/run-script/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/npm-package-arg": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
-			"integrity": "sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==",
-			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"proc-log": "^5.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-name": "^6.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/npm-pick-manifest": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-10.0.0.tgz",
-			"integrity": "sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==",
-			"dependencies": {
-				"npm-install-checks": "^7.1.0",
-				"npm-normalize-package-bin": "^4.0.0",
-				"npm-package-arg": "^12.0.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/run-script/node_modules/path-scurry": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@one-ini/wasm": {
@@ -4507,6 +4505,7 @@
 			"version": "11.0.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
 			"integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+			"dev": true,
 			"dependencies": {
 				"foreground-child": "^3.3.1",
 				"jackspeak": "^4.1.1",
@@ -4694,23 +4693,20 @@
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+			"integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
 			"dependencies": {
-				"lru-cache": "^11.1.0"
+				"lru-cache": "^10.0.1"
 			},
 			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/hosted-git-info/node_modules/lru-cache": {
-			"version": "11.2.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-			"engines": {
-				"node": "20 || >=22"
-			}
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
 		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
@@ -5286,6 +5282,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
 			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+			"dev": true,
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
 			},
@@ -6298,17 +6295,17 @@
 			}
 		},
 		"node_modules/npm-package-arg": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.1.tgz",
-			"integrity": "sha512-6zqls5xFvJbgFjB1B2U6yITtyGBjDBORB7suI4zA4T/sZ1OmkMFlaQSNB/4K0LtXNA1t4OprAFxPisadK5O2ag==",
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
+			"integrity": "sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==",
 			"dependencies": {
-				"hosted-git-info": "^9.0.0",
+				"hosted-git-info": "^8.0.0",
 				"proc-log": "^5.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-name": "^6.0.0"
 			},
 			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm-packlist": {
@@ -6323,17 +6320,17 @@
 			}
 		},
 		"node_modules/npm-pick-manifest": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.1.tgz",
-			"integrity": "sha512-HnU7FYSWbo7dTVHtK0G+BXbZ0aIfxz/aUCVLN0979Ec6rGUX5cJ6RbgVx5fqb5G31ufz+BVFA7y1SkRTPVNoVQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-10.0.0.tgz",
+			"integrity": "sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==",
 			"dependencies": {
 				"npm-install-checks": "^7.1.0",
 				"npm-normalize-package-bin": "^4.0.0",
-				"npm-package-arg": "^13.0.0",
+				"npm-package-arg": "^12.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm-registry-fetch": {
@@ -6349,36 +6346,6 @@
 				"minizlib": "^3.0.1",
 				"npm-package-arg": "^12.0.0",
 				"proc-log": "^5.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm-registry-fetch/node_modules/hosted-git-info": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
-			"integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm-registry-fetch/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-		},
-		"node_modules/npm-registry-fetch/node_modules/npm-package-arg": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
-			"integrity": "sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==",
-			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"proc-log": "^5.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-name": "^6.0.0"
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
@@ -6821,118 +6788,12 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/pacote/node_modules/@npmcli/git": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-6.0.3.tgz",
-			"integrity": "sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==",
-			"dependencies": {
-				"@npmcli/promise-spawn": "^8.0.0",
-				"ini": "^5.0.0",
-				"lru-cache": "^10.0.1",
-				"npm-pick-manifest": "^10.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"semver": "^7.3.5",
-				"which": "^5.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/@npmcli/package-json": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.2.0.tgz",
-			"integrity": "sha512-rCNLSB/JzNvot0SEyXqWZ7tX2B5dD2a1br2Dp0vSYVo5jh8Z0EZ7lS9TsZ1UtziddB1UfNUaMCc538/HztnJGA==",
-			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"glob": "^10.2.2",
-				"hosted-git-info": "^8.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
-				"proc-log": "^5.0.0",
-				"semver": "^7.5.3",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/pacote/node_modules/chownr": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
 			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/pacote/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/pacote/node_modules/hosted-git-info": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
-			"integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
-		"node_modules/pacote/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-		},
-		"node_modules/pacote/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/pacote/node_modules/minizlib": {
@@ -6956,49 +6817,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/pacote/node_modules/npm-package-arg": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
-			"integrity": "sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==",
-			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"proc-log": "^5.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-name": "^6.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/npm-pick-manifest": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-10.0.0.tgz",
-			"integrity": "sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==",
-			"dependencies": {
-				"npm-install-checks": "^7.1.0",
-				"npm-normalize-package-bin": "^4.0.0",
-				"npm-package-arg": "^12.0.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/path-scurry": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/pacote/node_modules/tar": {
@@ -7168,6 +6986,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
 			"integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+			"dev": true,
 			"dependencies": {
 				"lru-cache": "^11.0.0",
 				"minipass": "^7.1.2"
@@ -7183,6 +7002,7 @@
 			"version": "11.2.2",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
 			"integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+			"dev": true,
 			"engines": {
 				"node": "20 || >=22"
 			}
@@ -8939,12 +8759,9 @@
 			}
 		},
 		"node_modules/walk-up-path": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
-			"integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
-			"engines": {
-				"node": "20 || >=22"
-			}
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
+			"integrity": "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA=="
 		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"url": "git@github.com:SAP/ui5-project.git"
 	},
 	"dependencies": {
-		"@npmcli/config": "^10.4.2",
+		"@npmcli/config": "^9.0.0",
 		"@ui5/fs": "^4.0.3",
 		"@ui5/logger": "^4.0.2",
 		"ajv": "^6.12.6",


### PR DESCRIPTION
This reverts commit a944572.

Previously, `@npmcli/config` required a node version ^20.17.0 || >=22.9.0 which is unsupported by `@ui5/project`.
This PR downgrades it back to ^9.0.0 which requires a node version of ^18.17.0 || >=20.5.0 which fully satisfies our current support.